### PR TITLE
Added /outputfile command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,14 @@ ___
 - `/timestamp`
   - **Aliases:** `/tms`
   - **Description:** Shows message timestamps.
+
+- `/outputfile`
+  - **Arguments:** `inventory [optional_name]`
+  - **Example:** `/outputfile inventory my_inventory`
+  - **Description:** `inventory` outputs information about your equipment, inventory bag slots, held item, and bank slots to a file.
 ___
 ### Binds
-- Cycle through nearest NPCs 
+- Cycle through nearest NPCs
 - Cycle through nearest PCs
 - Strafe Right
 - Strafe Left
@@ -39,8 +44,8 @@ ___
   - `23` EXP Per Hour
 
 - **Label EqType's**
-  - `80` Mana/Max Mana 
-  - `81` Exp Per Hour Percentage 
+  - `80` Mana/Max Mana
+  - `81` Exp Per Hour Percentage
   - `124` Current Mana
   - `125` Max Mana
 ___

--- a/Zeal/Zeal.cpp
+++ b/Zeal/Zeal.cpp
@@ -20,6 +20,7 @@ ZealService::ZealService()
 	cycle_target = std::shared_ptr<CycleTarget>(new CycleTarget(this));
 	experience = std::shared_ptr<Experience>(new Experience(this));
 	chat_hook = std::shared_ptr<chat>(new chat(this, ini.get()));
+  outputfile_hook = std::shared_ptr<OutputFile>(new OutputFile(this));
 
 
 	looting_hook->hide_looted = ini->getValue<bool>("Zeal", "HideLooted"); //just remembers the state

--- a/Zeal/Zeal.h
+++ b/Zeal/Zeal.h
@@ -17,6 +17,7 @@ public:
 	std::shared_ptr<raid> raid_hook = nullptr;
 	std::shared_ptr<eqstr> eqstr_hook = nullptr;
 	std::shared_ptr<chat> chat_hook = nullptr;
+  std::shared_ptr<OutputFile> outputfile_hook = nullptr;
 
 
 	//other features

--- a/Zeal/Zeal.vcxproj
+++ b/Zeal/Zeal.vcxproj
@@ -173,6 +173,7 @@
     <ClInclude Include="camera_mods.h" />
     <ClInclude Include="InstructionLength.h" />
     <ClInclude Include="pch.h" />
+    <ClInclude Include="outputfile.h" />
     <ClInclude Include="raid.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="vectors.h" />
@@ -194,6 +195,7 @@
     <ClCompile Include="main_loop.cpp" />
     <ClCompile Include="memory.cpp" />
     <ClCompile Include="camera_mods.cpp" />
+    <ClInclude Include="outputfile.cpp" />
     <ClCompile Include="raid.cpp" />
     <ClCompile Include="vectors.cpp" />
     <ClCompile Include="Zeal.cpp" />

--- a/Zeal/Zeal.vcxproj.filters
+++ b/Zeal/Zeal.vcxproj.filters
@@ -108,6 +108,9 @@
     <ClInclude Include="chat.h">
       <Filter>Header Files\hooks</Filter>
     </ClInclude>
+    <ClInclude Include="outputfile.h">
+      <Filter>Header Files\hooks</Filter>
+    </ClInclude>
     <ClInclude Include="EqAddresses.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -165,6 +168,9 @@
       <Filter>Source Files\hooks</Filter>
     </ClCompile>
     <ClCompile Include="chat.cpp">
+      <Filter>Source Files\hooks</Filter>
+    </ClCompile>
+    <ClCompile Include="outputfile.cpp">
       <Filter>Source Files\hooks</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Zeal/commands.cpp
+++ b/Zeal/commands.cpp
@@ -6,7 +6,7 @@
 #include <algorithm>
 #include <cctype>
 
-bool caseInsensitiveStringCompare(const std::string& str1, const std::string& str2) {
+static bool caseInsensitiveStringCompare(const std::string& str1, const std::string& str2) {
 	// Check if the strings are of different lengths, if so, they can't match
 	if (str1.length() != str2.length()) {
 		return false;

--- a/Zeal/framework.h
+++ b/Zeal/framework.h
@@ -15,6 +15,7 @@
 #include "raid.h"
 #include "eqstr.h"
 #include "chat.h"
+#include "outputfile.h"
 
 #include "IO_ini.h"
 #include "main_loop.h"

--- a/Zeal/outputfile.cpp
+++ b/Zeal/outputfile.cpp
@@ -1,0 +1,232 @@
+#include "outputfile.h"
+#include "EqStructures.h"
+#include "EqAddresses.h"
+#include "EqFunctions.h"
+#include "Zeal.h"
+#include <algorithm>
+#include <fstream>
+
+enum EquipSlot {
+  LeftEar,
+  Head,
+  Face,
+  RightEar,
+  Neck,
+  Shoulder,
+  Arms,
+  Back,
+  LeftWrist,
+  RightWrist,
+  Range,
+  Hands,
+  Primary,
+  Secondary,
+  LeftFinger,
+  RightFinger,
+  Chest,
+  Legs,
+  Feet,
+  Waist,
+  Ammo
+};
+
+static std::string IDToEquipSlot(int equipSlot) {
+  switch (equipSlot) {
+    case LeftEar:
+    case RightEar:    return "Ear";
+    case Head:        return "Head";
+    case Face:        return "Face";
+    case Neck:        return "Neck";
+    case Shoulder:    return "Shoulders";
+    case Arms:        return "Arms";
+    case Back:        return "Back";
+    case LeftWrist:
+    case RightWrist:  return "Wrist";
+    case Range:       return "Range";
+    case Hands:       return "Hands";
+    case Primary:     return "Primary";
+    case Secondary:   return "Secondary";
+    case LeftFinger:
+    case RightFinger: return "Fingers";
+    case Chest:       return "Chest";
+    case Legs:        return "Legs";
+    case Feet:        return "Feet";
+    case Waist:       return "Waist";
+    case Ammo:        return "Ammo";
+    default:{}break;
+  }
+  return "Unknown";
+}
+
+// copied this over for now, maybe this should be centralized at some point.
+static bool caseInsensitiveStringCompare(const std::string& str1, const std::string& str2) {
+  // Check if the strings are of different lengths, if so, they can't match
+  if (str1.length() != str2.length()) {
+    return false;
+  }
+
+  // Convert both strings to lowercase and then compare
+  std::string str1Lower = str1;
+  std::string str2Lower = str2;
+  std::transform(str1Lower.begin(), str1Lower.end(), str1Lower.begin(), ::tolower);
+  std::transform(str2Lower.begin(), str2Lower.end(), str2Lower.begin(), ::tolower);
+
+  // Now, perform a case-insensitive comparison
+  return str1Lower == str2Lower;
+}
+
+static bool ItemIsContainer(Zeal::EqStructures::EQITEMINFO* item) {
+  return item->OpenType == 0x1;
+}
+
+static bool ItemIsStackable(Zeal::EqStructures::EQITEMINFO* item) {
+  return ((item->Common.IsStackable) && (item->Common.SpellId == 0));
+}
+
+void OutputFile::export_inventory(std::vector<std::string>& args) {
+  std::string t = "\t"; // output spacer
+
+  std::stringstream ss;
+  ss << "Location" << t << "Name" << t << "ID" << t << "Count" << t << "Slots" << std::endl;
+
+  // Processing Equipment
+  for (size_t i = 0; i < EQ_NUM_INVENTORY_SLOTS; ++i) {
+    auto item = Zeal::EqGame::get_self()->CharInfo->InventoryItem[i];
+    // EQITEMINFO->EquipSlot value only updates when a load happens. Don't use it for this.
+    if (item != nullptr) {
+      ss << IDToEquipSlot(i) << t << item->Name << t << item->Id << t << 1 << t << 0 << std::endl;
+    }
+    else {
+      ss << IDToEquipSlot(i) << t << "Empty" << t << "0" << t << "0" << t << "0" << std::endl;
+    }
+  }
+
+  // Processing Inventory Slots
+  for (size_t i = 0; i < EQ_NUM_INVENTORY_PACK_SLOTS; ++i) {
+    auto item = Zeal::EqGame::get_self()->CharInfo->InventoryPackItem[i];
+    if (item != nullptr) {
+      if (ItemIsContainer(item)) {
+        int capacity = static_cast<int>(item->Container.Capacity);
+        ss << "General" << i + 1 << t << item->Name << t << item->Id << t << 1 << t << capacity << std::endl;
+        for (int j = 0; j < capacity; ++j) {
+          auto bag_item = item->Container.Item[j];
+          if (bag_item != nullptr) {
+            int stack_count = ItemIsStackable(bag_item) ? static_cast<int>(bag_item->Common.StackCount) : 1;
+            ss << "General" << i + 1 << "-Slot" << j + 1 << t << bag_item->Name << t << bag_item->Id << t << stack_count << t << 0 << std::endl;
+          }
+          else {
+            ss << "General" << i + 1 << "-Slot" << j + 1 << t << "Empty" << t << "0" << t << "0" << t << "0" << std::endl;
+          }
+        }
+      }
+      else {
+        int stack_count = ItemIsStackable(item) ? static_cast<int>(item->Common.StackCount) : 1;
+        ss << "General" << i + 1 << t << item->Name << t << item->Id << t << stack_count << t << 0 << std::endl;
+      }
+    }
+    else {
+      ss << "General" << i + 1 << t << "Empty" << t << "0" << t << "0" << t << "0" << std::endl;
+    }
+  }
+
+  // Process Cursor Item
+  {
+    auto item = Zeal::EqGame::get_self()->CharInfo->CursorItem;
+    if (item != nullptr) {
+      if (ItemIsContainer(item)) {
+        int capacity = static_cast<int>(item->Container.Capacity);
+        ss << "Held" << t << item->Name << t << item->Id << t << 1 << t << capacity << std::endl;
+        for (int i = 0; i < capacity; ++i) {
+          auto bag_item = item->Container.Item[i];
+          if (bag_item != nullptr) {
+            int stack_count = ItemIsStackable(bag_item) ? static_cast<int>(bag_item->Common.StackCount) : 1;
+            ss << "Held" << "-Slot" << i + 1 << t << bag_item->Name << t << bag_item->Id << t << stack_count << t << 0 << std::endl;
+          }
+          else {
+            ss << "Held" << "-Slot" << i + 1 << t << "Empty" << t << "0" << t << "0" << t << "0" << std::endl;
+          }
+        }
+      }
+      else {
+        int stack_count = ItemIsStackable(item) ? static_cast<int>(item->Common.StackCount) : 1;
+        ss << "Held" << t << item->Name << t << item->Id << t << stack_count << t << 0 << std::endl;
+      }
+    }
+    else {
+      ss << "Held" << t << "Empty" << t << "0" << t << "0" << t << "0" << std::endl;
+    }
+  }
+
+  // Process Bank Items
+  for (size_t i = 0; i < EQ_NUM_INVENTORY_BANK_SLOTS; ++i) {
+    auto item = Zeal::EqGame::get_self()->CharInfo->InventoryBankItem[i];
+    if (item != nullptr) {
+      if (ItemIsContainer(item)) {
+        int capacity = static_cast<int>(item->Container.Capacity);
+        ss << "Bank" << i + 1 << t << item->Name << t << item->Id << t << 1 << t << capacity << std::endl;
+        for (int j = 0; j < capacity; ++j) {
+          auto bag_item = item->Container.Item[j];
+          if (bag_item != nullptr) {
+            int stack_count = ItemIsStackable(bag_item) ? static_cast<int>(bag_item->Common.StackCount) : 1;
+            ss << "Bank" << i + 1 << "-Slot" << j + 1 << t << bag_item->Name << t << bag_item->Id << t << stack_count << t << 0 << std::endl;
+          }
+          else {
+            ss << "Bank" << i + 1 << "-Slot" << j + 1 << t << "Empty" << t << "0" << t << "0" << t << "0" << std::endl;
+          }
+        }
+      }
+      else {
+        int stack_count = ItemIsStackable(item) ? static_cast<int>(item->Common.StackCount) : 1;
+        ss << "Bank" << i + 1 << t << item->Name << t << item->Id << t << stack_count << t << 0 << std::endl;
+      }
+    }
+    else {
+      ss << "Bank" << i + 1 << t << "Empty" << t << "0" << t << "0" << t << "0" << std::endl;
+    }
+  }
+
+  //Zeal::EqGame::print_chat(ss.str()); // debug purposes
+
+  std::string optional_name = "";
+  if (args.size() > 2) {
+    optional_name = args[2];
+  }
+  write_to_file(ss.str(), "Inventory", optional_name);
+  }
+
+  void OutputFile::write_to_file(std::string data, std::string file_arg, std::string optional_name)
+  {
+  std::string filename = optional_name;
+  if (filename.empty()) {
+    filename = Zeal::EqGame::get_self()->CharInfo->Name;
+    filename += "-" + file_arg;
+  }
+  filename += ".txt";
+
+  std::ofstream file;
+  file.open(filename);
+  file << data;
+  file.close();
+}
+
+OutputFile::OutputFile(ZealService* zeal)
+{
+  zeal->commands_hook->add("/outputfile", {},
+    [this](std::vector<std::string>& args) {
+      if (args.size() == 1 || args.size() > 3)
+      {
+        Zeal::EqGame::print_chat("usage: /outputfile [inventory] [optional filename]");
+        return true;
+      }
+      if (args.size() > 1 && caseInsensitiveStringCompare(args[1], "inventory"))
+      {
+        export_inventory(args);
+        return true;
+      }
+      return true;
+    });
+}
+
+OutputFile::~OutputFile()
+{
+}

--- a/Zeal/outputfile.h
+++ b/Zeal/outputfile.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "hook_wrapper.h"
+#include "memory.h"
+
+class OutputFile
+{
+public:
+  OutputFile(class ZealService* zeal);
+  ~OutputFile();
+private:
+  void export_inventory(std::vector<std::string>& args);
+  void write_to_file(std::string data, std::string filename, std::string optional_name);
+};


### PR DESCRIPTION
Currently only supports the inventory command, but that function is a 1:1 replica of the output from the EverQuest Titanium client, minus the shared bank slots and charm inventory slot.

My only concern with this PR is that maybe you would prefer to have `caseInsensitiveStringCompare` moved to a centralized location, but as it stands I just set both versions of them to be static so that they would be non-conflicting. Also, my EquipSlot enum is in the global namespace and that might not be to your liking.

Please let me know if you'd like anything changed.