### PR TITLE
some critical autostand updates

### DIFF
--- a/Zeal/Zeal.cpp
+++ b/Zeal/Zeal.cpp
@@ -23,7 +23,7 @@ ZealService::ZealService()
 	chat_hook = std::shared_ptr<chat>(new chat(this, ini.get()));
 	outputfile = std::shared_ptr<OutputFile>(new OutputFile(this));
 	buff_timers = std::shared_ptr<BuffTimers>(new BuffTimers(this));
-	auto_stand = std::shared_ptr<AutoStand>(new AutoStand(this));
+	auto_stand = std::shared_ptr<AutoStand>(new AutoStand(this, ini.get()));
 	alarm = std::shared_ptr<Alarm>(new Alarm(this));
 	
 

--- a/Zeal/auto_stand.cpp
+++ b/Zeal/auto_stand.cpp
@@ -2,24 +2,69 @@
 #include "Zeal.h"
 #include "EqAddresses.h"
 
+static void CloseSpellbook(void)
+{
+	Zeal::EqGame::change_stance(Stance::Stand);
+	Zeal::EqGame::Windows->CSpellBook->IsVisible = false;
+}
+
 void AutoStand::handle_movement_binds(int cmd, bool key_down)
 {
 	if (!Zeal::EqGame::game_wants_input() && key_down)
 	{
 		if (!Zeal::EqGame::KeyMods->Alt && !Zeal::EqGame::KeyMods->Shift && !Zeal::EqGame::KeyMods->Ctrl)
 		{
-			if (Zeal::EqGame::Windows->CLoot && Zeal::EqGame::Windows->CLoot->IsOpen && Zeal::EqGame::Windows->CLoot->IsVisible)
+			if (Zeal::EqGame::is_new_ui())
 			{
-				Zeal::EqGame::EqGameInternal::CLootWndDeactivate((int)Zeal::EqGame::Windows->CLoot, 0);
-				return;
+				if (Zeal::EqGame::Windows->CLoot && Zeal::EqGame::Windows->CLoot->IsOpen && Zeal::EqGame::Windows->CLoot->IsVisible)
+				{
+					Zeal::EqGame::EqGameInternal::CLootWndDeactivate((int)Zeal::EqGame::Windows->CLoot, 0);
+					return;
+				}
+				else if (Zeal::EqGame::Windows->CSpellBook && Zeal::EqGame::Windows->CSpellBook->IsVisible)
+				{
+					switch (cmd) {
+						case 3:
+							CloseSpellbook();
+							break;
+						case 5: // default should be turn page left (not implemented)
+							if (!spellbook_left_autostand)
+								return;
+							else
+								CloseSpellbook();
+							break;
+						case 6: // default to turn page right (not implemented)
+							if (!spellbook_right_autostand)
+								return;
+							else
+								CloseSpellbook();
+							break;
+						default:{}break;
+					}
+
+					return;
+				}
 			}
-			else if (Zeal::EqGame::Windows->CSpellBook && Zeal::EqGame::Windows->CSpellBook->IsVisible)
+			else
 			{
-				//Zeal::EqGame::change_stance(Stance::Stand);
-				//Zeal::EqGame::Windows->CSpellBook->IsVisible = false;
-				return;
+				if (Zeal::EqGame::get_active_corpse())
+				{
+					// how do we close corpse without closing the window?
+					return;
+				}
+				// spellbook handler here
+				// left and right arrows dont turn pages on oldui by default
+				// so we probably wont add support for other keys
 			}
-			Zeal::EqGame::change_stance(Stance::Stand);
+
+			// not in a window, handle things normally. (why did this check get removed?)
+			switch (Zeal::EqGame::get_self()->StandingState)
+			{
+				case Zeal::EqEnums::Stance::Sitting:
+					Zeal::EqGame::change_stance(Stance::Stand);
+					break;
+				default: { return; }
+			}
 		}
 	}
 }
@@ -28,23 +73,52 @@ void AutoStand::handle_spellcast_binds(int cmd)
 {
 	if (!Zeal::EqGame::game_wants_input())
 	{
-		if (Zeal::EqGame::Windows->CLoot && Zeal::EqGame::Windows->CLoot->IsOpen && Zeal::EqGame::Windows->CLoot->IsVisible)
+		if (Zeal::EqGame::is_new_ui())
 		{
-			return;
+			if (Zeal::EqGame::Windows->CLoot && Zeal::EqGame::Windows->CLoot->IsOpen && Zeal::EqGame::Windows->CLoot->IsVisible)
+			{
+				return;
+			}
+			else if (Zeal::EqGame::Windows->CSpellBook && Zeal::EqGame::Windows->CSpellBook->IsVisible)
+			{
+				return;
+			}
 		}
-		else if (Zeal::EqGame::Windows->CSpellBook && Zeal::EqGame::Windows->CSpellBook->IsVisible)
+		else
 		{
-			//Zeal::EqGame::change_stance(Stance::Stand);
-			//Zeal::EqGame::Windows->CSpellBook->IsVisible = false;
-			return;
+			if (Zeal::EqGame::get_active_corpse())
+			{
+				// how do we close corpse without closing the window?
+				return;
+			}
+			// need spellbook handler
 		}
-		Zeal::EqGame::change_stance(Stance::Stand);
+
+		// not in a window, handle things normally
+		switch (Zeal::EqGame::get_self()->StandingState)
+		{
+			case Zeal::EqEnums::Stance::Sitting:
+				Zeal::EqGame::change_stance(Stance::Stand);
+				break;
+			default: { return; }
+		}
 	}
 }
 
-AutoStand::AutoStand(ZealService* zeal)
+void AutoStand::load_settings(IO_ini* ini)
 {
+	if (!ini->exists("Zeal", "LeftTurnSpellbookAutostand"))
+		ini->setValue<bool>("Zeal", "LeftTurnSpellbookAutostand", false);
+	if (!ini->exists("Zeal", "RightTurnSpellbookAutostand"))
+		ini->setValue<bool>("Zeal", "RightTurnSpellbookAutostand", false);
 
+	spellbook_left_autostand = ini->getValue<bool>("Zeal", "LeftTurnSpellbookAutostand");
+	spellbook_right_autostand = ini->getValue<bool>("Zeal", "RightTurnSpellbookAutostand");
+}
+
+AutoStand::AutoStand(ZealService* zeal, class IO_ini* ini)
+{
+	load_settings(ini);
 }
 AutoStand::~AutoStand()
 {

--- a/Zeal/auto_stand.h
+++ b/Zeal/auto_stand.h
@@ -6,7 +6,11 @@ class AutoStand
 public:
 	void handle_movement_binds(int cmd, bool key_down);
 	void handle_spellcast_binds(int cmd);
-	AutoStand(class ZealService* zeal);
+	AutoStand(class ZealService* zeal, class IO_ini* ini);
 	~AutoStand();
+private:
+	void load_settings(IO_ini* ini);
+	bool spellbook_left_autostand;
+	bool spellbook_right_autostand;
 };
 


### PR DESCRIPTION
### General
Prevents autostanding out of non sitting position (not sure why this was changed when it originally got merged in)

### NewUI
Prevents back movement autostand out of spellbook, while forward movement does auto-stand
Prevents left/right movement autostand out of spellbook unless ini flags are toggled. Defaults to not autostanding.

### OldUI
Prevents autostanding and casting out of corpses.