### PR TITLE
fixed issue with /tms printing duplicate message on OldUI.

### DIFF
--- a/Zeal/chat.cpp
+++ b/Zeal/chat.cpp
@@ -28,9 +28,11 @@ void __fastcall PrintChat(int t, int unused, const char* data, short color, bool
         ZealService::get_instance()->hooks->hook_map["PrintChat"]->original(PrintChat)(t, unused, generateTimestampedString(data).c_str(), color, u);
         mem::write<byte>(0x5380C9, 0x75); //reset the logging
 
-        mem::write<byte>(0x53805B, 0xEB); //disable print chat
+        mem::write<byte>(0x53805B, 0xEB); //disable print chat for NewUI
+        mem::write<byte>(0x538090, 0xEB); //disable print chat for OldUI
         ZealService::get_instance()->hooks->hook_map["PrintChat"]->original(PrintChat)(t, unused, data, color, u);
-        mem::write<byte>(0x53805B, 0x74); //reset print chat
+        mem::write<byte>(0x538090, 0x74); //reset print chat for OldUI
+        mem::write<byte>(0x53805B, 0x74); //reset print chat for NewUI
     }
     else
         ZealService::get_instance()->hooks->hook_map["PrintChat"]->original(PrintChat)(t, unused, data, color, u);


### PR DESCRIPTION
I tested this change on both interfaces, and my change doesn't seem to cause any issues on NewUI. However, since we have a flag for OldUI in eqclient.ini, perhaps you'd rather load in that flag and have it used for so that extra mem::writes don't have to happen?

This seems to do what it needs to do for now though.