### PR TITLE
Movement/Autostand fixes.

### DIFF
--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -571,11 +571,6 @@ namespace Zeal
 		{
 			return *Zeal::EqGame::in_game;
 		}
-		void change_stance(Stance new_stance)
-		{
-			if (Self && Self->StandingState != (BYTE)new_stance)
-				EqGameInternal::change_stance(get_self(), 0, new_stance); //EQPlayer::ChangePosition
-		}
 		bool is_new_ui()
 		{
 			return *(BYTE*)0x8092D8;

--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -48,7 +48,6 @@ namespace Zeal
 			static mem::function<short __fastcall(int, int)> get_max_mana = 0x4B9483;
 			static mem::function<short __fastcall(int, int)> get_cur_mana = 0x4b9450;
 			static mem::function<int __cdecl(int, Vec3*)> t3dGetRegionNumberFromWorldAndXYZ = 0x0;
-			static mem::function<short __fastcall(Zeal::EqStructures::Entity*,int unused, unsigned char)> change_stance = 0x50be3c;
 			static mem::function<void __fastcall(DWORD, int unused, DWORD)> ui_something = 0x536bae;
 			static mem::function<float __stdcall(float input_heading)> fix_heading = 0x4a2eed;
 			static mem::function<void __stdcall()> ProcessMouseEvent = 0x525db4;
@@ -124,7 +123,6 @@ namespace Zeal
 		bool is_game_ui_window_hovered();
 		bool is_targetable(Zeal::EqStructures::Entity* ent);
 		bool is_in_game();
-		void change_stance(Stance new_stance);
 		void do_say(bool hide_local, const char* format, ...);
 		void do_say(bool hide_local, std::string data);
 		int get_region_from_pos(Vec3* pos);

--- a/Zeal/EqStructures.h
+++ b/Zeal/EqStructures.h
@@ -447,6 +447,11 @@ namespace Zeal
 
 		struct Entity
 		{
+			void ChangeStance(BYTE new_stance)
+			{
+				if (this && this->StandingState != new_stance)
+					reinterpret_cast<void(__thiscall*)(Entity*, unsigned char)>(0x50be3c)(this, new_stance);
+			}
 			/* 0x0000 */ BYTE Unknown0000; // always equals 0x03
 			/* 0x0001 */ CHAR Name[30]; // [0x1E]
 			/* 0x001F */ BYTE Unknown001F[37];

--- a/Zeal/Zeal.cpp
+++ b/Zeal/Zeal.cpp
@@ -57,7 +57,7 @@ ZealService::ZealService()
 		}); // spellcasting auto-stand
 	}
 	binds_hook->replace_bind(72, [this](int state) {
-		Zeal::EqGame::change_stance(Stance::Sit);
+		Zeal::EqGame::get_self()->ChangeStance(Stance::Sit);
 		return false;
 	}); // hotkey camp auto-sit
 

--- a/Zeal/buff_timers.h
+++ b/Zeal/buff_timers.h
@@ -18,6 +18,5 @@ public:
   BuffTimers(class ZealService* zeal);
   ~BuffTimers() {};
 private:
-  bool is_OldUI;
   void print_timers(void);
 };

--- a/Zeal/commands.cpp
+++ b/Zeal/commands.cpp
@@ -80,8 +80,7 @@ ChatCommands::ChatCommands(ZealService* zeal)
 		});
 	add("/camp", {},
 		[](std::vector<std::string>& args) {
-
-			Zeal::EqGame::change_stance(Stance::Sit);
+			Zeal::EqGame::get_self()->ChangeStance(Stance::Sit);
 			return false;
 		});
 	add("/showhelm", { "/helm" },

--- a/Zeal/player_movement.cpp
+++ b/Zeal/player_movement.cpp
@@ -2,59 +2,9 @@
 #include "Zeal.h"
 #include "EqAddresses.h"
 
-enum PerspectiveSpells // This was all I could find on the database. Please update if there are any missing.
-{
-	SHIFTING_SIGHT = 84,
-	EYE_OF_ZOMM = 323,
-	SIGHT_GRAFT = 361,
-	ASSIDUOUS_VISION = 384,
-	CAST_SIGHT = 407,
-	BIND_SIGHT = 500,
-	VISION = 580,
-	LYSSAS_SOLIDARITY_OF_VISION = 721,
-	EYE_OF_TALLON = 1720,
-};
-
-static bool HasActivePerspectiveModifier(void)
-{
-	auto CharInfo = Zeal::EqGame::get_self()->CharInfo;
-	for (size_t i = 0; i < EQ_NUM_BUFFS; ++i)
-	{
-		switch (CharInfo->Buff[i].SpellId)
-		{
-			case SHIFTING_SIGHT:
-			case EYE_OF_ZOMM:
-			case SIGHT_GRAFT:
-			case ASSIDUOUS_VISION:
-			case CAST_SIGHT:
-			case BIND_SIGHT:
-			case VISION:
-			case LYSSAS_SOLIDARITY_OF_VISION:
-			case EYE_OF_TALLON:
-				return true;
-				break;
-			default:{}break;
-		}
-	}
-
-	return false;
-}
-
-static bool UsingEyeOfZomm(void)
-{
-	auto CharInfo = Zeal::EqGame::get_self()->CharInfo;
-	for (size_t i = 0; i < EQ_NUM_BUFFS; ++i)
-	{
-		if (CharInfo->Buff[i].SpellId == EYE_OF_ZOMM || CharInfo->Buff[i].SpellId == EYE_OF_TALLON)
-			return true;
-	}
-
-	return false;
-}
-
 static void CloseSpellbook(void)
 {
-	Zeal::EqGame::change_stance(Stance::Stand);
+	Zeal::EqGame::get_self()->ChangeStance(Stance::Stand);
 	Zeal::EqGame::Windows->SpellBook->IsVisible = false;
 }
 
@@ -64,9 +14,6 @@ void PlayerMovement::handle_movement_binds(int cmd, bool key_down)
 	{
 		if (!Zeal::EqGame::KeyMods->Alt && !Zeal::EqGame::KeyMods->Shift && !Zeal::EqGame::KeyMods->Ctrl)
 		{
-			// no movement autostand while in eye of zomm
-			if (UsingEyeOfZomm()) { return; }
-
 			if (Zeal::EqGame::is_new_ui())
 			{
 				if (Zeal::EqGame::Windows->Loot && Zeal::EqGame::Windows->Loot->IsOpen && Zeal::EqGame::Windows->Loot->IsVisible)
@@ -76,9 +23,6 @@ void PlayerMovement::handle_movement_binds(int cmd, bool key_down)
 				}
 				else if (Zeal::EqGame::Windows->SpellBook && Zeal::EqGame::Windows->SpellBook->IsVisible)
 				{
-					// no spellbook autostand while in modified perspective.
-					if (HasActivePerspectiveModifier()) { return; }
-
 					switch (cmd) {
 						case 3:
 							CloseSpellbook();
@@ -112,9 +56,6 @@ void PlayerMovement::handle_movement_binds(int cmd, bool key_down)
 				}
 				else if (Zeal::EqGame::OldUI::spellbook_window_open())
 				{
-					// no spellbook autostand while in modified perspective.
-					if (HasActivePerspectiveModifier()) { return; }
-
 					// left and right arrows dont turn pages on oldui by default
 					// so I'm not sure if we'll add support for other keys
 					if (cmd == 4) { return; }
@@ -123,10 +64,10 @@ void PlayerMovement::handle_movement_binds(int cmd, bool key_down)
 				}
 			}
 
-			switch (Zeal::EqGame::get_self()->StandingState)
+			switch (Zeal::EqGame::get_controlled()->StandingState)
 			{
 				case Zeal::EqEnums::Stance::Sitting:
-					Zeal::EqGame::change_stance(Stance::Stand);
+					Zeal::EqGame::get_controlled()->ChangeStance(Stance::Stand);
 					break;
 				default: { return; }
 			}
@@ -166,7 +107,7 @@ void PlayerMovement::handle_spellcast_binds(int cmd)
 		switch (Zeal::EqGame::get_self()->StandingState)
 		{
 			case Zeal::EqEnums::Stance::Sitting:
-				Zeal::EqGame::change_stance(Stance::Stand);
+				Zeal::EqGame::get_self()->ChangeStance(Stance::Stand);
 				break;
 			default: { return; }
 		}

--- a/Zeal/player_movement.cpp
+++ b/Zeal/player_movement.cpp
@@ -60,13 +60,13 @@ static void CloseSpellbook(void)
 
 void PlayerMovement::handle_movement_binds(int cmd, bool key_down)
 {
-	// no movement autostand while in eye of zomm
-	if (UsingEyeOfZomm()) { return; }
-
 	if (!Zeal::EqGame::game_wants_input() && key_down)
 	{
 		if (!Zeal::EqGame::KeyMods->Alt && !Zeal::EqGame::KeyMods->Shift && !Zeal::EqGame::KeyMods->Ctrl)
 		{
+			// no movement autostand while in eye of zomm
+			if (UsingEyeOfZomm()) { return; }
+
 			if (Zeal::EqGame::is_new_ui())
 			{
 				if (Zeal::EqGame::Windows->Loot && Zeal::EqGame::Windows->Loot->IsOpen && Zeal::EqGame::Windows->Loot->IsVisible)

--- a/Zeal/player_movement.h
+++ b/Zeal/player_movement.h
@@ -22,6 +22,8 @@ private:
 	void load_settings(IO_ini* ini);
 	bool spellbook_left_autostand;
 	bool spellbook_right_autostand;
+	bool spellbook_left_strafe_autostand;
+	bool spellbook_right_strafe_autostand;
 	strafe_direction current_strafe = strafe_direction::None;
 	BYTE orig_reset_strafe[7] = { 0 };
 };

--- a/Zeal/spellsets.cpp
+++ b/Zeal/spellsets.cpp
@@ -85,7 +85,7 @@ void SpellSets::finished_memorizing(int a1, int a2)
             Zeal::EqGame::Spells::Memorize(mem_buffer.back().first, mem_buffer.back().second);
         else if (Zeal::EqGame::Windows->SpellBook->IsVisible)
         {
-            Zeal::EqGame::change_stance(original_stance);
+            Zeal::EqGame::get_self()->ChangeStance(original_stance);
             Zeal::EqGame::Windows->SpellBook->IsVisible = false;
         }
     }


### PR DESCRIPTION
- Added a check to prevent all directional autostand while in eye of zomm type spells.
- Added a check to prevent all directional autostand in spellbook while using perspective changing spells. (bind sight/zomm)
- Added in two .ini flags to check for autostanding with strafe while in spellbook (default behavior is enabled)
- Removed an unnecessary line from `buff_timers.h`

The eye of zomm directional autostand changes are dependent on having an eqgame.dll published from @SecretsOTheP with the removal of the autostand from the dll side to properly function (currently it **will** autostand while outside of spellbook with all versions of the eqgame.dll file that are accessible from the quarm discord)