### PR TITLE
Completing the /sit command by adding "on" as an argument to match existing "off" argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ ___
   - **Aliases:** `/autoinv`, `/ai`
   - **Description:** Drops whatever is on your cursor into your inventory.
 
+- `/sit`
+  - **Description:** The /sit command now accepts "on" as an argument. Using "/sit on" will always make you sit, even if you are currently sitting. This matches the game's native "/sit off" which always makes you stand even if you are currently standing. The "/sit" command will continue to toggle sit/stand state if the argument provided is not on or off.
+
 - `/camp`
   - **Description:** Auto sits before camping.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ ___
   - **Description:** Drops whatever is on your cursor into your inventory.
 
 - `/sit`
-  - **Description:** The /sit command now accepts "on" as an argument. Using "/sit on" will always make you sit, even if you are currently sitting. This matches the game's native "/sit off" which always makes you stand even if you are currently standing. The "/sit" command will continue to toggle sit/stand state if the argument provided is not on or off.
+  - **Description:** The /sit command now accepts "on" as an argument. Using "/sit on" will always make you sit, even if you are currently sitting. This matches the game's native "/sit off" which always makes you stand even if you are currently standing. The "/sit" command will continue to toggle sit/stand state if no argument is provided or if the argument provided is not on or off.
 
 - `/camp`
   - **Description:** Auto sits before camping.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ ___
   - **Description:** Drops whatever is on your cursor into your inventory.
 
 - `/sit`
-  - **Description:** The /sit command now accepts "on" as an argument. Using "/sit on" will always make you sit, even if you are currently sitting. This matches the game's native "/sit off" which always makes you stand even if you are currently standing. The "/sit" command will continue to toggle sit/stand state if no argument is provided or if the argument provided is not on or off.
+  - **Description:** The /sit command now accepts "on" as an argument. Using "/sit on" will always make you sit, even if you are currently sitting. This matches the game's native "/sit off" which always makes you stand even if you are currently standing. The "/sit" command will continue to toggle sit/stand state if no argument is provided or if the argument provided is not on or off. Additionally, "/sit down" now works as well and will always make you sit, even if already sitting.
 
 - `/camp`
   - **Description:** Auto sits before camping.

--- a/Zeal/commands.cpp
+++ b/Zeal/commands.cpp
@@ -79,7 +79,7 @@ ChatCommands::ChatCommands(ZealService* zeal)
 	add("/sit", {},
 		[](std::vector<std::string>& args) {
 			if (args.size() > 1 && args.size() < 3) {
-				if (StringUtil::caseInsensitive(args[1], "on")) {
+				if (StringUtil::caseInsensitive(args[1], "on") || StringUtil::caseInsensitive(args[1], "down")) {
 					Zeal::EqGame::get_self()->ChangeStance(Stance::Sit);
 					return true;
 				}

--- a/Zeal/commands.cpp
+++ b/Zeal/commands.cpp
@@ -76,6 +76,16 @@ ChatCommands::ChatCommands(ZealService* zeal)
 
 			return false;
 		});
+	add("/sit", {},
+		[](std::vector<std::string>& args) {
+			if (args.size() > 1 && args.size() < 3) {
+				if (StringUtil::caseInsensitive(args[1], "on")) {
+					Zeal::EqGame::get_self()->ChangeStance(Stance::Sit);
+					return true;
+				}
+			}
+			return false;
+		});
 	add("/camp", {},
 		[](std::vector<std::string>& args) {
 			Zeal::EqGame::get_self()->ChangeStance(Stance::Sit);


### PR DESCRIPTION
Hello again.

The game as is has a /sit command. If no argument is provided or any argument is provided other than "off" the /sit command acts as a toggle between a sitting and standing state. If the native /sit command is provided the "off" argument ("/sit off") then it will always stand, even if standing already.

This update will intercept the native /sit command, and if the argument provided is "on" or "down" ("/sit on" | "/sit down") it will always sit, even if sitting already.

The purpose of this change is to provide the missing "on" argument to match the existing off argument, as well as the "down" argument which might be more natural. This will allow people to use "/sit on" or "/sit down" in macros if their intention is always to sit regardless of whether they are already sitting or not (ie other lines in the macro continue to process).

Summary:
Existing game behavior:

/sit - toggles between sit and stand
/sit off - always stands
/sit on - argument is ignored so same as /sit
/sit down - argument is ignored so same as /sit
/sit anyOtherArgument - argument is ignored so same as /sit

New game behavior

/sit - toggles between sit and stand (unchanged)
/sit off - always stands (unchanged)
**/sit on - always sits (proposed param)
/sit down - always sits (proposed param)**
/sit anyOtherArgument - argument is ignored so same as /sit (unchanged)