### PR TITLE
prevent call to GetFocusWnd() on OldUI that crashes client.

### DIFF
--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -44,10 +44,12 @@ namespace Zeal
 		bool game_wants_input()
 		{
 			int chat_input = EqGameInternal::UI_ChatInputCheck();
-			int focused_wnd = EqGameInternal::GetFocusWnd(*(int*)0x809db4, 0);
 			bool focused_window_needs_input = false;
-			if (focused_wnd)
-				focused_window_needs_input = EqGameInternal::CXWndIsType(focused_wnd, 0, 2);
+			if (is_new_ui()) {
+				int focused_wnd = EqGameInternal::GetFocusWnd(*(int*)0x809db4, 0);
+				if (focused_wnd)
+					focused_window_needs_input = EqGameInternal::CXWndIsType(focused_wnd, 0, 2);
+			}
 			return chat_input!=0 || focused_window_needs_input;
 		}
 


### PR DESCRIPTION
Basically the same alteration that I brought up in #17 but with the new `is_new_ui()` check, so that we can build and successfully run on both ui's