### PR TITLE
Add github create_release workflow

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,93 @@
+# Manually triggered release workflow.
+
+name: Create manual release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_notes:
+        description: 'Summary description prepended to changelog'
+        required: true
+        type: string
+
+env:
+  SOLUTION_FILE_PATH: ./Zeal.sln
+
+jobs:
+  build_release:
+    name: Build and upload release
+    runs-on: windows-2022
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Parse the git short hash to embed in the build using a compiler define
+        id: parse_git
+        shell: bash
+        run: |
+          SHORT_HASH=$(git rev-parse --short "$GITHUB_SHA")
+          echo short_hash=$SHORT_HASH >> $GITHUB_OUTPUT
+
+      - name: Extract the ZEAL_VERSION from the source code to use as the tag for the release
+        id: zeal_version
+        shell: bash
+        env:
+          SED_PARAMS: 's/^[^"]*"\([^"]*\)".*/\1/'
+        run: |
+          ZEAL_VERSION=$(grep '#define ZEAL_VERSION' Zeal/Zeal.h | sed $SED_PARAMS)
+          echo version=v$ZEAL_VERSION >> $GITHUB_OUTPUT
+
+      - name: Build the Zeal solution using msbuild to find the path to VS Studio
+        env:
+          ZEAL_BUILD_VERSION: ${{ steps.parse_git.outputs.short_hash }} # Consider also appending a dirty flag.
+        run: |
+          msbuild /m /p:Configuration=Release /p:Platform=x86 /p:zeal_build_version=$env:ZEAL_BUILD_VERSION $env:SOLUTION_FILE_PATH
+
+      - name: Create the zip filename (using bash shell)
+        id: zip_filename
+        shell: bash
+        env:
+          ZEAL_VERSION: ${{ steps.zeal_version.outputs.version }}
+          ZEAL_BUILD_VERSION: ${{ steps.parse_git.outputs.short_hash }}
+        run: |
+          ZIP_FILENAME=zeal\_$ZEAL_VERSION\_$ZEAL_BUILD_VERSION.zip
+          echo $ZIP_FILENAME
+          echo filename=$ZIP_FILENAME >> $GITHUB_OUTPUT
+
+      - name: Zip up the artifacts
+        id: zip
+        shell: pwsh
+        env:
+          ZIP_FILENAME:  ${{ steps.zip_filename.outputs.filename }}
+        run: |
+          7z a -tzip $env:ZIP_FILENAME ./Release/Zeal.asi ./Release/Zeal.pdb ./Zeal/GameXML/EQUI_OptionsWindow.xml
+
+      - name: Create a changelog since the last release tag
+        id: changelog
+        shell: bash
+        run: |
+          CHANGELOG="${{ github.workspace }}-changelog.txt"
+          LAST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
+          echo "# Release notes" > $CHANGELOG
+          echo ${{ github.event.inputs.release_notes }} >> $CHANGELOG
+          echo ""
+          echo "# Changes since $LAST_TAG" >> $CHANGELOG
+          git log --pretty=format:"- %s" $LAST_TAG..HEAD >> $CHANGELOG
+          echo filename=$CHANGELOG >> $GITHUB_OUTPUT
+
+      - name: Create the github release tag and upload artifacts
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "${{ steps.zip_filename.outputs.filename }}"
+          artifactContentType: application/zip
+          artifactErrorsFailBuild: true
+          bodyFile:  "${{ steps.changelog.outputs.filename }}"
+          commit: ${{ github.sha }}
+          generateReleaseNotes: true
+          tag: ${{ steps.zeal_version.outputs.version }}
+

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ ___
   - **Description:** plays songs in order until interrupted in any fashion.
 
 - `/map`
-  - **Arguments:** `on`, `off`, `rect`, `marker`, `background`, `zoom`
+  - **Arguments:** `on`, `off`, `rect`, `marker`, `background`, `zoom`, `poi`
   - **Example:** `/map` toggles map on and off
   - **Example:** `/map marker 500 -100` sets a target marker at loc 500, -100 (default size)
   - **Example:** `/map marker 500 -100 0.03` sets a target marker at loc 500, -100 with size = 3% of screen
@@ -87,6 +87,7 @@ ___
   - **Example:** `/map 0` shortcut for map marker 0 0 0 (clears marker)
   - **Example:** `/map zoom 200` sets map scaling to 200% (2x) and centers on position
   - **Example:** `/map rect 0.02 0.03 0.5 0.6` map window top=2% left=3% bottom=50% right=60% of screen dimensions
+  - **Example:** `/map poi` lists points of interest, use `/map poi 2` to drop marker at index [2] of list
   - **Description:** controls map enable, size, and markers
     
 - `/pandelay`
@@ -189,6 +190,9 @@ ___
 - Slow turn right
 - Target nearest pc corpse
 - Target nearest npc corpse
+- Toggle map on/off
+- Toggle through map default zooms
+- Toggle through map backgrounds
 ___
 ### UI
 - **Gauge EqType's**
@@ -229,10 +233,24 @@ ___
   - Zeal_FirstPersonLabel_Y
   - Zeal_PanDelayLabel
 ___
-### Building and Installation
-<br>
-32bit x86
-<br>
-file extension .asi
-<br>
-move zeal.asi into the root of your game folder
+### Building
+#### Github official release builds
+1. Commit an updated, unique ZEAL_VERSION in Zeal/Zeal.h that will be used as the release tag.
+2. Go to the "Actions" tab of the Github workspace
+3. Select the "Create Manual Release" workflow on the left
+4. Click the drop-down menu on the right top side titled "Run workflow"
+5. Select the branch with the commit to be released
+6. Add a summary description that will be prepended to the change log notes
+7. Click the green "Run workflow" button
+8. After the green checkmark appears, go back to the main workspace and verify the content of the new release tag.
+
+#### Local builds
+Build in 32bit x86 mode using Microsoft Visual Studio 2022 (free Community edition works)
+
+### Installation
+1. Download the "zeal_v*.zip" from a tagged release on github
+2. Extract zeal.asi and place it in the root of your game folder
+3. Extract EQUI_OptionsWindow.xml and place it in your active ui folder (example: uifiles/duxaUI)
+
+The zeal.pdb file is a symbols file only useful for debugging with developer tools (ignore).
+

--- a/Zeal/Zeal.h
+++ b/Zeal/Zeal.h
@@ -1,6 +1,9 @@
 #pragma once
 #include "framework.h"
 #define ZEAL_VERSION "0.3.80"
+#ifndef ZEAL_BUILD_VERSION  // Set by github actions
+#define ZEAL_BUILD_VERSION "UNOFFICIAL"  // Local build
+#endif
 static std::atomic<bool> exitFlag(false);
 class ZealService
 {

--- a/Zeal/Zeal.vcxproj
+++ b/Zeal/Zeal.vcxproj
@@ -102,6 +102,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;ZEAL_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(zeal_build_version)'!=''">ZEAL_BUILD_VERSION="$(zeal_build_version)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>

--- a/Zeal/commands.cpp
+++ b/Zeal/commands.cpp
@@ -336,7 +336,7 @@ ChatCommands::ChatCommands(ZealService* zeal)
 			if (args.size() > 1 && Zeal::String::compare_insensitive(args[1], "version"))
 			{
 				std::stringstream ss;
-				ss << "Zeal version: " << ZEAL_VERSION << std::endl;
+				ss << "Zeal version: " << ZEAL_VERSION << " (" << ZEAL_BUILD_VERSION << ")" << std::endl;
 				Zeal::EqGame::print_chat(ss.str());
 				return true;
 			}

--- a/Zeal/crash_handler.cpp
+++ b/Zeal/crash_handler.cpp
@@ -162,7 +162,7 @@ void WriteMiniDump(EXCEPTION_POINTERS* pep, const std::string& reason) {
             std::ofstream reasonFile(reasonFilePath);
             if (reasonFile.is_open()) {
                 reasonFile << "Unhandled exception occurred: " << reason << std::endl << std::endl;
-                reasonFile << "Zeal Version: " << ZEAL_VERSION << std::endl << std::endl;
+                reasonFile << "Zeal Version: " << ZEAL_VERSION << " (" << ZEAL_BUILD_VERSION << ")" << std::endl << std::endl;
                 if (pep != nullptr && pep->ExceptionRecord != nullptr) {
                     reasonFile << "Exception Code: 0x" << std::hex << pep->ExceptionRecord->ExceptionCode << std::endl;
                     if (exceptionCodeStrings.count(pep->ExceptionRecord->ExceptionCode))

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -130,7 +130,7 @@ void ui_options::UpdateOptions()
 	ui->SetChecked("Zeal_ClassicClasses", ZealService::get_instance()->chat_hook->UseClassicClassNames);
 	ui->SetChecked("Zeal_TellWindows", ZealService::get_instance()->tells->enabled);
 
-	ui->SetLabelValue("Zeal_VersionValue", "%s", ZEAL_VERSION);
+	ui->SetLabelValue("Zeal_VersionValue", "%s (%s)", ZEAL_VERSION, ZEAL_BUILD_VERSION);
 	ui->SetSliderValue("Zeal_TargetRingFill_Slider", static_cast<int>(ZealService::get_instance()->target_ring->get_ring_pct() * 100.0f));
 	ui->SetLabelValue("Zeal_TargetRingFill_Value", "%.2f", ZealService::get_instance()->target_ring->get_ring_pct());
 

--- a/Zeal/zone_map.cpp
+++ b/Zeal/zone_map.cpp
@@ -616,6 +616,7 @@ void ZoneMap::parse_rect(const std::vector<std::string>& args) {
     if ((tlbr.size() != 4) || !set_map_rect(tlbr[0], tlbr[1], tlbr[2], tlbr[3]))
     {
         Zeal::EqGame::print_chat("Usage: /map rect <top> <left> <bottom> <right> (fraction of screen dimensions)");
+        Zeal::EqGame::print_chat("Example: /map rect 0.1 0.2 0.5 0.6");
     }
 }
 
@@ -642,6 +643,7 @@ void ZoneMap::parse_marker(const std::vector<std::string>& args) {
     }
 
     Zeal::EqGame::print_chat("Usage: /map marker <y> <x> [size] (fractional size: optional, 0 disables)");
+    Zeal::EqGame::print_chat("Example: /map marker 500 -1000 (drops a marker at loc 500, -1000)");
 }
 
 bool ZoneMap::parse_shortcuts(const std::vector<std::string>& args) {
@@ -702,7 +704,8 @@ void ZoneMap::parse_poi(const std::vector<std::string>& args) {
         set_enabled(true);
     }
     else {
-        Zeal::EqGame::print_chat("Usage: /map poi <selection>");
+        Zeal::EqGame::print_chat("Usage: /map poi <index> (displays list if <index> is blank)");
+        Zeal::EqGame::print_chat("Example: /map poi 2 (drops a marker at list item [2])");
     }
 }
 
@@ -747,6 +750,7 @@ bool ZoneMap::parse_command(const std::vector<std::string>& args) {
     }
     else if (!parse_shortcuts(args)) {
         Zeal::EqGame::print_chat("Usage: /map [on|off|rect|marker|background|zoom|poi], /map <y> <x>, /map 0");
+        Zeal::EqGame::print_chat("Examples: /map 100 -200 (drops a marker at loc 100, -200), /map 0 (clears marker)");
     }
     return true;
 }


### PR DESCRIPTION
- Added a manually triggerable github workflow to generate a tagged release including the build and zip file generation
- Updated README with the build process steps
- Added a compiler defined ZEAL_BUILD_VERSION that allows the github action to embed the short git hash in the built .asi so it can be displayed as part of the version (also confirms it is an official clean build)
- Improved zone_map help in README and zone_map commands