### PR TITLE
oldui spellbook check

### DIFF
--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -610,5 +610,31 @@ namespace Zeal
 			}
 		}
 
+		namespace OldUI
+		{
+			bool spellbook_window_open()
+			{
+				// ISSUE: There is currently a small edge case where chat scrollbar usage can cause the value we're checking to flicker.
+				HMODULE dx8 = GetModuleHandleA("eqgfx_dx8.dll");
+				// feedback/help window increase offset of pointer by 44, but they also get hit by game_wants_input(), so don't bother check them.
+				if (dx8)
+				{
+					int offset = 0;
+					for (size_t i = 0; i < EQ_NUM_SPELL_GEMS; ++i) {
+						if (Zeal::EqGame::get_self()->CharInfo->MemorizedSpell[i] != USHRT_MAX) {
+							offset += 88;
+						}
+					}
+					if (Zeal::EqGame::get_target()) { offset += 44; }
+					bool view_button_clicked = (*(DWORD*)((DWORD)dx8 + (0x3CD1C4 + offset)) != ULONG_MAX); // weird offset edge case (view hotkey not included)
+					if (view_button_clicked) { offset += 44; }
+					return (*(DWORD*)((DWORD)dx8 + (0x3CD1C4 + offset)) == ULONG_MAX);
+				}
+				else
+				{
+					return false;
+				}
+			}
+		}
 	}
 }

--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -96,6 +96,10 @@ namespace Zeal
 			void Forget(int index);
 			void UpdateGems(int index);
 		}
+		namespace OldUI
+		{
+			bool spellbook_window_open();
+		}
 		bool is_new_ui();
 		HWND get_game_window();
 		bool is_in_char_select();

--- a/Zeal/auto_stand.cpp
+++ b/Zeal/auto_stand.cpp
@@ -52,9 +52,14 @@ void AutoStand::handle_movement_binds(int cmd, bool key_down)
 					// how do we close corpse without closing the window?
 					return;
 				}
-				// spellbook handler here
-				// left and right arrows dont turn pages on oldui by default
-				// so we probably wont add support for other keys
+				else if (Zeal::EqGame::OldUI::spellbook_window_open())
+				{
+					// left and right arrows dont turn pages on oldui by default
+					// so I'm not sure if we'll add support for other keys
+					if (cmd == 4) { return; }
+					else if (cmd == 5 && !spellbook_left_autostand)  { return; }
+					else if (cmd == 6 && !spellbook_right_autostand) { return; }
+				}
 			}
 
 			// not in a window, handle things normally. (why did this check get removed?)
@@ -91,7 +96,10 @@ void AutoStand::handle_spellcast_binds(int cmd)
 				// how do we close corpse without closing the window?
 				return;
 			}
-			// need spellbook handler
+			else if (Zeal::EqGame::OldUI::spellbook_window_open())
+			{
+				return;
+			}
 		}
 
 		// not in a window, handle things normally


### PR DESCRIPTION
Very dirty code, but seems to function fine except the one known edge case I couldn't figure out how to handle.

We should definitely look into a better way to handle this, but this currently puts auto-stand on OldUI in the same place as NewUI.