### PR TITLE
Reverting clearing of chat buffer on OldUI

### DIFF
--- a/Zeal/commands.cpp
+++ b/Zeal/commands.cpp
@@ -35,8 +35,6 @@ void __fastcall InterpretCommand(int c, int unused, int player, char* cmd)
 			}
 		}
 		if (cmd_handled) {
-			if (!Zeal::EqGame::is_new_ui())
-				cmd[0] = '\0';
 			return;
 		}
 	}


### PR DESCRIPTION
reverting this change because using social macros with custom commands in them will clear those lines out of the macros.