### PR TITLE
(On Hold) [melody] non-casting state between songs

### DIFF
--- a/Zeal/melody.h
+++ b/Zeal/melody.h
@@ -7,7 +7,7 @@ class Melody
 public:
 	bool start(const std::vector<int>& new_songs); //returns true if no errors
 	void end();
-	void handle_stop_cast_callback(BYTE reason);
+	void handle_stop_cast_callback(BYTE reason, short spell_id);
 	Melody(class ZealService* pHookWrapper, class IO_ini* ini);
 	~Melody();
 private:


### PR DESCRIPTION
# What
- This makes the player in a non-casting/singing state during the small gaps between songs in a Melody, by making the stop_current_cast happen sooner.
- Previously, the Melody would do a frame-perfect stop_cast/cast combination right as the next song was ready to cast.
- This does not alter the timing or speed of Melody in any way, because the Cast event still happens on the regular timing.

Supporting changes
- Adjusting the StopCast and StopCast callback logic slightly to tolerate non-song events and handle/ignore them properly, if they were to occur.

# Visualization / Example
This visualizes the effect of the change on the player state:
```
(Song 1)                   (Song 2)
!cccccccccccccccccccccc!sss!ccccccccccc...  // before
!cccccccccccccccccccccc!   !ccccccccccc...  // after
```
Legend
- 'c' is time spent casting
- 's' is time spent singing
- '!' denote a spell cast beginning or end

# Why
Previously, stopcast was not invoked until the startcast of the next song. This caused the melody to be completely airtight in terms of the player always being in a casting state. This differs from standard twisting mechanics where there is a small window of non-casting between songs (the gap between `/stopsong` and `/cast #`). This window between songs was often utlized by bards to use clicklies like Breath of Harmony by timing their clicky right in this window, without interrupting their twist rotation.

This is not an attempt to add any smart-clicky support, features, automation, or scope creep for Melody. This is just to allow the client to be in a non-casting state in the small gap between songs, which more accurately mirrors how song twisting worked, allowing players the same access to techniques that they used to be able to use while twisting back in the day. I see this more as a feature-parity style change, but would make people fairly happy with being able to use their clickies during a Melody (but still requires fairly precise user control to pull off).

# Test
I did initial testing on this and it seems to not break melody behavior after I added the supporting changes. Without the supporting changes, Melody would sometimes repeat a song because some clickies emit a "reason 3" stopcast event for their spell ID, which we should simply ignore by checking that it wasn't the melody song that we got the event for.
  
Tested/working with:
- Breath of Harmony (doesn't cause a "reason 3" stopcast event)
- Jboots (causes a "reason 3" stopcast event)
- Casted spells like Pegasus Cloak / Illusions (usually has a "reason 3" stopcast event)