### PR TITLE
Added a /buffs command to output buff timers on OldUI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ ___
   - **Arguments:** `inventory [optional_name]`
   - **Example:** `/outputfile inventory my_inventory`
   - **Description:** `inventory` outputs information about your equipment, inventory bag slots, held item, and bank slots to a file.
+ 
+- `/buffs`
+  - **Description:** Outputs the players buff timers to the chat only if they are using OldUI.
 ___
 ### Binds
 - Cycle through nearest NPCs

--- a/Zeal/EqStructures.h
+++ b/Zeal/EqStructures.h
@@ -323,7 +323,7 @@ namespace Zeal
 			/* 0x0002 */ BYTE Modifier; // divide by 10 to get Bard song modifier
 			/* 0x0003 */ BYTE Unknown0003;
 			/* 0x0004 */ WORD SpellId;
-			/* 0x0006 */ WORD Ticks; //  duration in ticks ; seconds = ticks * 3
+			/* 0x0006 */ WORD Ticks; //  duration in ticks ; seconds = ticks * 6
 			/* 0x0008 */ WORD Unknown0008;
 			/* 0x000A */
 		};

--- a/Zeal/Zeal.cpp
+++ b/Zeal/Zeal.cpp
@@ -21,6 +21,7 @@ ZealService::ZealService()
 	experience = std::shared_ptr<Experience>(new Experience(this));
 	chat_hook = std::shared_ptr<chat>(new chat(this, ini.get()));
 	outputfile = std::shared_ptr<OutputFile>(new OutputFile(this));
+  buff_timers = std::shard_ptr<BuffTimers>(new BuffTimers(this));
 
 
 	looting_hook->hide_looted = ini->getValue<bool>("Zeal", "HideLooted"); //just remembers the state

--- a/Zeal/Zeal.h
+++ b/Zeal/Zeal.h
@@ -25,6 +25,7 @@ public:
 	std::shared_ptr<OutputFile> outputfile = nullptr;
 	std::shared_ptr<Experience> experience = nullptr;
 	std::shared_ptr<CycleTarget> cycle_target = nullptr;
+  std::shared_ptr<BuffTimers> buff_timers = nullptr;
 	
 
 	bool exit = false;

--- a/Zeal/Zeal.vcxproj
+++ b/Zeal/Zeal.vcxproj
@@ -154,6 +154,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="binds.h" />
+    <ClInclude Include="buff_timers.h" />
     <ClInclude Include="chat.h" />
     <ClInclude Include="commands.h" />
     <ClInclude Include="cycle_target.h" />
@@ -182,6 +183,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="binds.cpp" />
+    <ClCompile Include="buff_timers.cpp" />
     <ClCompile Include="chat.cpp" />
     <ClCompile Include="commands.cpp" />
     <ClCompile Include="cycle_target.cpp" />

--- a/Zeal/Zeal.vcxproj.filters
+++ b/Zeal/Zeal.vcxproj.filters
@@ -117,6 +117,9 @@
     <ClInclude Include="outputfile.h">
       <Filter>Header Files\other</Filter>
     </ClInclude>
+    <ClInclude Include="buff_timers.h">
+      <Filter>Header Files\other</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
@@ -177,6 +180,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="outputfile.cpp">
+      <Filter>Source Files\other</Filter>
+    </ClCompile>
+    <ClCompile Include="buff_timers.cpp">
       <Filter>Source Files\other</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Zeal/buff_timers.cpp
+++ b/Zeal/buff_timers.cpp
@@ -5,21 +5,23 @@
 // the spell name based on the spell id.
 void BuffTimers::print_timers(void) {
   std::stringstream ss;
+  bool apply_delimeter[EQ_NUM_BUFFS]{};
 
   auto CharInfo = Zeal::EqGame::get_self()->CharInfo;
   for (size_t i = 0; i < EQ_NUM_BUFFS; ++i) {
-    WORD SpellId = CharInfo->Buff[i].SpellId;
-    if (SpellId != USHRT_MAX) {
-      if (i != 0)
-        ss << ", ";
+    WORD BuffId = CharInfo->Buff[i].SpellId;
+    apply_delimeter[i] = (BuffID != USHRT_MAX);
+  }
+  apply_delimeter[0] = false;
 
+  for (size_t i = 0; i < EQ_NUM_BUFFS; ++i) {
+    WORD BuffId = CharInfo->Buff[i].SpellId;
+    if (BuffId != USHRT_MAX) {
       int Mins = ((CharInfo->Buff[i].Ticks) * 6) / 60;
       int Secs = ((CharInfo->Buff[i].Ticks) * 6) % 60;
-      if (i != EQ_NUM_BUFFS)
-        ss << "(" << i + 1 << ")" << " " << Mins << "m" << Secs << "s";
-      else
-        ss << "(" << i + 1 << ")" << " " << Mins << "m" << Secs << "s" << std::endl;
-    }
+
+      if (apply_delimeter[i]) { ss << ", "; }
+      ss << "(" << i + 1 << ")" << " " << Mins << "m" << Secs << "s";
   }
 
   Zeal::EqGame::print_chat(ss.str());

--- a/Zeal/buff_timers.cpp
+++ b/Zeal/buff_timers.cpp
@@ -1,0 +1,40 @@
+#include "buff_timers.h"
+#include "Zeal.h"
+
+// An improvement we could have would be having a pointer/hook to the function that provides
+// the spell name based on the spell id.
+void BuffTimers::print_timers(void) {
+  std::stringstream ss;
+
+  auto CharInfo = Zeal::EqGame::get_self()->CharInfo;
+  for (size_t i = 0; i < EQ_NUM_BUFFS; ++i) {
+    WORD SpellId = CharInfo->Buff[i].SpellId;
+    if (SpellId != USHRT_MAX) {
+      if (i != 0)
+        ss << ", ";
+
+      int Mins = ((CharInfo->Buff[i].Ticks) * 6) / 60;
+      int Secs = ((CharInfo->Buff[i].Ticks) * 6) % 60;
+      if (i != EQ_NUM_BUFFS)
+        ss << "(" << i + 1 << ")" << " " << Mins << "m" << Secs << "s";
+      else
+        ss << "(" << i + 1 << ")" << " " << Mins << "m" << Secs << "s" << std::endl;
+    }
+  }
+
+  Zeal::EqGame::print_chat(ss.str());
+}
+
+BuffTimers::BuffTimers(ZealService* zeal)
+{
+  is_OldUI = ZealService::get_instance()->ini->getValue<bool>("Defaults", "OldUI");
+
+  zeal->commands_hook->add("/buffs", {},
+    [this](std::vector<std::string>& args) {
+      if (is_OldUI)
+        print_timers();
+      Zeal::EqGame::do_say(true, "");
+      return true;
+    }
+  );
+}

--- a/Zeal/buff_timers.h
+++ b/Zeal/buff_timers.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "hook_wrapper.h"
+#include "memory.h"
+
+class BuffTimers
+{
+public:
+  BuffTimers(class ZealService* zeal);
+  ~BuffTimers() {};
+private:
+  bool is_OldUI;
+  void print_timers(void);
+};

--- a/Zeal/framework.h
+++ b/Zeal/framework.h
@@ -6,7 +6,6 @@
 #include "EqFunctions.h"
 //hooks
 #include "commands.h"
-#include "cycle_target.h"
 #include "camera_mods.h"
 #include "looting.h"
 #include "FindPattern.h"
@@ -15,11 +14,14 @@
 #include "raid.h"
 #include "eqstr.h"
 #include "chat.h"
-#include "outputfile.h"
-
 #include "IO_ini.h"
 #include "main_loop.h"
+// other features
+#include "cycle_target.h"
+#include "outputfile.h"
 #include "experience.h"
+#include "buff_timers.h"
+
 #include "Zeal.h"
 
 extern HMODULE this_module;


### PR DESCRIPTION
The most recent eqgame.dll provided by Secrets for Quarm allows the user to have access to buff timers and (obviously) does not function the same way on OldUI. Due to such, I went ahead and wrote up a quick chat command that will output buff timers to the chat, and only functions on OldUI.

The extra do_say() on line 36 of buff_timers.cpp is a dirty fix for OldUI to clear the most recent custom chat command out of the input buffer. Do feel free to remove this if/when the custom commands properly clear for OldUI as well.