### PR TITLE
Refine zone map zoom and add poi support

### DIFF
--- a/Zeal/binds.cpp
+++ b/Zeal/binds.cpp
@@ -264,6 +264,12 @@ void Binds::add_binds()
 			ZealService::get_instance()->zone_map->toggle_background();
 		}
 		});
+	add_bind(230, "Toggle Map Zoom", "ToggleMapZoom", key_category::UI, [this](int key_down) {
+		if (key_down && !Zeal::EqGame::EqGameInternal::UI_ChatInputCheck())
+		{
+			ZealService::get_instance()->zone_map->toggle_zoom();
+		}
+		});
 	add_bind(255, "Auto Inventory", "AutoInventory", key_category::Commands | key_category::Macros, [](int key_down)
 	{
 		if (key_down)

--- a/Zeal/physics.cpp
+++ b/Zeal/physics.cpp
@@ -61,7 +61,7 @@ Physics::Physics(ZealService* zeal, IO_ini* ini)
 
 	zeal->hooks->Add("ProcessPhysics", 0x54D964, ProcessPhysics, hook_type_detour);
 	zeal->hooks->Add("MovePlayer", 0x504765, MovePlayer, hook_type_detour);
-	mem::write<float>(0x5e6204, 0.06f);
+	//mem::write<float>(0x5e6204, 0.06f);  // Interferes with bard instrument mods (resists, selo's)
 	//zeal->hooks->Add("GetTime", 0x54dbad, GetTime, hook_type_replace_call);
 	//-*(float*)0x5e6204 = 0.06f;
 	//0x5e44d4 How high off the ground you stop dropping during levitate

--- a/Zeal/zone_map.h
+++ b/Zeal/zone_map.h
@@ -20,6 +20,7 @@ public:
 	void set_position_default_size(float new_size);
 	void set_marker_default_size(float new_size);
 	void toggle_background();
+	void toggle_zoom();
 
 	void callback_render();
 
@@ -40,6 +41,7 @@ private:
 	void parse_marker(const std::vector<std::string>& args);
 	void parse_background(const std::vector<std::string>& args);
 	void parse_zoom(const std::vector<std::string>& args);
+	void parse_poi(const std::vector<std::string>& args);
 	void set_marker(int y, int x);
 	void clear_marker();
 	bool set_zoom(int zoom_percent);


### PR DESCRIPTION
- Added line clipping to map render to improve zoom
- Added keybind for toggling zoom (off, 2x, 4x, 8x)
- Added point of interest (poi) support using map data /map poi - lists available poi with numeric index and locs /map poi <#> - puts target marker on map at location
- Disabled levitate physics tweak as it was interfering with Bard instrument modifiers (obvious with drums and resists)