### PR TITLE
Map updates: width & height, enable fix, poi search, background alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ ___
   - **Description:** plays songs in order until interrupted in any fashion.
 
 - `/map`
-  - **Arguments:** `on`, `off`, `rect`, `marker`, `background`, `zoom`, `poi`
+  - **Arguments:** `on`, `off`, `size`, `alignment`, `marker`, `background`, `zoom`, `poi`
   - **Example:** `/map` toggles map on and off
   - **Example:** `/map marker 500 -100` sets a target marker at loc 500, -100 (default size)
   - **Example:** `/map marker 500 -100 3` sets a target marker at loc 500, -100 with size = 3% of screen

--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ ___
   - **Example:** `/map 500 -100` shortcut for map marker 500 -100
   - **Example:** `/map 0` shortcut for map marker 0 0 0 (clears marker)
   - **Example:** `/map zoom 200` sets map scaling to 200% (2x) and centers on position
-  - **Example:** `/map rect 2 3 50 60` map window top=2% left=3% bottom=50% right=60% of screen dimensions
+  - **Example:** `/map size 2 3 50 60` map window top=2% left=3% height=50% width=60% of screen dimensions
   - **Example:** `/map poi` lists points of interest, use `/map poi 2` to drop marker at index [2] of list
+  - **Example:** `/map search_term` searches poi list for 'search_term' and drops a marker at first match
   - **Description:** controls map enable, size, and markers
     
 - `/pandelay`

--- a/Zeal/GameXML/EQUI_OptionsWindow.xml
+++ b/Zeal/GameXML/EQUI_OptionsWindow.xml
@@ -5898,13 +5898,69 @@
     <AlignCenter>false</AlignCenter>
     <AlignRight>true</AlignRight>
   </Label>
+  <!-- Zeal Map Background Alpha -->
+  <Label item="Zeal_MapBackgroundAlpha_Label">
+    <ScreenID>Zeal_MapBackgroundAlpha_Label</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>100</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>14</CY>
+    </Size>
+    <Text>Background alpha</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
+  <Slider item="Zeal_MapBackgroundAlpha_Slider">
+    <ScreenID>Zeal_MapBackgroundAlpha_Slider</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>120</Y>
+    </Location>
+    <Size>
+      <CX>100</CX>
+      <CY>16</CY>
+    </Size>
+    <SliderArt>SDT_DefSlider</SliderArt>
+  </Slider>
+  <Label item="Zeal_MapBackgroundAlpha_Value">
+    <ScreenID>Zeal_MapBackgroundAlpha_Value</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>110</X>
+      <Y>120</Y>
+    </Location>
+    <Size>
+      <CX>40</CX>
+      <CY>16</CY>
+    </Size>
+    <Text>0</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>true</AlignRight>
+  </Label>
   <!-- Zeal Map Alignment Combobox -->
   <Label item="Zeal_MapAlignment_Label">
     <ScreenID>Zeal_MapAlignment_Label</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>100</Y>
+      <Y>142</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -5925,7 +5981,7 @@
     <DrawTemplate>WDT_Inner</DrawTemplate>
     <Location>
       <X>10</X>
-      <Y>120</Y>
+      <Y>162</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -6032,6 +6088,9 @@
     <Pieces>Zeal_MapZoom_Label</Pieces>
     <Pieces>Zeal_MapZoom_Slider</Pieces>
     <Pieces>Zeal_MapZoom_Value</Pieces>
+    <Pieces>Zeal_MapBackgroundAlpha_Label</Pieces>
+    <Pieces>Zeal_MapBackgroundAlpha_Slider</Pieces>
+    <Pieces>Zeal_MapBackgroundAlpha_Value</Pieces>
     <Pieces>Zeal_MapAlignment_Label</Pieces>
     <Pieces>Zeal_MapAlignment_Combobox</Pieces>
     <Pieces>Zeal_MapBackground_Label</Pieces>

--- a/Zeal/GameXML/EQUI_OptionsWindow.xml
+++ b/Zeal/GameXML/EQUI_OptionsWindow.xml
@@ -5562,9 +5562,9 @@
     <AlignCenter>false</AlignCenter>
     <AlignRight>true</AlignRight>
   </Label>
-  <!-- Zeal Map Right -->
-  <Label item="Zeal_MapRight_Label">
-    <ScreenID>Zeal_MapRight_Label</ScreenID>
+  <!-- Zeal Map Width -->
+  <Label item="Zeal_MapWidth_Label">
+    <ScreenID>Zeal_MapWidth_Label</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>197</X>
@@ -5574,7 +5574,7 @@
       <CX>150</CX>
       <CY>14</CY>
     </Size>
-    <Text>Right edge limit</Text>
+    <Text>Width limit</Text>
     <TextColor>
       <R>255</R>
       <G>255</G>
@@ -5584,8 +5584,8 @@
     <AlignCenter>false</AlignCenter>
     <AlignRight>false</AlignRight>
   </Label>
-  <Slider item="Zeal_MapRight_Slider">
-    <ScreenID>Zeal_MapRight_Slider</ScreenID>
+  <Slider item="Zeal_MapWidth_Slider">
+    <ScreenID>Zeal_MapWidth_Slider</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>197</X>
@@ -5597,8 +5597,8 @@
     </Size>
     <SliderArt>SDT_DefSlider</SliderArt>
   </Slider>
-  <Label item="Zeal_MapRight_Value">
-    <ScreenID>Zeal_MapRight_Value</ScreenID>
+  <Label item="Zeal_MapWidth_Value">
+    <ScreenID>Zeal_MapWidth_Value</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>297</X>
@@ -5674,9 +5674,9 @@
     <AlignCenter>false</AlignCenter>
     <AlignRight>true</AlignRight>
   </Label>
-  <!-- Zeal Map Bottom -->
-  <Label item="Zeal_MapBottom_Label">
-    <ScreenID>Zeal_MapBottom_Label</ScreenID>
+  <!-- Zeal Map Height -->
+  <Label item="Zeal_MapHeight_Label">
+    <ScreenID>Zeal_MapHeight_Label</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>197</X>
@@ -5686,7 +5686,7 @@
       <CX>150</CX>
       <CY>14</CY>
     </Size>
-    <Text>Bottom edge limit</Text>
+    <Text>Height limit</Text>
     <TextColor>
       <R>255</R>
       <G>255</G>
@@ -5696,8 +5696,8 @@
     <AlignCenter>false</AlignCenter>
     <AlignRight>false</AlignRight>
   </Label>
-  <Slider item="Zeal_MapBottom_Slider">
-    <ScreenID>Zeal_MapBottom_Slider</ScreenID>
+  <Slider item="Zeal_MapHeight_Slider">
+    <ScreenID>Zeal_MapHeight_Slider</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>197</X>
@@ -5709,8 +5709,8 @@
     </Size>
     <SliderArt>SDT_DefSlider</SliderArt>
   </Slider>
-  <Label item="Zeal_MapBottom_Value">
-    <ScreenID>Zeal_MapBottom_Value</ScreenID>
+  <Label item="Zeal_MapHeight_Value">
+    <ScreenID>Zeal_MapHeight_Value</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>297</X>
@@ -6014,15 +6014,15 @@
     <Pieces>Zeal_MapLeft_Label</Pieces>
     <Pieces>Zeal_MapLeft_Slider</Pieces>
     <Pieces>Zeal_MapLeft_Value</Pieces>
-    <Pieces>Zeal_MapRight_Label</Pieces>
-    <Pieces>Zeal_MapRight_Slider</Pieces>
-    <Pieces>Zeal_MapRight_Value</Pieces>
+    <Pieces>Zeal_MapWidth_Label</Pieces>
+    <Pieces>Zeal_MapWidth_Slider</Pieces>
+    <Pieces>Zeal_MapWidth_Value</Pieces>
     <Pieces>Zeal_MapTop_Label</Pieces>
     <Pieces>Zeal_MapTop_Slider</Pieces>
     <Pieces>Zeal_MapTop_Value</Pieces>
-    <Pieces>Zeal_MapBottom_Label</Pieces>
-    <Pieces>Zeal_MapBottom_Slider</Pieces>
-    <Pieces>Zeal_MapBottom_Value</Pieces>
+    <Pieces>Zeal_MapHeight_Label</Pieces>
+    <Pieces>Zeal_MapHeight_Slider</Pieces>
+    <Pieces>Zeal_MapHeight_Value</Pieces>
     <Pieces>Zeal_MapPositionSize_Label</Pieces>
     <Pieces>Zeal_MapPositionSize_Slider</Pieces>
     <Pieces>Zeal_MapPositionSize_Value</Pieces>

--- a/Zeal/string_util.cpp
+++ b/Zeal/string_util.cpp
@@ -76,32 +76,37 @@ namespace Zeal
 		}
 
 
-		bool tryParse(const std::string& str, int* result) {
+		bool tryParse(const std::string& str, int* result, bool quiet) {
 			try {
 				*result = std::stoi(str);
 				return true;
 			}
 			catch (const std::invalid_argument& e) {
-				Zeal::EqGame::print_chat("Invalid Argument %s", e.what());
+				if (!quiet)
+					Zeal::EqGame::print_chat("Invalid Argument %s", e.what());
 				return false;
 			}
 			catch (const std::out_of_range& e) {
-				Zeal::EqGame::print_chat("Out of range: %s", e.what());
+				if (!quiet) {
+					Zeal::EqGame::print_chat("Out of range: %s", e.what());
+				}
 				return false;
 			}
 		}
 
-		bool tryParse(const std::string& str, float* result) {
+		bool tryParse(const std::string& str, float* result, bool quiet) {
 			try {
 				*result = std::stof(str);
 				return true;
 			}
 			catch (const std::invalid_argument& e) {
-				Zeal::EqGame::print_chat("Invalid Argument %s", e.what());
+				if (!quiet)
+					Zeal::EqGame::print_chat("Invalid Argument %s", e.what());
 				return false;
 			}
 			catch (const std::out_of_range& e) {
-				Zeal::EqGame::print_chat("Out of range: %s", e.what());
+				if (!quiet)
+					Zeal::EqGame::print_chat("Out of range: %s", e.what());
 				return false;
 			}
 		}

--- a/Zeal/string_util.h
+++ b/Zeal/string_util.h
@@ -8,8 +8,8 @@ namespace Zeal
 		std::string trim_and_reduce_spaces(const std::string& input);
 		bool compare_insensitive(const std::string& str1, const std::string& str2);
 		std::vector<std::string> split(const std::string& str, const std::string& delim);
-		bool tryParse(const std::string& str, int* result);
-		bool tryParse(const std::string& str, float* result);
+		bool tryParse(const std::string& str, int* result, bool quiet = false);
+		bool tryParse(const std::string& str, float* result, bool quiet = false);
 		std::string bytes_to_hex(const char* byteArray, size_t length);
 		std::string replace(std::string& input, const std::string& from, const std::string& to);
 	};

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -100,6 +100,9 @@ void ui_options::InitUI()
 	ui->AddSliderCallback(Zeal::EqGame::Windows->Options, "Zeal_MapMarkerSize_Slider", [this](Zeal::EqUI::SliderWnd* wnd, int value) {
 		ZealService::get_instance()->zone_map->set_marker_size(value);
 	});
+	ui->AddSliderCallback(Zeal::EqGame::Windows->Options, "Zeal_MapBackgroundAlpha_Slider", [this](Zeal::EqUI::SliderWnd* wnd, int value) {
+		ZealService::get_instance()->zone_map->set_background_alpha(value);
+		});
 
 	ui->AddLabel(Zeal::EqGame::Windows->Options, "Zeal_PanDelayValueLabel");
 	ui->AddLabel(Zeal::EqGame::Windows->Options, "Zeal_FirstPersonLabel_X");
@@ -117,6 +120,7 @@ void ui_options::InitUI()
 	ui->AddLabel(Zeal::EqGame::Windows->Options, "Zeal_MapHeight_Value");
 	ui->AddLabel(Zeal::EqGame::Windows->Options, "Zeal_MapPositionSize_Value");
 	ui->AddLabel(Zeal::EqGame::Windows->Options, "Zeal_MapMarkerSize_Value");
+	ui->AddLabel(Zeal::EqGame::Windows->Options, "Zeal_MapBackgroundAlpha_Value");
 
 	/*set the current states*/
 	UpdateOptions();
@@ -182,6 +186,7 @@ void ui_options::UpdateOptionsMapOnly()
 	ui->SetSliderValue("Zeal_MapHeight_Slider", ZealService::get_instance()->zone_map->get_map_height());
 	ui->SetSliderValue("Zeal_MapPositionSize_Slider", ZealService::get_instance()->zone_map->get_position_size());
 	ui->SetSliderValue("Zeal_MapMarkerSize_Slider", ZealService::get_instance()->zone_map->get_marker_size());
+	ui->SetSliderValue("Zeal_MapBackgroundAlpha_Slider", ZealService::get_instance()->zone_map->get_background_alpha());
 	ui->SetLabelValue("Zeal_MapZoom_Value", "%i%%", ZealService::get_instance()->zone_map->get_zoom());
 	ui->SetLabelValue("Zeal_MapLeft_Value", "%i%%", ZealService::get_instance()->zone_map->get_map_left());
 	ui->SetLabelValue("Zeal_MapWidth_Value", "%i%%", ZealService::get_instance()->zone_map->get_map_width());
@@ -189,6 +194,7 @@ void ui_options::UpdateOptionsMapOnly()
 	ui->SetLabelValue("Zeal_MapHeight_Value", "%i%%", ZealService::get_instance()->zone_map->get_map_height());
 	ui->SetLabelValue("Zeal_MapPositionSize_Value", "%i%%", ZealService::get_instance()->zone_map->get_position_size());
 	ui->SetLabelValue("Zeal_MapMarkerSize_Value", "%i%%", ZealService::get_instance()->zone_map->get_marker_size());
+	ui->SetLabelValue("Zeal_MapBackgroundAlpha_Value", "%i%%", ZealService::get_instance()->zone_map->get_background_alpha());
 }
 
 

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -80,19 +80,19 @@ void ui_options::InitUI()
 		ui->SetLabelValue("Zeal_TargetRingFill_Value", "%.2f", val);
 	});
 	ui->AddSliderCallback(Zeal::EqGame::Windows->Options, "Zeal_MapZoom_Slider", [this](Zeal::EqUI::SliderWnd* wnd, int value) {
-		ZealService::get_instance()->zone_map->set_zoom(value + 100);  // Note zoom offset.
+		ZealService::get_instance()->zone_map->set_zoom(value * 15 + 100);  // Note scale and zoom offset.
 	});
 	ui->AddSliderCallback(Zeal::EqGame::Windows->Options, "Zeal_MapLeft_Slider", [this](Zeal::EqUI::SliderWnd* wnd, int value) {
 		ZealService::get_instance()->zone_map->set_map_left(value);
 	});
-	ui->AddSliderCallback(Zeal::EqGame::Windows->Options, "Zeal_MapRight_Slider", [this](Zeal::EqUI::SliderWnd* wnd, int value) {
-		ZealService::get_instance()->zone_map->set_map_right(value);
+	ui->AddSliderCallback(Zeal::EqGame::Windows->Options, "Zeal_MapWidth_Slider", [this](Zeal::EqUI::SliderWnd* wnd, int value) {
+		ZealService::get_instance()->zone_map->set_map_width(value);
 	});
 	ui->AddSliderCallback(Zeal::EqGame::Windows->Options, "Zeal_MapTop_Slider", [this](Zeal::EqUI::SliderWnd* wnd, int value) {
 		ZealService::get_instance()->zone_map->set_map_top(value);
 	});
-	ui->AddSliderCallback(Zeal::EqGame::Windows->Options, "Zeal_MapBottom_Slider", [this](Zeal::EqUI::SliderWnd* wnd, int value) {
-		ZealService::get_instance()->zone_map->set_map_bottom(value);
+	ui->AddSliderCallback(Zeal::EqGame::Windows->Options, "Zeal_MapHeight_Slider", [this](Zeal::EqUI::SliderWnd* wnd, int value) {
+		ZealService::get_instance()->zone_map->set_map_height(value);
 	});
 	ui->AddSliderCallback(Zeal::EqGame::Windows->Options, "Zeal_MapPositionSize_Slider", [this](Zeal::EqUI::SliderWnd* wnd, int value) {
 		ZealService::get_instance()->zone_map->set_position_size(value);
@@ -112,9 +112,9 @@ void ui_options::InitUI()
 	ui->AddLabel(Zeal::EqGame::Windows->Options, "Zeal_TargetRingFill_Value");
 	ui->AddLabel(Zeal::EqGame::Windows->Options, "Zeal_MapZoom_Value");
 	ui->AddLabel(Zeal::EqGame::Windows->Options, "Zeal_MapLeft_Value");
-	ui->AddLabel(Zeal::EqGame::Windows->Options, "Zeal_MapRight_Value");
+	ui->AddLabel(Zeal::EqGame::Windows->Options, "Zeal_MapWidth_Value");
 	ui->AddLabel(Zeal::EqGame::Windows->Options, "Zeal_MapTop_Value");
-	ui->AddLabel(Zeal::EqGame::Windows->Options, "Zeal_MapBottom_Value");
+	ui->AddLabel(Zeal::EqGame::Windows->Options, "Zeal_MapHeight_Value");
 	ui->AddLabel(Zeal::EqGame::Windows->Options, "Zeal_MapPositionSize_Value");
 	ui->AddLabel(Zeal::EqGame::Windows->Options, "Zeal_MapMarkerSize_Value");
 
@@ -175,18 +175,18 @@ void ui_options::UpdateOptionsMapOnly()
 	ui->SetChecked("Zeal_Map", ZealService::get_instance()->zone_map->is_enabled());
 	ui->SetComboValue("Zeal_MapBackground_Combobox", ZealService::get_instance()->zone_map->get_background());
 	ui->SetComboValue("Zeal_MapAlignment_Combobox", ZealService::get_instance()->zone_map->get_alignment());
-	ui->SetSliderValue("Zeal_MapZoom_Slider", ZealService::get_instance()->zone_map->get_zoom() - 100);
+	ui->SetSliderValue("Zeal_MapZoom_Slider", (ZealService::get_instance()->zone_map->get_zoom() - 100)/15);  // 100 to 1600%
 	ui->SetSliderValue("Zeal_MapLeft_Slider", ZealService::get_instance()->zone_map->get_map_left());
-	ui->SetSliderValue("Zeal_MapRight_Slider", ZealService::get_instance()->zone_map->get_map_right());
+	ui->SetSliderValue("Zeal_MapWidth_Slider", ZealService::get_instance()->zone_map->get_map_width());
 	ui->SetSliderValue("Zeal_MapTop_Slider", ZealService::get_instance()->zone_map->get_map_top());
-	ui->SetSliderValue("Zeal_MapBottom_Slider", ZealService::get_instance()->zone_map->get_map_bottom());
+	ui->SetSliderValue("Zeal_MapHeight_Slider", ZealService::get_instance()->zone_map->get_map_height());
 	ui->SetSliderValue("Zeal_MapPositionSize_Slider", ZealService::get_instance()->zone_map->get_position_size());
 	ui->SetSliderValue("Zeal_MapMarkerSize_Slider", ZealService::get_instance()->zone_map->get_marker_size());
 	ui->SetLabelValue("Zeal_MapZoom_Value", "%i%%", ZealService::get_instance()->zone_map->get_zoom());
 	ui->SetLabelValue("Zeal_MapLeft_Value", "%i%%", ZealService::get_instance()->zone_map->get_map_left());
-	ui->SetLabelValue("Zeal_MapRight_Value", "%i%%", ZealService::get_instance()->zone_map->get_map_right());
+	ui->SetLabelValue("Zeal_MapWidth_Value", "%i%%", ZealService::get_instance()->zone_map->get_map_width());
 	ui->SetLabelValue("Zeal_MapTop_Value", "%i%%", ZealService::get_instance()->zone_map->get_map_top());
-	ui->SetLabelValue("Zeal_MapBottom_Value", "%i%%", ZealService::get_instance()->zone_map->get_map_bottom());
+	ui->SetLabelValue("Zeal_MapHeight_Value", "%i%%", ZealService::get_instance()->zone_map->get_map_height());
 	ui->SetLabelValue("Zeal_MapPositionSize_Value", "%i%%", ZealService::get_instance()->zone_map->get_position_size());
 	ui->SetLabelValue("Zeal_MapMarkerSize_Value", "%i%%", ZealService::get_instance()->zone_map->get_marker_size());
 }

--- a/Zeal/zone_map.cpp
+++ b/Zeal/zone_map.cpp
@@ -4,6 +4,7 @@
 #include "EqAddresses.h"
 #include "string_util.h"
 #include "zone_map_data.h"
+#include <string>
 
 // Possible enhancements:
 // - Support a command for default small / med / large map sizes
@@ -176,9 +177,9 @@ void ZoneMap::render_load_map() {
 
     // Calculate the initial offset based on alignment of the full map data.
     offset_y = rect_top - zone_map_data->min_y * scale_factor;
-    if (map_alignment_state == 2)  // Right alignment
+    if (map_alignment_state == AlignmentType::kRight)
         offset_x = rect_right - zone_map_data->max_x * scale_factor;
-    else if (map_alignment_state == 1)  // Center alignment
+    else if (map_alignment_state == AlignmentType::kCenter)
         offset_x = (rect_right + rect_left) * 0.5 -
           (zone_map_data->max_x + zone_map_data->min_x) * 0.5f * scale_factor;
     else  // Default left alignment.
@@ -418,13 +419,20 @@ void ZoneMap::render_update_marker_buffer() {
                                     {0, 0, 0}, {-size, short_size, 0}, {-size, -short_size, 0}
     };
     MapVertex marker_vertices[kNumVertices];
+
+    // Skip drawing the marker if the center is off the map.
     const float rect_left = map_rect_left * screen_size.x;
     const float rect_right = map_rect_right * screen_size.x;
     const float rect_top = map_rect_top * screen_size.y;
     const float rect_bottom = map_rect_bottom * screen_size.y;
+    if ((screen_x <= rect_left) || (screen_x >= rect_right) ||
+        (screen_y <= rect_top) || (screen_y >= rect_bottom))
+        return;
+
+    // Add vertices constraining to fit within the valid screen.
     for (int i = 0; i < kNumVertices; ++i) {
-        marker_vertices[i].x = max(rect_left, min(rect_right, marker[i].x + screen_x));
-        marker_vertices[i].y = max(rect_top, min(rect_bottom, marker[i].y + screen_y));
+        marker_vertices[i].x = max(0, min(screen_size.x - 1, marker[i].x + screen_x));
+        marker_vertices[i].y = max(0, min(screen_size.y - 1, marker[i].y + screen_y));
         marker_vertices[i].z = 0.5f;
         marker_vertices[i].rhw = 1.f;
         marker_vertices[i].color = D3DCOLOR_XRGB(255, 0, 0);
@@ -509,8 +517,9 @@ bool ZoneMap::set_background(int new_state, bool update_default) {
     return true;
 }
 
-bool ZoneMap::set_alignment(int alignment, bool update_default) {
-    alignment = max(0, min(kAlignmentStates - 1, alignment));
+bool ZoneMap::set_alignment(int alignment_in, bool update_default) {
+    AlignmentType alignment{ alignment_in };
+    alignment = max(AlignmentType::kFirst, min(AlignmentType::kLast, alignment));
 
     map_alignment_state = alignment;
     zone_id = kInvalidZoneId;  // Triggers reload.
@@ -599,7 +608,7 @@ void ZoneMap::load_ini(IO_ini* ini)
     if (!ini->exists("Zeal", "MapBackgroundState"))
         ini->setValue<int>("Zeal", "MapBackgroundState", 0);
     if (!ini->exists("Zeal", "MapAlignment"))
-        ini->setValue<int>("Zeal", "MapAlignment", 0);
+        ini->setValue<int>("Zeal", "MapAlignment", static_cast<int>(AlignmentType::kFirst));
     if (!ini->exists("Zeal", "MapRectTop"))
         ini->setValue<float>("Zeal", "MapRectTop", kDefaultRectTop);
     if (!ini->exists("Zeal", "MapRectLeft"))
@@ -616,7 +625,7 @@ void ZoneMap::load_ini(IO_ini* ini)
     // TODO: Protect against corrupted ini file (like a boolean instead of float).
     enabled = ini->getValue<bool>("Zeal", "MapEnabled");
     map_background_state = ini->getValue<int>("Zeal", "MapBackgroundState");
-    map_alignment_state = ini->getValue<int>("Zeal", "MapAlignment");
+    map_alignment_state = AlignmentType(ini->getValue<int>("Zeal", "MapAlignment"));
     map_rect_top = ini->getValue<float>("Zeal", "MapRectTop");
     map_rect_left = ini->getValue<float>("Zeal", "MapRectLeft");
     map_rect_bottom = ini->getValue<float>("Zeal", "MapRectBottom");
@@ -626,7 +635,7 @@ void ZoneMap::load_ini(IO_ini* ini)
 
     // Sanity clamp ini values.
     map_background_state = max(0, min(kBackgroundStates - 1, map_background_state));
-    map_alignment_state = max(0, min(kAlignmentStates - 1, map_alignment_state));
+    map_alignment_state = max(AlignmentType::kFirst, min(AlignmentType::kLast, map_alignment_state));
     if (map_rect_top < 0 || map_rect_top > map_rect_bottom || map_rect_bottom > 1) {
         map_rect_top = kDefaultRectTop;
         map_rect_bottom = kDefaultRectBottom;
@@ -645,20 +654,32 @@ void ZoneMap::update_ui_options() {
        ZealService::get_instance()->ui->options->UpdateOptionsMapOnly();
 }
 
-bool ZoneMap::set_map_top(int top_percent, bool update_default) {
-    return set_map_rect(top_percent / 100.f, map_rect_left, map_rect_bottom, map_rect_right, update_default);
+bool ZoneMap::set_map_top(int top_percent, bool update_default, bool preserve_height) {
+    float new_top = top_percent / 100.f;
+    float bottom = preserve_height ? (new_top + (map_rect_bottom - map_rect_top)) : map_rect_bottom;
+    return set_map_rect(new_top, map_rect_left, bottom, map_rect_right, update_default);
 }
 
-bool ZoneMap::set_map_left(int left_percent, bool update_default) {
-    return set_map_rect(map_rect_top, left_percent / 100.f , map_rect_bottom, map_rect_right, update_default);
+bool ZoneMap::set_map_left(int left_percent, bool update_default, bool preserve_width) {
+    float new_left = left_percent / 100.f;
+    float right = preserve_width ? (new_left + (map_rect_right - map_rect_left)) : map_rect_right;
+    return set_map_rect(map_rect_top, new_left, map_rect_bottom, right, update_default);
 }
 
 bool ZoneMap::set_map_bottom(int bottom_percent, bool update_default) {
     return set_map_rect(map_rect_top, map_rect_left, bottom_percent / 100.f, map_rect_right, update_default);
 }
 
+bool ZoneMap::set_map_height(int height_percent, bool update_default) {
+    return set_map_rect(map_rect_top, map_rect_left, map_rect_top + height_percent / 100.f, map_rect_right, update_default);
+}
+
 bool ZoneMap::set_map_right(int right_percent, bool update_default) {
     return set_map_rect(map_rect_top, map_rect_left, map_rect_bottom, right_percent / 100.f, update_default);
+}
+
+bool ZoneMap::set_map_width(int width_percent, bool update_default) {
+    return set_map_rect(map_rect_top, map_rect_left, map_rect_bottom, map_rect_left + width_percent / 100.f, update_default);
 }
 
 bool ZoneMap::set_map_rect(float top, float left, float bottom, float right, bool update_default) {
@@ -705,9 +726,47 @@ void ZoneMap::parse_rect(const std::vector<std::string>& args) {
     if ((tlbr.size() != 4) || !set_map_rect(tlbr[0] / 100.f, tlbr[1] / 100.f, tlbr[2] / 100.f, tlbr[3] / 100.f))
     {
         Zeal::EqGame::print_chat("Usage: /map rect <top> <left> <bottom> <right> (percent of screen dimensions)");
-        Zeal::EqGame::print_chat("Example: /map rect 10 20 50 60");
+        Zeal::EqGame::print_chat("Example: /map rect 10 20 50 65");
     }
 }
+
+// Alternative to the more direct rect that supports width and height.
+void ZoneMap::parse_size(const std::vector<std::string>& args) {
+    std::vector<int> tlhw;
+    for (int i = 2; i < args.size(); i++)
+    {
+        int value = 0;
+        if (Zeal::String::tryParse(args[i], &value))
+            tlhw.push_back(value);
+        else
+            break;
+    }
+
+    if ((tlhw.size() != 4) || !set_map_rect(tlhw[0] / 100.f, tlhw[1] / 100.f,
+        (tlhw[0] + tlhw[2]) / 100.f,    // Convert height to bottom (top + height).
+        (tlhw[1] + tlhw[3]) / 100.f))   // And width to right (left + width).
+    {
+        Zeal::EqGame::print_chat("Usage: /map size <top> <left> <height> <width> (percent of screen dimensions)");
+        Zeal::EqGame::print_chat("Example: /map size 10 20 40 45");
+    }
+}
+
+void ZoneMap::parse_alignment(const std::vector<std::string>& args) {
+    int alignment = AlignmentType::kFirst - 1;
+    if (args.size() == 3) {
+        if (args[2] == "left")
+            alignment = AlignmentType::kLeft;
+        else  if (args[2] == "center")
+            alignment = AlignmentType::kCenter;
+        else if (args[2] == "right")
+            alignment = AlignmentType::kRight;
+    }
+
+    if ((alignment < AlignmentType::kFirst) || !set_alignment(alignment)) {
+        Zeal::EqGame::print_chat("Usage: /map alignment left,center,right");
+    }
+}
+
 
 void ZoneMap::parse_marker(const std::vector<std::string>& args) {
     if (args.size() <= 2) {
@@ -735,14 +794,58 @@ void ZoneMap::parse_marker(const std::vector<std::string>& args) {
     Zeal::EqGame::print_chat("Example: /map marker 500 -1000 (drops a marker at loc 500, -1000)");
 }
 
+bool ZoneMap::search_poi(const std::string& search_term) {
+    Zeal::EqStructures::Entity* self = Zeal::EqGame::get_self();
+    if (!self)
+        return false;  // Not handled here.
+
+    const ZoneMapData* zone_map_data = get_zone_map_data(self->ZoneId);
+    if (!zone_map_data || zone_map_data->num_labels == 0) {
+        Zeal::EqGame::print_chat("No map POI data available for this zone");
+        return false;
+    }
+
+    // Go through the labels looking for a match. Use lowercase for both.
+    std::string search_lower = search_term;
+    std::transform(search_lower.begin(), search_lower.end(), search_lower.begin(), ::tolower);
+    int match_count = 0;
+    for (int i = 0; i < zone_map_data->num_labels; ++i) {
+        const ZoneMapLabel& label = zone_map_data->labels[i];
+        std::string label_lower = std::string(label.label);
+        std::transform(label_lower.begin(), label_lower.end(), label_lower.begin(), ::tolower);
+        if (label_lower.find(search_lower) != std::string::npos) {
+            match_count++;
+            const char* flag = "-";
+            if (match_count == 1) {
+                Zeal::EqGame::print_chat("Map poi search results for: %s:", search_term.c_str());
+                flag = "+";  // Flag the POI that was used for the marker.
+                // Note: Need to negate y and x to go from map data to world coordinates.
+                set_marker(-zone_map_data->labels[i].y, -zone_map_data->labels[i].x);
+                set_enabled(true);
+            }
+            Zeal::EqGame::print_chat("%s[%i]: (%i, %i): %s", flag, i, -label.y, -label.x, label.label);
+        }
+    }
+    if (match_count == 0) {
+        Zeal::EqGame::print_chat("%s is not a poi match", search_term.c_str());
+        return false;
+    }
+    return true;
+}
+
 bool ZoneMap::parse_shortcuts(const std::vector<std::string>& args) {
     // Support implicit shortcuts (/map 0 = clear marker, /map y x = set marker).
     int y = 0;
     int x = 0;
-    if (args.size() == 2 && args[1] == "0") {
-        clear_marker();
-        return true;
-    } 
+    if (args.size() == 2) {
+        if (args[1] == "0") {
+            clear_marker();
+            return true;
+        }
+        if (args[1] != "help") {
+            return search_poi(args[1]);
+        }
+    }
     else if (args.size() == 3 && Zeal::String::tryParse(args[1], &y) && Zeal::String::tryParse(args[2], &x)) {
         set_marker(y, x);
         set_enabled(true);
@@ -779,12 +882,13 @@ void ZoneMap::parse_poi(const std::vector<std::string>& args) {
     // Note: Need to negate y and x to go from map data to world coordinates.
     int poi = 0;
     if (args.size() == 2) {
+        Zeal::EqGame::print_chat("Map POI list for zone: %s", zone_map_data->name);
         for (int i = 0; i < zone_map_data->num_labels; ++i) {
             const ZoneMapLabel& label = zone_map_data->labels[i];
             Zeal::EqGame::print_chat("[%i]: (%i, %i): %s", i, -label.y, -label.x, label.label);
         }
     }
-    else if (args.size() == 3 && Zeal::String::tryParse(args[2], &poi)) {
+    else if (args.size() == 3 && Zeal::String::tryParse(args[2], &poi, true)) {
         if (poi < 0 || poi >= zone_map_data->num_labels) {
             Zeal::EqGame::print_chat("Invalid selection index");
             return;
@@ -792,15 +896,19 @@ void ZoneMap::parse_poi(const std::vector<std::string>& args) {
         set_marker(-zone_map_data->labels[poi].y, -zone_map_data->labels[poi].x);
         set_enabled(true);
     }
-    else {
-        Zeal::EqGame::print_chat("Usage: /map poi <index> (displays list if <index> is blank)");
+    else if (args.size() != 3 || !search_poi(args[2])) {
+        Zeal::EqGame::print_chat("Usage: /map poi (displays list of all points of interest)");
+        Zeal::EqGame::print_chat("Usage: /map poi <#> (drops a marker at numeric list [#])");
+        Zeal::EqGame::print_chat("Usage: /map poi <phrase> (search poi labels for phrase)");
         Zeal::EqGame::print_chat("Example: /map poi 2 (drops a marker at list item [2])");
+        Zeal::EqGame::print_chat("Example: /map poi cazic (searches poi labels for 'cazic')");
     }
 }
 
 
 void ZoneMap::dump() {
-    Zeal::EqGame::print_chat("enabled: %i, background: %i, zone: %i", enabled, map_background_state, zone_id);
+    Zeal::EqGame::print_chat("enabled: %i, background: %i, align: %i, zone: %i",
+                            enabled, map_background_state, map_alignment_state, zone_id);
     Zeal::EqGame::print_chat("marker: zone: %i, y: %i, x: %i", marker_zone_id, marker_y, marker_x);
     Zeal::EqGame::print_chat("rect: t: %f, l: %f, b: %f, r: %f", map_rect_top, map_rect_left, map_rect_bottom, map_rect_right);
     Zeal::EqGame::print_chat("clip: t: %f, l: %f, b: %f, r: %f", clip_rect_top, clip_rect_left, clip_rect_bottom, clip_rect_right);
@@ -823,6 +931,12 @@ bool ZoneMap::parse_command(const std::vector<std::string>& args) {
     else if (args[1] == "rect") {
         parse_rect(args);  // Set the Top, Left, Bottom, Right coordinates of window.
     }
+    else if (args[1] == "size") {
+        parse_size(args);  // Set the Top, Left, Height, Width of window.
+    }
+    else if (args[1] == "alignment") {
+        parse_alignment(args);
+    }
     else if (args[1] == "marker") {
         parse_marker(args);
     }
@@ -839,7 +953,7 @@ bool ZoneMap::parse_command(const std::vector<std::string>& args) {
         dump();
     }
     else if (!parse_shortcuts(args)) {
-        Zeal::EqGame::print_chat("Usage: /map [on|off|rect|marker|background|zoom|poi], /map <y> <x>, /map 0");
+        Zeal::EqGame::print_chat("Usage: /map [on|off|size|marker|background|zoom|poi], /map <y> <x>, /map 0");
         Zeal::EqGame::print_chat("Examples: /map 100 -200 (drops a marker at loc 100, -200), /map 0 (clears marker)");
     }
     return true;

--- a/Zeal/zone_map.h
+++ b/Zeal/zone_map.h
@@ -8,6 +8,8 @@
 class ZoneMap
 {
 public:
+	enum AlignmentType: int { kLeft = 0, kCenter, kRight, kFirst = kLeft, kLast = kRight };
+
 	static constexpr float kMaxPositionSize = 0.05f;  // In fraction of screen size.
 	static constexpr float kMaxMarkerSize = 0.05f;
 
@@ -21,20 +23,24 @@ public:
 	void set_enabled(bool enable, bool update_default = false);
 	bool set_background(int new_state, bool update_default = true); // [clear, dark, light, tan]
 	bool set_alignment(int new_state, bool update_default = true); // [left, center, right]
-	bool set_map_top(int top_percent, bool update_default = true);
-	bool set_map_left(int left_percent, bool update_default = true);
+	bool set_map_top(int top_percent, bool update_default = true, bool preserve_height = true);
+	bool set_map_left(int left_percent, bool update_default = true, bool preserve_width = true);
 	bool set_map_bottom(int bottom_percent, bool update_default = true);
+	bool set_map_height(int height_percent, bool update_default = true);
 	bool set_map_right(int right_percent, bool update_default = true);
+	bool set_map_width(int width_percent, bool update_default = true);
 	bool set_position_size(int new_size_percent, bool update_default = true);
 	bool set_marker_size(int new_size_percent, bool update_default = true);
 	bool set_zoom(int zoom_percent);  // Note: 100% = 1x.
 
 	int get_background() const { return map_background_state; }
-	int get_alignment() const { return map_alignment_state; }
+	int get_alignment() const { return static_cast<int>(map_alignment_state); }
 	int get_map_top() const { return static_cast<int>(map_rect_top * 100 + 0.5f); }
 	int get_map_left() const { return static_cast<int>(map_rect_left * 100 + 0.5f); }
 	int get_map_bottom() const { return static_cast<int>(map_rect_bottom * 100 + 0.5f); }
+	int get_map_height() const { return static_cast<int>((map_rect_bottom - map_rect_top) * 100 + 0.5f); }
 	int get_map_right() const { return static_cast<int>(map_rect_right * 100 + 0.5f); }
+	int get_map_width() const { return static_cast<int>((map_rect_right - map_rect_left) * 100 + 0.5f); }
 	int get_position_size() const { return static_cast<int>(position_size / kMaxPositionSize * 100 + 0.5f); }
 	int get_marker_size() const { return static_cast<int>(marker_size / kMaxMarkerSize * 100 + 0.5f); }
 	int get_zoom() const { return static_cast<int>(zoom_factor * 100 + 0.5f); }
@@ -59,10 +65,13 @@ private:
 	bool parse_command(const std::vector<std::string>& args);
 	bool parse_shortcuts(const std::vector<std::string>& args);
 	void parse_rect(const std::vector<std::string>& args);
+	void parse_size(const std::vector<std::string>& args);
+	void parse_alignment(const std::vector<std::string>& args);
 	void parse_marker(const std::vector<std::string>& args);
 	void parse_background(const std::vector<std::string>& args);
 	void parse_zoom(const std::vector<std::string>& args);
 	void parse_poi(const std::vector<std::string>& args);
+	bool search_poi(const std::string& search);
 	void set_marker(int y, int x);
 	void clear_marker();
 	bool set_map_rect(float top, float left, float bottom, float right, bool update_default = false);
@@ -80,7 +89,7 @@ private:
 
 	bool enabled = false;
 	int map_background_state = 0;
-	int map_alignment_state = 0;
+	AlignmentType map_alignment_state = AlignmentType::kFirst;
 	int zone_id = kInvalidZoneId;
 	int marker_zone_id = kInvalidZoneId;
 	int zoom_recenter_zone_id = kInvalidZoneId;

--- a/Zeal/zone_map.h
+++ b/Zeal/zone_map.h
@@ -8,7 +8,8 @@
 class ZoneMap
 {
 public:
-	enum AlignmentType: int { kLeft = 0, kCenter, kRight, kFirst = kLeft, kLast = kRight };
+	struct AlignmentType { enum e: int{ kLeft = 0, kCenter, kRight, kFirst = kLeft, kLast = kRight }; };
+	struct BackgroundType { enum e: int { kClear = 0, kDark, kLight, kTan, kFirst = kClear, kLast = kTan }; };
 
 	static constexpr float kMaxPositionSize = 0.05f;  // In fraction of screen size.
 	static constexpr float kMaxMarkerSize = 0.05f;
@@ -22,6 +23,7 @@ public:
 	bool is_enabled() const { return enabled; }
 	void set_enabled(bool enable, bool update_default = false);
 	bool set_background(int new_state, bool update_default = true); // [clear, dark, light, tan]
+	bool set_background_alpha(int percent, bool update_default = true);
 	bool set_alignment(int new_state, bool update_default = true); // [left, center, right]
 	bool set_map_top(int top_percent, bool update_default = true, bool preserve_height = true);
 	bool set_map_left(int left_percent, bool update_default = true, bool preserve_width = true);
@@ -33,7 +35,8 @@ public:
 	bool set_marker_size(int new_size_percent, bool update_default = true);
 	bool set_zoom(int zoom_percent);  // Note: 100% = 1x.
 
-	int get_background() const { return map_background_state; }
+	int get_background() const { return static_cast<int>(map_background_state); }
+	int get_background_alpha() const { return static_cast<int>(map_background_alpha * 100 + 0.5f); }
 	int get_alignment() const { return static_cast<int>(map_alignment_state); }
 	int get_map_top() const { return static_cast<int>(map_rect_top * 100 + 0.5f); }
 	int get_map_left() const { return static_cast<int>(map_rect_left * 100 + 0.5f); }
@@ -51,8 +54,7 @@ public:
 
 private:
 	static constexpr int kInvalidZoneId = 0;
-	static constexpr int kBackgroundStates = 4;  // 0 = clear.
-	static constexpr int kAlignmentStates = 3; // 0 = Left, 1 = Center, 2 = Right.
+	static constexpr float kDefaultBackgroundAlpha = 0.5f;
 	static constexpr float kDefaultRectTop = 0.1f;
 	static constexpr float kDefaultRectLeft = 0.1f;
 	static constexpr float kDefaultRectBottom = 0.4f;
@@ -84,12 +86,14 @@ private:
 	void render_release_resources();
 	void render_load_map();
 	void render_map();
+	void render_background();
 	int render_update_position_buffer();
 	void render_update_marker_buffer();
 
 	bool enabled = false;
-	int map_background_state = 0;
-	AlignmentType map_alignment_state = AlignmentType::kFirst;
+	BackgroundType::e map_background_state = BackgroundType::kClear;
+	float map_background_alpha = kDefaultBackgroundAlpha;
+	AlignmentType::e map_alignment_state = AlignmentType::kFirst;
 	int zone_id = kInvalidZoneId;
 	int marker_zone_id = kInvalidZoneId;
 	int zoom_recenter_zone_id = kInvalidZoneId;


### PR DESCRIPTION
   - Based on ease of use feedback, switched from specifying bottom
      and right edge limits to specifying height and width limits
      - Left existing /map rect command as is but added new /map size
        command that uses height and width
      - Updated options xml with new sliders and constraints
    - Added /map alignment to supplement the UI combobox
    - Cleaned up the marker rendering near the edges of the clip rect
    - Added a poi search functionality
      - /map poi <search_term> prints out a list of matches and drops
        a marker on the first match in the list
      - /map <search_term> is a shortcut (although search_term
        collisions with /map commands will get ignored)
   - Map enable is now properly sticky when set in options
   - Added an alpha transparency factor for the map backgrounds
      (command line and options)