### PR TITLE
custom /alarm command for oldui users

### DIFF
--- a/Zeal/Zeal.cpp
+++ b/Zeal/Zeal.cpp
@@ -24,6 +24,7 @@ ZealService::ZealService()
 	outputfile = std::shared_ptr<OutputFile>(new OutputFile(this));
 	buff_timers = std::shared_ptr<BuffTimers>(new BuffTimers(this));
 	auto_stand = std::shared_ptr<AutoStand>(new AutoStand(this));
+	alarm = std::shared_ptr<Alarm>(new Alarm(this));
 	
 
 

--- a/Zeal/Zeal.h
+++ b/Zeal/Zeal.h
@@ -27,6 +27,7 @@ public:
 	std::shared_ptr<CycleTarget> cycle_target = nullptr;
 	std::shared_ptr<BuffTimers> buff_timers = nullptr;
 	std::shared_ptr<AutoStand> auto_stand = nullptr;
+	std::shared_ptr<Alarm> alarm = nullptr;
 	
 	
 

--- a/Zeal/Zeal.vcxproj
+++ b/Zeal/Zeal.vcxproj
@@ -153,6 +153,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="alarm.h" />
     <ClInclude Include="auto_stand.h" />
     <ClInclude Include="binds.h" />
     <ClInclude Include="buff_timers.h" />
@@ -185,6 +186,7 @@
     <ClInclude Include="Zeal.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="alarm.cpp" />
     <ClCompile Include="auto_stand.cpp" />
     <ClCompile Include="binds.cpp" />
     <ClCompile Include="buff_timers.cpp" />

--- a/Zeal/Zeal.vcxproj.filters
+++ b/Zeal/Zeal.vcxproj.filters
@@ -129,6 +129,9 @@
     <ClInclude Include="spellsets.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="alarm.h">
+      <Filter>Header Files\hooks</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
@@ -201,6 +204,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="spellsets.cpp">
+      <Filter>Source Files\hooks</Filter>
+    </ClCompile>
+    <ClCompile Include="alarm.cpp">
       <Filter>Source Files\hooks</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Zeal/alarm.cpp
+++ b/Zeal/alarm.cpp
@@ -1,0 +1,54 @@
+#include "alarm.h"
+#include "Zeal.h"
+
+void Alarm::Set(int minutes, int seconds)
+{
+  if (!enabled)
+  {
+    enabled = true;
+    duration = ((minutes * 60) + seconds) * 1000;
+    std::ostringstream oss;
+    oss << "[Alarm] SET! (" << minutes << "m" << seconds << "s)" << std::endl;
+    Zeal::EqGame::print_chat(oss.str());
+  }
+  else
+  {
+    Zeal::EqGame::print_chat("[Alarm] Please halt the active alarm before attempting to set a new one.");
+  }
+}
+
+void Alarm::Halt(void)
+{
+  if (enabled) {
+    enabled = false;
+    Zeal::EqGame::print_chat("[Alarm] HALT!");
+  }
+  else
+  {
+    Zeal::EqGame::print_chat("[Alarm] No active alarm.");
+  }
+}
+
+void Alarm::callback_main()
+{
+  if (enabled)
+  {
+    if (!start_time)
+      start_time = GetTickCount64();
+
+    if (GetTickCount64() - start_time > duration)
+    {
+      Zeal::EqGame::print_chat("[Alarm] COMPLETED!");
+      enabled = false;
+    }
+  }
+  else
+  {
+    start_time = 0;
+  }
+}
+
+Alarm::Alarm(ZealService* zeal)
+{
+	zeal->main_loop_hook->add_callback([this]() { callback_main(); });
+}

--- a/Zeal/alarm.h
+++ b/Zeal/alarm.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "hook_wrapper.h"
+#include "memory.h"
+
+class Alarm
+{
+public:
+	Alarm(class ZealService* zeal);
+	~Alarm() {};
+	void Set(int minutes, int seconds);
+	void Halt(void);
+private:
+	void callback_main();
+	ULONGLONG start_time = 0;
+	double duration = 0;
+	bool enabled = false;
+};
+

--- a/Zeal/buff_timers.cpp
+++ b/Zeal/buff_timers.cpp
@@ -20,6 +20,7 @@ void BuffTimers::print_timers(void) {
     }
   }
 
+  oss << "[Buffs] ";
   if (activeBuffs.size() != 0) {
     for (size_t i = 0; i <  activeBuffs.size(); ++i) {
       BuffDetails details = activeBuffs[i];
@@ -34,8 +35,9 @@ void BuffTimers::print_timers(void) {
   }
   else
   {
-    oss << "[Buffs] None";
+    oss << "None";
   }
+  oss << std::endl;
 
   Zeal::EqGame::print_chat(oss.str());
 }

--- a/Zeal/commands.cpp
+++ b/Zeal/commands.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cctype>
 #include "StringUtil.h"
+#include <thread>
 
 void __fastcall InterpretCommand(int c, int unused, int player, char* cmd)
 {
@@ -130,11 +131,45 @@ ChatCommands::ChatCommands(ZealService* zeal)
 		});
 	add("/alarm", {},
 		[this, zeal](std::vector<std::string>& args) {
-			if (Zeal::EqGame::Windows->CAlarm)
-				Zeal::EqGame::Windows->CAlarm->IsVisible = true;
-			else
-				Zeal::EqGame::print_chat("Alarm window not found");
-			return true;
+			if (Zeal::EqGame::is_new_ui()) {
+				if (Zeal::EqGame::Windows->CAlarm)
+					Zeal::EqGame::Windows->CAlarm->IsVisible = true;
+				else
+					Zeal::EqGame::print_chat("Alarm window not found");
+
+				return true;
+			}
+			else {
+				if (args.size() == 1) {
+					std::ostringstream oss;
+					oss << "-- ALARM COMMANDS --" << std::endl << "/alarm set #m#s" << std::endl << "/alarm halt" << std::endl;
+					Zeal::EqGame::print_chat(oss.str());
+					return true;
+				}
+				if (args.size() > 1 && args.size() < 4) {
+					if (StringUtil::caseInsensitive(args[1], "set")) {
+						int minutes = 0;
+						int seconds = 0;
+						int delim[2] = { args[2].find("m"), args[2].find("s") };
+						if (StringUtil::tryParse(args[2].substr(0, delim[0]), &minutes) &&
+								StringUtil::tryParse(args[2].substr(delim[0]+1, delim[1]), &seconds))
+						{
+							zeal->alarm->Set(minutes, seconds);
+							return true;
+						}
+						else
+						{
+							Zeal::EqGame::print_chat("[Alarm] Failed to parse the specified duration.");
+							return true;
+						}
+					}
+					else if (StringUtil::caseInsensitive(args[1], "halt")) {
+						zeal->alarm->Halt();
+						return true;
+					}
+				}
+			}
+			return false;
 		});
 	//add("/tunnelfps", {},
 	//	[this, zeal](std::vector<std::string>& args) {

--- a/Zeal/commands.cpp
+++ b/Zeal/commands.cpp
@@ -150,7 +150,7 @@ ChatCommands::ChatCommands(ZealService* zeal)
 					if (StringUtil::caseInsensitive(args[1], "set")) {
 						int minutes = 0;
 						int seconds = 0;
-						int delim[2] = { args[2].find("m"), args[2].find("s") };
+						size_t delim[2] = { args[2].find("m"), args[2].find("s") };
 						if (StringUtil::tryParse(args[2].substr(0, delim[0]), &minutes) &&
 								StringUtil::tryParse(args[2].substr(delim[0]+1, delim[1]), &seconds))
 						{

--- a/Zeal/commands.cpp
+++ b/Zeal/commands.cpp
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <cctype>
 #include "StringUtil.h"
-#include <thread>
 
 void __fastcall InterpretCommand(int c, int unused, int player, char* cmd)
 {

--- a/Zeal/framework.h
+++ b/Zeal/framework.h
@@ -23,6 +23,7 @@
 #include "buff_timers.h"
 #include "auto_stand.h"
 #include "spellsets.h"
+#include "alarm.h"
 
 #include "Zeal.h"
 


### PR DESCRIPTION
Since /alarm on newui just reopens the alarm window to set a fresh timer, I set up a command and added a callback to the mainloop hook to create a pseudo timer. 

The command currently only supports one timer at a time, and I don't think I should be adding support for more given that the alarm window only supports one alarm at a time (to my knowledge).