### PR TITLE
Improve map zoom and add alignment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ ___
   - **Arguments:** `on`, `off`, `rect`, `marker`, `background`, `zoom`, `poi`
   - **Example:** `/map` toggles map on and off
   - **Example:** `/map marker 500 -100` sets a target marker at loc 500, -100 (default size)
-  - **Example:** `/map marker 500 -100 0.03` sets a target marker at loc 500, -100 with size = 3% of screen
+  - **Example:** `/map marker 500 -100 3` sets a target marker at loc 500, -100 with size = 3% of screen
   - **Example:** `/map 500 -100` shortcut for map marker 500 -100
   - **Example:** `/map 0` shortcut for map marker 0 0 0 (clears marker)
   - **Example:** `/map zoom 200` sets map scaling to 200% (2x) and centers on position
-  - **Example:** `/map rect 0.02 0.03 0.5 0.6` map window top=2% left=3% bottom=50% right=60% of screen dimensions
+  - **Example:** `/map rect 2 3 50 60` map window top=2% left=3% bottom=50% right=60% of screen dimensions
   - **Example:** `/map poi` lists points of interest, use `/map poi 2` to drop marker at index [2] of list
   - **Description:** controls map enable, size, and markers
     

--- a/Zeal/GameXML/EQUI_OptionsWindow.xml
+++ b/Zeal/GameXML/EQUI_OptionsWindow.xml
@@ -5506,9 +5506,9 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
-  <!-- Zeal Map Width -->
-  <Label item="Zeal_MapWidth_Label">
-    <ScreenID>Zeal_MapWidth_Label</ScreenID>
+  <!-- Zeal Map Left -->
+  <Label item="Zeal_MapLeft_Label">
+    <ScreenID>Zeal_MapLeft_Label</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>197</X>
@@ -5518,7 +5518,7 @@
       <CX>150</CX>
       <CY>14</CY>
     </Size>
-    <Text>Width</Text>
+    <Text>Left edge limit</Text>
     <TextColor>
       <R>255</R>
       <G>255</G>
@@ -5528,8 +5528,8 @@
     <AlignCenter>false</AlignCenter>
     <AlignRight>false</AlignRight>
   </Label>
-  <Slider item="Zeal_MapWidth_Slider">
-    <ScreenID>Zeal_MapWidth_Slider</ScreenID>
+  <Slider item="Zeal_MapLeft_Slider">
+    <ScreenID>Zeal_MapLeft_Slider</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>197</X>
@@ -5541,8 +5541,8 @@
     </Size>
     <SliderArt>SDT_DefSlider</SliderArt>
   </Slider>
-  <Label item="Zeal_MapWidth_Value">
-    <ScreenID>Zeal_MapWidth_Value</ScreenID>
+  <Label item="Zeal_MapLeft_Value">
+    <ScreenID>Zeal_MapLeft_Value</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>297</X>
@@ -5562,9 +5562,9 @@
     <AlignCenter>false</AlignCenter>
     <AlignRight>true</AlignRight>
   </Label>
-  <!-- Zeal Map Height -->
-  <Label item="Zeal_MapHeight_Label">
-    <ScreenID>Zeal_MapHeight_Label</ScreenID>
+  <!-- Zeal Map Right -->
+  <Label item="Zeal_MapRight_Label">
+    <ScreenID>Zeal_MapRight_Label</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>197</X>
@@ -5574,7 +5574,7 @@
       <CX>150</CX>
       <CY>14</CY>
     </Size>
-    <Text>Height</Text>
+    <Text>Right edge limit</Text>
     <TextColor>
       <R>255</R>
       <G>255</G>
@@ -5584,8 +5584,8 @@
     <AlignCenter>false</AlignCenter>
     <AlignRight>false</AlignRight>
   </Label>
-  <Slider item="Zeal_MapHeight_Slider">
-    <ScreenID>Zeal_MapHeight_Slider</ScreenID>
+  <Slider item="Zeal_MapRight_Slider">
+    <ScreenID>Zeal_MapRight_Slider</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>197</X>
@@ -5597,12 +5597,236 @@
     </Size>
     <SliderArt>SDT_DefSlider</SliderArt>
   </Slider>
-  <Label item="Zeal_MapHeight_Value">
-    <ScreenID>Zeal_MapHeight_Value</ScreenID>
+  <Label item="Zeal_MapRight_Value">
+    <ScreenID>Zeal_MapRight_Value</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>297</X>
       <Y>72</Y>
+    </Location>
+    <Size>
+      <CX>50</CX>
+      <CY>16</CY>
+    </Size>
+    <Text>0</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>true</AlignRight>
+  </Label>
+  <!-- Zeal Map Top -->
+  <Label item="Zeal_MapTop_Label">
+    <ScreenID>Zeal_MapTop_Label</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>197</X>
+      <Y>94</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>14</CY>
+    </Size>
+    <Text>Top edge limit</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
+  <Slider item="Zeal_MapTop_Slider">
+    <ScreenID>Zeal_MapTop_Slider</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>197</X>
+      <Y>114</Y>
+    </Location>
+    <Size>
+      <CX>100</CX>
+      <CY>16</CY>
+    </Size>
+    <SliderArt>SDT_DefSlider</SliderArt>
+  </Slider>
+  <Label item="Zeal_MapTop_Value">
+    <ScreenID>Zeal_MapTop_Value</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>297</X>
+      <Y>114</Y>
+    </Location>
+    <Size>
+      <CX>50</CX>
+      <CY>16</CY>
+    </Size>
+    <Text>0</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>true</AlignRight>
+  </Label>
+  <!-- Zeal Map Bottom -->
+  <Label item="Zeal_MapBottom_Label">
+    <ScreenID>Zeal_MapBottom_Label</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>197</X>
+      <Y>136</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>14</CY>
+    </Size>
+    <Text>Bottom edge limit</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
+  <Slider item="Zeal_MapBottom_Slider">
+    <ScreenID>Zeal_MapBottom_Slider</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>197</X>
+      <Y>156</Y>
+    </Location>
+    <Size>
+      <CX>100</CX>
+      <CY>16</CY>
+    </Size>
+    <SliderArt>SDT_DefSlider</SliderArt>
+  </Slider>
+  <Label item="Zeal_MapBottom_Value">
+    <ScreenID>Zeal_MapBottom_Value</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>297</X>
+      <Y>156</Y>
+    </Location>
+    <Size>
+      <CX>50</CX>
+      <CY>16</CY>
+    </Size>
+    <Text>0</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>true</AlignRight>
+  </Label>
+  <!-- Zeal Map Position Size -->
+  <Label item="Zeal_MapPositionSize_Label">
+    <ScreenID>Zeal_MapPositionSize_Label</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>197</X>
+      <Y>178</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>14</CY>
+    </Size>
+    <Text>Position size</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
+  <Slider item="Zeal_MapPositionSize_Slider">
+    <ScreenID>Zeal_MapPositionSize_Slider</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>197</X>
+      <Y>198</Y>
+    </Location>
+    <Size>
+      <CX>100</CX>
+      <CY>16</CY>
+    </Size>
+    <SliderArt>SDT_DefSlider</SliderArt>
+  </Slider>
+  <Label item="Zeal_MapPositionSize_Value">
+    <ScreenID>Zeal_MapPositionSize_Value</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>297</X>
+      <Y>198</Y>
+    </Location>
+    <Size>
+      <CX>50</CX>
+      <CY>16</CY>
+    </Size>
+    <Text>0</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>true</AlignRight>
+  </Label>
+  <!-- Zeal Map Marker Size -->
+  <Label item="Zeal_MapMarkerSize_Label">
+    <ScreenID>Zeal_MapMarkerSize_Label</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>197</X>
+      <Y>220</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>14</CY>
+    </Size>
+    <Text>Marker size</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
+  <Slider item="Zeal_MapMarkerSize_Slider">
+    <ScreenID>Zeal_MapMarkerSize_Slider</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>197</X>
+      <Y>240</Y>
+    </Location>
+    <Size>
+      <CX>100</CX>
+      <CY>16</CY>
+    </Size>
+    <SliderArt>SDT_DefSlider</SliderArt>
+  </Slider>
+  <Label item="Zeal_MapMarkerSize_Value">
+    <ScreenID>Zeal_MapMarkerSize_Value</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>297</X>
+      <Y>240</Y>
     </Location>
     <Size>
       <CX>50</CX>
@@ -5624,7 +5848,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>197</X>
-      <Y>94</Y>
+      <Y>262</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -5645,7 +5869,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>197</X>
-      <Y>114</Y>
+      <Y>282</Y>
     </Location>
     <Size>
       <CX>100</CX>
@@ -5658,7 +5882,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>297</X>
-      <Y>114</Y>
+      <Y>282</Y>
     </Location>
     <Size>
       <CX>50</CX>
@@ -5674,6 +5898,51 @@
     <AlignCenter>false</AlignCenter>
     <AlignRight>true</AlignRight>
   </Label>
+  <!-- Zeal Map Alignment Combobox -->
+  <Label item="Zeal_MapAlignment_Label">
+    <ScreenID>Zeal_MapAlignment_Label</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>100</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>14</CY>
+    </Size>
+    <Text>Alignment</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
+  <Combobox item="Zeal_MapAlignment_Combobox">
+    <ScreenID>Zeal_MapAlignment_Combobox</ScreenID>
+    <DrawTemplate>WDT_Inner</DrawTemplate>
+    <Location>
+      <X>10</X>
+      <Y>120</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>24</CY>
+    </Size>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ListHeight>70</ListHeight>
+    <Button>BDT_Combo</Button>
+    <Style_Border>true</Style_Border>
+    <Choices>Top Left</Choices>
+    <Choices>Top Center</Choices>
+    <Choices>Top Right</Choices>
+  </Combobox>
   <!-- Zeal Map Background Combobox -->
   <Label item="Zeal_MapBackground_Label">
     <ScreenID>Zeal_MapBackground_Label</ScreenID>
@@ -5716,9 +5985,9 @@
     <Button>BDT_Combo</Button>
     <Style_Border>true</Style_Border>
     <Choices>None</Choices>
-    <Choices>1</Choices>
-    <Choices>2</Choices>
-    <Choices>3</Choices>
+    <Choices>Dark</Choices>
+    <Choices>Light</Choices>
+    <Choices>Tan</Choices>
   </Combobox>
   <!-- *** Zeal Map Tab *** -->
   <Page item="OptionsZealMapPage">
@@ -5742,15 +6011,29 @@
     </TabTextActiveColor>
     <Style_Sizable>true</Style_Sizable>
     <Pieces>Zeal_Map</Pieces>
-    <Pieces>Zeal_MapWidth_Label</Pieces>
-    <Pieces>Zeal_MapWidth_Slider</Pieces>
-    <Pieces>Zeal_MapWidth_Value</Pieces>
-    <Pieces>Zeal_MapHeight_Label</Pieces>
-    <Pieces>Zeal_MapHeight_Slider</Pieces>
-    <Pieces>Zeal_MapHeight_Value</Pieces>
+    <Pieces>Zeal_MapLeft_Label</Pieces>
+    <Pieces>Zeal_MapLeft_Slider</Pieces>
+    <Pieces>Zeal_MapLeft_Value</Pieces>
+    <Pieces>Zeal_MapRight_Label</Pieces>
+    <Pieces>Zeal_MapRight_Slider</Pieces>
+    <Pieces>Zeal_MapRight_Value</Pieces>
+    <Pieces>Zeal_MapTop_Label</Pieces>
+    <Pieces>Zeal_MapTop_Slider</Pieces>
+    <Pieces>Zeal_MapTop_Value</Pieces>
+    <Pieces>Zeal_MapBottom_Label</Pieces>
+    <Pieces>Zeal_MapBottom_Slider</Pieces>
+    <Pieces>Zeal_MapBottom_Value</Pieces>
+    <Pieces>Zeal_MapPositionSize_Label</Pieces>
+    <Pieces>Zeal_MapPositionSize_Slider</Pieces>
+    <Pieces>Zeal_MapPositionSize_Value</Pieces>
+    <Pieces>Zeal_MapMarkerSize_Label</Pieces>
+    <Pieces>Zeal_MapMarkerSize_Slider</Pieces>
+    <Pieces>Zeal_MapMarkerSize_Value</Pieces>
     <Pieces>Zeal_MapZoom_Label</Pieces>
     <Pieces>Zeal_MapZoom_Slider</Pieces>
     <Pieces>Zeal_MapZoom_Value</Pieces>
+    <Pieces>Zeal_MapAlignment_Label</Pieces>
+    <Pieces>Zeal_MapAlignment_Combobox</Pieces>
     <Pieces>Zeal_MapBackground_Label</Pieces>
     <Pieces>Zeal_MapBackground_Combobox</Pieces>
     <Location>

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -11,8 +11,8 @@ float GetSensitivityFromSlider(int value)
 }
 int GetSensitivityForSlider(float* value)
 {
-	if (*value > 0)
-		return *value * 100.f;
+	if (value && *value > 0)
+		return static_cast<int>(*value * 100.f);
 	else
 		return 0;
 }
@@ -36,9 +36,10 @@ void ui_options::InitUI()
 	ui->AddCheckboxCallback(Zeal::EqGame::Windows->Options, "Zeal_TargetRing", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->target_ring->set_enabled(wnd->Checked); });
 	ui->AddCheckboxCallback(Zeal::EqGame::Windows->Options, "Zeal_ClassicClasses", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->chat_hook->set_classes(wnd->Checked); });
 	ui->AddCheckboxCallback(Zeal::EqGame::Windows->Options, "Zeal_TellWindows", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->tells->SetEnabled(wnd->Checked); });
-	ui->AddCheckboxCallback(Zeal::EqGame::Windows->Options, "Zeal_Map", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->zone_map->set_enabled(wnd->Checked); });
+	ui->AddCheckboxCallback(Zeal::EqGame::Windows->Options, "Zeal_Map", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->zone_map->set_enabled(wnd->Checked, true); });
 	ui->AddComboCallback(Zeal::EqGame::Windows->Options, "Zeal_Timestamps_Combobox", [this](Zeal::EqUI::BasicWnd* wnd, int value) { ZealService::get_instance()->chat_hook->set_timestamp(value); });
-	ui->AddComboCallback(Zeal::EqGame::Windows->Options, "Zeal_MapBackground_Combobox", [this](Zeal::EqUI::BasicWnd* wnd, int value) { ZealService::get_instance()->zone_map->set_background(value, false); });
+	ui->AddComboCallback(Zeal::EqGame::Windows->Options, "Zeal_MapBackground_Combobox", [this](Zeal::EqUI::BasicWnd* wnd, int value) { ZealService::get_instance()->zone_map->set_background(value); });
+	ui->AddComboCallback(Zeal::EqGame::Windows->Options, "Zeal_MapAlignment_Combobox", [this](Zeal::EqUI::BasicWnd* wnd, int value) { ZealService::get_instance()->zone_map->set_alignment(value); });
 	ui->AddSliderCallback(Zeal::EqGame::Windows->Options, "Zeal_PanDelaySlider", [this](Zeal::EqUI::SliderWnd* wnd, int value) {
 		ZealService::get_instance()->camera_mods->set_pan_delay(value*4); 
 		ui->SetLabelValue("Zeal_PanDelayValueLabel", "%d ms", ZealService::get_instance()->camera_mods->pan_delay);
@@ -79,21 +80,26 @@ void ui_options::InitUI()
 		ui->SetLabelValue("Zeal_TargetRingFill_Value", "%.2f", val);
 	});
 	ui->AddSliderCallback(Zeal::EqGame::Windows->Options, "Zeal_MapZoom_Slider", [this](Zeal::EqUI::SliderWnd* wnd, int value) {
-		int val = value + 100;
-		ZealService::get_instance()->zone_map->set_zoom(val);
-		ui->SetLabelValue("Zeal_MapZoom_Value", "%i", val);
+		ZealService::get_instance()->zone_map->set_zoom(value + 100);  // Note zoom offset.
 	});
-	ui->AddSliderCallback(Zeal::EqGame::Windows->Options, "Zeal_MapWidth_Slider", [this](Zeal::EqUI::SliderWnd* wnd, int value) {
-		float new_val = (float)value / 100;
-		ZealService::get_instance()->zone_map->set_map_width(new_val);
-		ui->SetLabelValue("Zeal_MapWidth_Value", "%i", value);
+	ui->AddSliderCallback(Zeal::EqGame::Windows->Options, "Zeal_MapLeft_Slider", [this](Zeal::EqUI::SliderWnd* wnd, int value) {
+		ZealService::get_instance()->zone_map->set_map_left(value);
 	});
-	ui->AddSliderCallback(Zeal::EqGame::Windows->Options, "Zeal_MapHeight_Slider", [this](Zeal::EqUI::SliderWnd* wnd, int value) {
-		float new_val = (float)value / 100;
-		ZealService::get_instance()->zone_map->set_map_height(new_val);
-		ui->SetLabelValue("Zeal_MapHeight_Value", "%i", value);
+	ui->AddSliderCallback(Zeal::EqGame::Windows->Options, "Zeal_MapRight_Slider", [this](Zeal::EqUI::SliderWnd* wnd, int value) {
+		ZealService::get_instance()->zone_map->set_map_right(value);
 	});
-	ui->SetSliderValue("", ZealService::get_instance()->zone_map->get_zoom());
+	ui->AddSliderCallback(Zeal::EqGame::Windows->Options, "Zeal_MapTop_Slider", [this](Zeal::EqUI::SliderWnd* wnd, int value) {
+		ZealService::get_instance()->zone_map->set_map_top(value);
+	});
+	ui->AddSliderCallback(Zeal::EqGame::Windows->Options, "Zeal_MapBottom_Slider", [this](Zeal::EqUI::SliderWnd* wnd, int value) {
+		ZealService::get_instance()->zone_map->set_map_bottom(value);
+	});
+	ui->AddSliderCallback(Zeal::EqGame::Windows->Options, "Zeal_MapPositionSize_Slider", [this](Zeal::EqUI::SliderWnd* wnd, int value) {
+		ZealService::get_instance()->zone_map->set_position_size(value);
+	});
+	ui->AddSliderCallback(Zeal::EqGame::Windows->Options, "Zeal_MapMarkerSize_Slider", [this](Zeal::EqUI::SliderWnd* wnd, int value) {
+		ZealService::get_instance()->zone_map->set_marker_size(value);
+	});
 
 	ui->AddLabel(Zeal::EqGame::Windows->Options, "Zeal_PanDelayValueLabel");
 	ui->AddLabel(Zeal::EqGame::Windows->Options, "Zeal_FirstPersonLabel_X");
@@ -105,9 +111,13 @@ void ui_options::InitUI()
 	ui->AddLabel(Zeal::EqGame::Windows->Options, "Zeal_VersionValue");
 	ui->AddLabel(Zeal::EqGame::Windows->Options, "Zeal_TargetRingFill_Value");
 	ui->AddLabel(Zeal::EqGame::Windows->Options, "Zeal_MapZoom_Value");
-	ui->AddLabel(Zeal::EqGame::Windows->Options, "Zeal_MapWidth_Value");
-	ui->AddLabel(Zeal::EqGame::Windows->Options, "Zeal_MapHeight_Value");
-	
+	ui->AddLabel(Zeal::EqGame::Windows->Options, "Zeal_MapLeft_Value");
+	ui->AddLabel(Zeal::EqGame::Windows->Options, "Zeal_MapRight_Value");
+	ui->AddLabel(Zeal::EqGame::Windows->Options, "Zeal_MapTop_Value");
+	ui->AddLabel(Zeal::EqGame::Windows->Options, "Zeal_MapBottom_Value");
+	ui->AddLabel(Zeal::EqGame::Windows->Options, "Zeal_MapPositionSize_Value");
+	ui->AddLabel(Zeal::EqGame::Windows->Options, "Zeal_MapMarkerSize_Value");
+
 	/*set the current states*/
 	UpdateOptions();
 }
@@ -123,7 +133,6 @@ void ui_options::UpdateOptions()
 {
 	ui->SetComboValue("Zeal_Timestamps_Combobox", ZealService::get_instance()->chat_hook->TimeStampsStyle);
 	ui->SetComboValue("Zeal_HideCorpseCombobox", 2);
-	ui->SetComboValue("Zeal_MapBackground_Combobox", ZealService::get_instance()->zone_map->get_background());
 	ui->SetSliderValue("Zeal_PanDelaySlider", ZealService::get_instance()->camera_mods->pan_delay > 0.f ? ZealService::get_instance()->camera_mods->pan_delay / 4 : 0.f);
 	ui->SetSliderValue("Zeal_HoverTimeout_Slider", ZealService::get_instance()->tooltips->hover_timeout > 0 ? ZealService::get_instance()->tooltips->hover_timeout / 5 : 0);
 	ui->SetSliderValue("Zeal_ThirdPersonSlider_Y", GetSensitivityForSlider(&ZealService::get_instance()->camera_mods->user_sensitivity_y_3rd));
@@ -131,9 +140,6 @@ void ui_options::UpdateOptions()
 	ui->SetSliderValue("Zeal_FirstPersonSlider_Y", GetSensitivityForSlider(&ZealService::get_instance()->camera_mods->user_sensitivity_y));
 	ui->SetSliderValue("Zeal_FirstPersonSlider_X", GetSensitivityForSlider(&ZealService::get_instance()->camera_mods->user_sensitivity_x));
 	ui->SetSliderValue("Zeal_FoVSlider", static_cast<int>((ZealService::get_instance()->camera_mods->fov - 45.0f) / 45.0f * 100.0f));
-	ui->SetSliderValue("Zeal_MapZoom_Slider", ZealService::get_instance()->zone_map->get_zoom()-100);
-	ui->SetSliderValue("Zeal_MapWidth_Slider", ZealService::get_instance()->zone_map->get_map_width());
-	ui->SetSliderValue("Zeal_MapHeight_Slider", ZealService::get_instance()->zone_map->get_map_height());
 	ui->SetLabelValue("Zeal_FoVValueLabel", "%.0f", ZealService::get_instance()->camera_mods->fov);
 	ui->SetLabelValue("Zeal_FirstPersonLabel_X", "%.2f", ZealService::get_instance()->camera_mods->user_sensitivity_x);
 	ui->SetLabelValue("Zeal_FirstPersonLabel_Y", "%.2f", ZealService::get_instance()->camera_mods->user_sensitivity_y);
@@ -141,9 +147,6 @@ void ui_options::UpdateOptions()
 	ui->SetLabelValue("Zeal_ThirdPersonLabel_Y", "%.2f", ZealService::get_instance()->camera_mods->user_sensitivity_y_3rd);
 	ui->SetLabelValue("Zeal_PanDelayValueLabel", "%d ms", ZealService::get_instance()->camera_mods->pan_delay);
 	ui->SetLabelValue("Zeal_HoverTimeout_Value", "%d ms", ZealService::get_instance()->tooltips->hover_timeout);
-	ui->SetLabelValue("Zeal_MapZoom_Value", "%i%%", ZealService::get_instance()->zone_map->get_zoom());
-	ui->SetLabelValue("Zeal_MapWidth_Value", "%i%%", ZealService::get_instance()->zone_map->get_map_width());
-	ui->SetLabelValue("Zeal_MapHeight_Value", "%i%%", ZealService::get_instance()->zone_map->get_map_height());
 	ui->SetChecked("Zeal_HideCorpse", ZealService::get_instance()->looting_hook->hide_looted);
 	ui->SetChecked("Zeal_Cam", ZealService::get_instance()->camera_mods->enabled);
 	ui->SetChecked("Zeal_BlueCon", ZealService::get_instance()->chat_hook->UseBlueCon);
@@ -157,15 +160,36 @@ void ui_options::UpdateOptions()
 	ui->SetChecked("Zeal_TargetRing", ZealService::get_instance()->target_ring->enabled);
 	ui->SetChecked("Zeal_ClassicClasses", ZealService::get_instance()->chat_hook->UseClassicClassNames);
 	ui->SetChecked("Zeal_TellWindows", ZealService::get_instance()->tells->enabled);
-	ui->SetChecked("Zeal_Map", ZealService::get_instance()->zone_map->is_enabled());
 
 
 	ui->SetLabelValue("Zeal_VersionValue", "%s (%s)", ZEAL_VERSION, ZEAL_BUILD_VERSION);
 	ui->SetSliderValue("Zeal_TargetRingFill_Slider", static_cast<int>(ZealService::get_instance()->target_ring->get_ring_pct() * 100.0f));
 	ui->SetLabelValue("Zeal_TargetRingFill_Value", "%.2f", ZealService::get_instance()->target_ring->get_ring_pct());
 
+	UpdateOptionsMapOnly();
+
 }
 
+void ui_options::UpdateOptionsMapOnly()
+{
+	ui->SetChecked("Zeal_Map", ZealService::get_instance()->zone_map->is_enabled());
+	ui->SetComboValue("Zeal_MapBackground_Combobox", ZealService::get_instance()->zone_map->get_background());
+	ui->SetComboValue("Zeal_MapAlignment_Combobox", ZealService::get_instance()->zone_map->get_alignment());
+	ui->SetSliderValue("Zeal_MapZoom_Slider", ZealService::get_instance()->zone_map->get_zoom() - 100);
+	ui->SetSliderValue("Zeal_MapLeft_Slider", ZealService::get_instance()->zone_map->get_map_left());
+	ui->SetSliderValue("Zeal_MapRight_Slider", ZealService::get_instance()->zone_map->get_map_right());
+	ui->SetSliderValue("Zeal_MapTop_Slider", ZealService::get_instance()->zone_map->get_map_top());
+	ui->SetSliderValue("Zeal_MapBottom_Slider", ZealService::get_instance()->zone_map->get_map_bottom());
+	ui->SetSliderValue("Zeal_MapPositionSize_Slider", ZealService::get_instance()->zone_map->get_position_size());
+	ui->SetSliderValue("Zeal_MapMarkerSize_Slider", ZealService::get_instance()->zone_map->get_marker_size());
+	ui->SetLabelValue("Zeal_MapZoom_Value", "%i%%", ZealService::get_instance()->zone_map->get_zoom());
+	ui->SetLabelValue("Zeal_MapLeft_Value", "%i%%", ZealService::get_instance()->zone_map->get_map_left());
+	ui->SetLabelValue("Zeal_MapRight_Value", "%i%%", ZealService::get_instance()->zone_map->get_map_right());
+	ui->SetLabelValue("Zeal_MapTop_Value", "%i%%", ZealService::get_instance()->zone_map->get_map_top());
+	ui->SetLabelValue("Zeal_MapBottom_Value", "%i%%", ZealService::get_instance()->zone_map->get_map_bottom());
+	ui->SetLabelValue("Zeal_MapPositionSize_Value", "%i%%", ZealService::get_instance()->zone_map->get_position_size());
+	ui->SetLabelValue("Zeal_MapMarkerSize_Value", "%i%%", ZealService::get_instance()->zone_map->get_marker_size());
+}
 
 
 ui_options::ui_options(ZealService* zeal, IO_ini* ini, ui_manager* mgr)

--- a/Zeal/ui_options.h
+++ b/Zeal/ui_options.h
@@ -7,6 +7,7 @@ class ui_options
 {
 public:
 	void UpdateOptions();
+	void UpdateOptionsMapOnly();
 	ui_options(class ZealService* zeal, class IO_ini* ini, class ui_manager* mgr);
 	~ui_options();
 private:

--- a/Zeal/zone_map.h
+++ b/Zeal/zone_map.h
@@ -8,24 +8,37 @@
 class ZoneMap
 {
 public:
+	static constexpr float kMaxPositionSize = 0.05f;  // In fraction of screen size.
+	static constexpr float kMaxMarkerSize = 0.05f;
+
 	ZoneMap(class ZealService* zeal, class IO_ini* ini);
 	~ZoneMap();
 
 	// UI control interface.
-	// Rect and position are in fractions of screen dimensions (0.f to 1.f).
+	// Rect and sizes are in percentages of screen dimensions (0 to 100).
+	// Setting update_default stores to the ini and triggers a ui update.
 	bool is_enabled() const { return enabled; }
 	void set_enabled(bool enable, bool update_default = false);
-	bool set_background(int new_state, bool update_default = false);
-	bool set_map_rect(float top, float left, float bottom, float right, bool update_default = true);
-	void set_map_width(float width);
-	void set_map_height(float height);
-	int get_map_width();
-	int get_map_height();
-	void set_position_default_size(float new_size);
-	void set_marker_default_size(float new_size);
-	bool set_zoom(int zoom_percent);
-	int get_zoom();
-	int get_background();
+	bool set_background(int new_state, bool update_default = true); // [clear, dark, light, tan]
+	bool set_alignment(int new_state, bool update_default = true); // [left, center, right]
+	bool set_map_top(int top_percent, bool update_default = true);
+	bool set_map_left(int left_percent, bool update_default = true);
+	bool set_map_bottom(int bottom_percent, bool update_default = true);
+	bool set_map_right(int right_percent, bool update_default = true);
+	bool set_position_size(int new_size_percent, bool update_default = true);
+	bool set_marker_size(int new_size_percent, bool update_default = true);
+	bool set_zoom(int zoom_percent);  // Note: 100% = 1x.
+
+	int get_background() const { return map_background_state; }
+	int get_alignment() const { return map_alignment_state; }
+	int get_map_top() const { return static_cast<int>(map_rect_top * 100 + 0.5f); }
+	int get_map_left() const { return static_cast<int>(map_rect_left * 100 + 0.5f); }
+	int get_map_bottom() const { return static_cast<int>(map_rect_bottom * 100 + 0.5f); }
+	int get_map_right() const { return static_cast<int>(map_rect_right * 100 + 0.5f); }
+	int get_position_size() const { return static_cast<int>(position_size / kMaxPositionSize * 100 + 0.5f); }
+	int get_marker_size() const { return static_cast<int>(marker_size / kMaxMarkerSize * 100 + 0.5f); }
+	int get_zoom() const { return static_cast<int>(zoom_factor * 100 + 0.5f); }
+
 	void toggle_background();
 	void toggle_zoom();
 	void callback_render();
@@ -33,6 +46,7 @@ public:
 private:
 	static constexpr int kInvalidZoneId = 0;
 	static constexpr int kBackgroundStates = 4;  // 0 = clear.
+	static constexpr int kAlignmentStates = 3; // 0 = Left, 1 = Center, 2 = Right.
 	static constexpr float kDefaultRectTop = 0.1f;
 	static constexpr float kDefaultRectLeft = 0.1f;
 	static constexpr float kDefaultRectBottom = 0.4f;
@@ -41,6 +55,7 @@ private:
 	static constexpr float kDefaultMarkerSize = 0.02f;
 
 	// UI and parser methods.
+	// Rect and sizes are in fractions of screen dimensions(0.f to 1.f).
 	bool parse_command(const std::vector<std::string>& args);
 	bool parse_shortcuts(const std::vector<std::string>& args);
 	void parse_rect(const std::vector<std::string>& args);
@@ -50,7 +65,9 @@ private:
 	void parse_poi(const std::vector<std::string>& args);
 	void set_marker(int y, int x);
 	void clear_marker();
-	
+	bool set_map_rect(float top, float left, float bottom, float right, bool update_default = false);
+	void update_ui_options();
+
 	void load_ini(class IO_ini* ini);
 	void dump();
 
@@ -63,11 +80,13 @@ private:
 
 	bool enabled = false;
 	int map_background_state = 0;
+	int map_alignment_state = 0;
 	int zone_id = kInvalidZoneId;
 	int marker_zone_id = kInvalidZoneId;
+	int zoom_recenter_zone_id = kInvalidZoneId;
 	int marker_x = 0;
 	int marker_y = 0;
-
+	
 	float scale_factor = 0;  // Conversion factors for map data to screen coordinates.
 	float zoom_factor = 1.f;
 	float offset_x = 0;
@@ -76,6 +95,10 @@ private:
 	float map_rect_left = kDefaultRectLeft;
 	float map_rect_bottom = kDefaultRectBottom;
 	float map_rect_right = kDefaultRectRight;
+	float clip_rect_top = 0;
+	float clip_rect_left = 0;
+	float clip_rect_bottom = 0;
+	float clip_rect_right = 0;
 	float position_size = kDefaultPositionSize;
 	float marker_size = kDefaultMarkerSize;
 


### PR DESCRIPTION
- Based on feedback changed the behavior of map zoom to retain the current position x,y location when zooming in/out (except for a final 'snap' when zooming out fully to 100%)
- Added map alignment options (top left, top center, top right)
- Updated UI options with alignment, marker size, position size, and the full map rectangle top, bottom, left, and right
- Changed the command interface for rect and marker sizes to use percent to match the UI options