### PR TITLE
[melody] Internal logic improvements / fixes

### DIFF
--- a/Zeal/EqStructures.h
+++ b/Zeal/EqStructures.h
@@ -99,6 +99,8 @@
 #define USERCOLOR_ECHO_CHAT_9           0xFF +  68 //  68 - chat 9 echo
 #define USERCOLOR_ECHO_CHAT_10          0xFF +  69 //  69 - chat 10 echo
 
+constexpr WORD kInvalidSpellId = 0xffff; // spell_id used when not casting or empty spell gem
+
 namespace Zeal
 {
 	namespace EqEnums

--- a/Zeal/EqStructures.h
+++ b/Zeal/EqStructures.h
@@ -99,7 +99,6 @@
 #define USERCOLOR_ECHO_CHAT_9           0xFF +  68 //  68 - chat 9 echo
 #define USERCOLOR_ECHO_CHAT_10          0xFF +  69 //  69 - chat 10 echo
 
-
 namespace Zeal
 {
 	namespace EqEnums
@@ -165,6 +164,53 @@ namespace Zeal
 			Sit = 9,
 			Stand = 10,
 			Taunt = 11
+		};
+		enum SpellTargetType
+		{
+			/* 01 */	TargetOptional = 0x01,
+			/* 02 */	AEClientV1 = 0x02,
+			/* 03 */	GroupV1 = 0x03,
+			/* 04 */	PBAE = 0x04,
+			/* 05 */	Target = 0x05,
+			/* 06 */	Self = 0x06,
+			/* 07 */	// NOT USED
+			/* 08 */	TargetedAE = 0x08,
+			/* 09 */	Animal = 0x09,
+			/* 10 */	Undead = 0x0a,
+			/* 11 */	Summoned = 0x0b,
+			/* 12 */	// NOT USED
+			/* 13 */	Tap = 0x0d,
+			/* 14 */	Pet = 0x0e,
+			/* 15 */	Corpse = 0x0f,
+			/* 16 */	Plant = 0x10,
+			/* 17 */	UberGiant = 0x11, //special giant
+			/* 18 */	UberDragon = 0x12, //special dragon
+			/* 19 */	// NOT USED
+			/* 20 */	TargetedAETap = 0x14,
+			/* 21 */	// NOT USED
+			/* 22 */	// NOT USED
+			/* 23 */	// NOT USED
+			/* 24 */	UndeadAE = 0x18,
+			/* 25 */	SummonedAE = 0x19,
+			/* 26 */	// NOT USED
+			/* 27 */	// NOT USED
+			/* 28 */	// NOT USED
+			/* 29 */	// NOT USED
+			/* 30 */	// NOT USED
+			/* 31 */	// NOT USED
+			/* 32 */	// NOT USED
+			/* 33 */	// NOT USED
+			/* 34 */	// NOT USED
+			/* 35 */	// NOT USED
+			/* 36 */	// NOT USED
+			/* 37 */	// NOT USED
+			/* 38 */	// NOT USED
+			/* 39 */	// NOT USED
+			/* 40 */	AEBard = 0x28,
+			/* 41 */	GroupV2 = 0x29,
+			/* 42 */	// NOT USED
+			/* 43 */	ProjectIllusion = 0x2b, // Not found in spell data, used internally.
+
 		};
 
 
@@ -453,13 +499,13 @@ namespace Zeal
 			{
 				return reinterpret_cast<short(__thiscall*)(EQCHARINFO*)>(0x4b9450)(this);
 			}
-			int cast(UINT gem, short spell_id, int* item, short item_slot)
+			int cast(UINT gem, WORD spell_id, int* item, short item_slot)
 			{
-				return reinterpret_cast<int(__thiscall*)(EQCHARINFO*, UINT, short, int*, short)>(0x4c483b)(this, gem, spell_id, item, item_slot);
+				return reinterpret_cast<int(__thiscall*)(EQCHARINFO*, UINT, WORD, int*, short)>(0x4c483b)(this, gem, spell_id, item, item_slot);
 			}
-			void stop_cast(UINT reason, short spell_id)
+			void stop_cast(UINT reason, WORD spell_id)
 			{
-				return reinterpret_cast<void(__thiscall*)(EQCHARINFO*, UINT, short)>(0x4cb510)(this, reason, spell_id);
+				return reinterpret_cast<void(__thiscall*)(EQCHARINFO*, UINT, WORD)>(0x4cb510)(this, reason, spell_id);
 			}
 			/* 0x0000 */ BYTE Unknown0000[2];
 			/* 0x0002 */ CHAR Name[64]; // [0x40]

--- a/Zeal/commands.cpp
+++ b/Zeal/commands.cpp
@@ -218,7 +218,7 @@ ChatCommands::ChatCommands(ZealService* zeal)
 					Zeal::EqGame::print_chat("item %s does not have a spell attached to it.", item->Name);
 					return true;
 				}
-				if (!self->ActorInfo || self->ActorInfo->CastingSpellId != 0xffff)
+				if (!self->ActorInfo || self->ActorInfo->CastingSpellId != kInvalidSpellId)
 				{
 					Zeal::EqGame::print_chat(USERCOLOR_SPELLS, "You must stop casting to cast this spell!");
 					return true;

--- a/Zeal/labels.cpp
+++ b/Zeal/labels.cpp
@@ -77,7 +77,7 @@ bool GetLabelFromEq(int EqType, Zeal::EqUI::CXSTR* str, bool* override_color, UL
 		{
 			if (Zeal::EqGame::get_controlled()->ActorInfo->CastingSpellId) {
 				int spell_id = Zeal::EqGame::get_controlled()->ActorInfo->CastingSpellId;
-				if (spell_id == 65535) spell_id = 0; // avoid crash while player is not casting a spell
+				if (spell_id == kInvalidSpellId) spell_id = 0; // avoid crash while player is not casting a spell
 				Zeal::EqStructures::SPELL* casting_spell = Zeal::EqGame::get_spell_mgr()->Spells[spell_id];
 				Zeal::EqGame::CXStr_PrintString(str, "%s", casting_spell->Name);
 				*override_color = false;

--- a/Zeal/melody.cpp
+++ b/Zeal/melody.cpp
@@ -38,9 +38,9 @@
 //   failing (like Selo's indoors), the vulnerable timing window is dominant, making it
 //   hard to click off the melody with the UI. The new retry_count logic mitigates this.
 
-
 constexpr int RETRY_COUNT_REWIND_LIMIT = 8;  // Will rewind up to 8 times.
 constexpr int RETRY_COUNT_END_LIMIT = 15;  // Will terminate if 15 retries w/out a 'success'.
+constexpr ULONGLONG MELODY_SONG_INTERVAL = 150; // Interval between songs. If too low, the song may not fire.
 
 bool Melody::start(const std::vector<int>& new_songs)
 {
@@ -79,6 +79,7 @@ bool Melody::start(const std::vector<int>& new_songs)
     songs = new_songs;
     current_index = -1;
     retry_count = 0;
+    casting_melody_song = -1;
     if (songs.size())
         Zeal::EqGame::print_chat(USERCOLOR_SPELLS, "You begin playing a melody.");
     return true;
@@ -91,11 +92,12 @@ void Melody::end()
         current_index = -1;
         songs.clear();
         retry_count = 0;
+        casting_melody_song = -1;
         Zeal::EqGame::print_chat(USERCOLOR_SPELL_FAILURE, "Your melody has ended.");
     }
 }
 
-void Melody::handle_stop_cast_callback(BYTE reason)
+void Melody::handle_stop_cast_callback(BYTE reason, SHORT spell_id)
 {
     // Terminate melody on stop except for missed note (part of reason == 3) rewind attempts.
     if (reason != 3 || !songs.size())
@@ -109,26 +111,36 @@ void Melody::handle_stop_cast_callback(BYTE reason)
     // is not allowed in the zone), so we use a retry_count to limit the spammy loop that is
     // difficult to click off with UI spell gems (/stopsong, /melody still work fine). The modulo
     // check skips the rewind so it advances to the next song but then allows that song to retry.
-    if ((current_index >= 0) && (++retry_count % RETRY_COUNT_REWIND_LIMIT)) {
+    if (casting_melody_song == spell_id && (++retry_count % RETRY_COUNT_REWIND_LIMIT)) {
         current_index--;
         if (current_index < 0) {  // Handle wraparound.
             current_index = songs.size() - 1;
         }
     }
+    casting_melody_song = -1;
 }
 
 void __fastcall StopCast(int t, int u, BYTE reason, short spell_id)
 {
-    ZealService::get_instance()->melody->handle_stop_cast_callback(reason);
+    ZealService::get_instance()->melody->handle_stop_cast_callback(reason, spell_id);
     ZealService::get_instance()->hooks->hook_map["StopCast"]->original(StopCast)(t, u, reason, spell_id);
 }
 
 void Melody::stop_current_cast()
 {
-    // Note: This code assumes the current_index is valid to look up the spell_id for the StopCast call.
     Zeal::EqStructures::EQCHARINFO* char_info = Zeal::EqGame::get_char_info();
-    if (char_info && current_index>=0 && current_index < songs.size())
-        ZealService::get_instance()->hooks->hook_map["StopCast"]->original(StopCast)((int)char_info, 0, 0, char_info->MemorizedSpell[songs[current_index]]);
+    Zeal::EqStructures::Entity* self = Zeal::EqGame::get_self();
+    if (char_info && self && self->ActorInfo && self->ActorInfo->CastingSpellId != 0xffff) {
+        // Rewind if interrupted mid song cast
+        if (casting_melody_song == self->ActorInfo->CastingSpellId) {
+            current_index--;
+            if (current_index < 0) {
+                current_index = songs.size() - 1;
+            }
+        }
+        ZealService::get_instance()->hooks->hook_map["StopCast"]->original(StopCast)((int)char_info, 0, 0, self->ActorInfo->CastingSpellId);
+    }
+    casting_melody_song = -1;
 }
 
 void Melody::tick()
@@ -162,28 +174,33 @@ void Melody::tick()
         return;
     }
 
-    if ((current_timestamp - casting_visible_timestamp) < 150)
+    // Successfully finished casting current song/spell
+    casting_melody_song = -1; // clear this field to prevent the song from repeating if interrupted
+
+    // Wait for MELODY_SONG_INTERVAL ms between casting the next song
+    if ((current_timestamp - casting_visible_timestamp) < MELODY_SONG_INTERVAL)
         return;
- 
+
     // Handles situations like trade windows, looting (Stance::Bind), and ducking.
     if (!Zeal::EqGame::get_eq() || !Zeal::EqGame::get_eq()->IsOkToTransact() ||
         self->StandingState != Stance::Stand)
         return;
 
-    if (self->ActorInfo && self->ActorInfo->CastingSpellGemNumber == 255) //255 = Bard Singing
-        stop_current_cast();  //abort bard song if active.
+    stop_current_cast();  //abort bard song if active.
 
+    // Cast the next song in the melody
     current_index++;
     if (current_index >= songs.size() || current_index < 0)
         current_index = 0;
 
     int current_gem = songs[current_index];  // songs is 'guaranteed' to have a valid gem index from start().
-    if (char_info->MemorizedSpell[current_gem] == -1)
+    short current_song = char_info->MemorizedSpell[current_gem];
+    if (current_song == -1)
         return;  //simply skip empty gem slots (unexpected to occur)
 
     //handle a common issue of no target gracefully (notify once and skip to next song w/out retry failures).
     if (Zeal::EqGame::get_spell_mgr() &&
-        Zeal::EqGame::get_spell_mgr()->Spells[char_info->MemorizedSpell[current_gem]]->TargetType == 5 &&
+        (Zeal::EqGame::get_spell_mgr()->Spells[current_song]->TargetType == 5 || Zeal::EqGame::get_spell_mgr()->Spells[current_song]->TargetType == 8) &&
         !Zeal::EqGame::get_target())
     {
         Zeal::EqGame::print_chat(USERCOLOR_SPELL_FAILURE, "You must first select a target for spell %i", current_gem + 1);
@@ -191,7 +208,8 @@ void Melody::tick()
         return;
     }
 
-    char_info->cast(current_gem, char_info->MemorizedSpell[current_gem], 0, 0);
+    casting_melody_song = current_song;
+    char_info->cast(current_gem, current_song, 0, 0);
     start_of_cast_timestamp = current_timestamp;
 }
 

--- a/Zeal/melody.cpp
+++ b/Zeal/melody.cpp
@@ -79,7 +79,7 @@ bool Melody::start(const std::vector<int>& new_songs)
     songs = new_songs;
     current_index = -1;
     retry_count = 0;
-    casting_melody_song = -1;
+    casting_melody_spell_id = kInvalidSpellId;
     if (songs.size())
         Zeal::EqGame::print_chat(USERCOLOR_SPELLS, "You begin playing a melody.");
     return true;
@@ -92,12 +92,12 @@ void Melody::end()
         current_index = -1;
         songs.clear();
         retry_count = 0;
-        casting_melody_song = -1;
+        casting_melody_spell_id = kInvalidSpellId;
         Zeal::EqGame::print_chat(USERCOLOR_SPELL_FAILURE, "Your melody has ended.");
     }
 }
 
-void Melody::handle_stop_cast_callback(BYTE reason, SHORT spell_id)
+void Melody::handle_stop_cast_callback(BYTE reason, WORD spell_id)
 {
     // Terminate melody on stop except for missed note (part of reason == 3) rewind attempts.
     if (reason != 3 || !songs.size())
@@ -111,16 +111,16 @@ void Melody::handle_stop_cast_callback(BYTE reason, SHORT spell_id)
     // is not allowed in the zone), so we use a retry_count to limit the spammy loop that is
     // difficult to click off with UI spell gems (/stopsong, /melody still work fine). The modulo
     // check skips the rewind so it advances to the next song but then allows that song to retry.
-    if (casting_melody_song == spell_id && (++retry_count % RETRY_COUNT_REWIND_LIMIT)) {
+    if (casting_melody_spell_id == spell_id && (++retry_count % RETRY_COUNT_REWIND_LIMIT)) {
         current_index--;
         if (current_index < 0) {  // Handle wraparound.
             current_index = songs.size() - 1;
         }
     }
-    casting_melody_song = -1;
+    casting_melody_spell_id = kInvalidSpellId;
 }
 
-void __fastcall StopCast(int t, int u, BYTE reason, short spell_id)
+void __fastcall StopCast(int t, int u, BYTE reason, WORD spell_id)
 {
     ZealService::get_instance()->melody->handle_stop_cast_callback(reason, spell_id);
     ZealService::get_instance()->hooks->hook_map["StopCast"]->original(StopCast)(t, u, reason, spell_id);
@@ -130,17 +130,10 @@ void Melody::stop_current_cast()
 {
     Zeal::EqStructures::EQCHARINFO* char_info = Zeal::EqGame::get_char_info();
     Zeal::EqStructures::Entity* self = Zeal::EqGame::get_self();
-    if (char_info && self && self->ActorInfo && self->ActorInfo->CastingSpellId != 0xffff) {
-        // Rewind if interrupted mid song cast
-        if (casting_melody_song == self->ActorInfo->CastingSpellId) {
-            current_index--;
-            if (current_index < 0) {
-                current_index = songs.size() - 1;
-            }
-        }
+    if (char_info && self && self->ActorInfo && self->ActorInfo->CastingSpellId != kInvalidSpellId) {
         ZealService::get_instance()->hooks->hook_map["StopCast"]->original(StopCast)((int)char_info, 0, 0, self->ActorInfo->CastingSpellId);
     }
-    casting_melody_song = -1;
+    casting_melody_spell_id = kInvalidSpellId;
 }
 
 void Melody::tick()
@@ -175,7 +168,8 @@ void Melody::tick()
     }
 
     // Successfully finished casting current song/spell
-    casting_melody_song = -1; // clear this field to prevent the song from repeating if interrupted
+    // Reseting this field prevents the song from repeating after this point
+    casting_melody_spell_id = kInvalidSpellId;
 
     // Wait for MELODY_SONG_INTERVAL ms between casting the next song
     if ((current_timestamp - casting_visible_timestamp) < MELODY_SONG_INTERVAL)
@@ -194,13 +188,14 @@ void Melody::tick()
         current_index = 0;
 
     int current_gem = songs[current_index];  // songs is 'guaranteed' to have a valid gem index from start().
-    short current_song = char_info->MemorizedSpell[current_gem];
-    if (current_song == -1)
+    WORD current_gem_spell_id = char_info->MemorizedSpell[current_gem];
+    if (current_gem_spell_id == kInvalidSpellId)
         return;  //simply skip empty gem slots (unexpected to occur)
 
     //handle a common issue of no target gracefully (notify once and skip to next song w/out retry failures).
     if (Zeal::EqGame::get_spell_mgr() &&
-        (Zeal::EqGame::get_spell_mgr()->Spells[current_song]->TargetType == 5 || Zeal::EqGame::get_spell_mgr()->Spells[current_song]->TargetType == 8) &&
+        (Zeal::EqGame::get_spell_mgr()->Spells[current_gem_spell_id]->TargetType == Zeal::EqEnums::SpellTargetType::Target ||
+            Zeal::EqGame::get_spell_mgr()->Spells[current_gem_spell_id]->TargetType == Zeal::EqEnums::SpellTargetType::TargetedAE) &&
         !Zeal::EqGame::get_target())
     {
         Zeal::EqGame::print_chat(USERCOLOR_SPELL_FAILURE, "You must first select a target for spell %i", current_gem + 1);
@@ -208,8 +203,8 @@ void Melody::tick()
         return;
     }
 
-    casting_melody_song = current_song;
-    char_info->cast(current_gem, current_song, 0, 0);
+    casting_melody_spell_id = current_gem_spell_id;
+    char_info->cast(current_gem, current_gem_spell_id, 0, 0);
     start_of_cast_timestamp = current_timestamp;
 }
 

--- a/Zeal/melody.h
+++ b/Zeal/melody.h
@@ -2,12 +2,15 @@
 #include "hook_wrapper.h"
 #include "memory.h"
 #include "EqUI.h"
+
+constexpr WORD kInvalidSpellId = 0xffff; // spell_id used when not casting or empty spell gem
+
 class Melody
 {
 public:
 	bool start(const std::vector<int>& new_songs); //returns true if no errors
 	void end();
-	void handle_stop_cast_callback(BYTE reason, SHORT spell_id);
+	void handle_stop_cast_callback(BYTE reason, WORD spell_id);
 	Melody(class ZealService* pHookWrapper, class IO_ini* ini);
 	~Melody();
 private:
@@ -16,6 +19,6 @@ private:
 	int current_index = 0;  // Active song index. -1 if not started yet.
 	std::vector<int> songs; // Gem indices (base 0) for melody.
 	int retry_count = 0; // Tracks unsuccessful song casts.
-	short casting_melody_song = -1; // Current melody song being cast, or -1. This is used to determine if an interruptted song was the current melody song.
+	WORD casting_melody_spell_id = kInvalidSpellId; // Current melody song being cast. Is only a valid id while cast window is visible (actively casting).
 };
 

--- a/Zeal/melody.h
+++ b/Zeal/melody.h
@@ -3,8 +3,6 @@
 #include "memory.h"
 #include "EqUI.h"
 
-constexpr WORD kInvalidSpellId = 0xffff; // spell_id used when not casting or empty spell gem
-
 class Melody
 {
 public:

--- a/Zeal/melody.h
+++ b/Zeal/melody.h
@@ -7,7 +7,7 @@ class Melody
 public:
 	bool start(const std::vector<int>& new_songs); //returns true if no errors
 	void end();
-	void handle_stop_cast_callback(BYTE reason);
+	void handle_stop_cast_callback(BYTE reason, SHORT spell_id);
 	Melody(class ZealService* pHookWrapper, class IO_ini* ini);
 	~Melody();
 private:
@@ -16,5 +16,6 @@ private:
 	int current_index = 0;  // Active song index. -1 if not started yet.
 	std::vector<int> songs; // Gem indices (base 0) for melody.
 	int retry_count = 0; // Tracks unsuccessful song casts.
+	short casting_melody_song = -1; // Current melody song being cast, or -1. This is used to determine if an interruptted song was the current melody song.
 };
 


### PR DESCRIPTION
# Internal Logic Improvements and Cleanup for Melody

## Summary
- Eliminated several edge cases where Melody could skip songs forward/backward incorrectly.

## Internal Changes
These changes are aimed as fixing some current bugs and possible future bugs by future-proofing a lot of the logic in here to work even if non-songs are thrown into the mix of events happening.
- Store `casting_melody_spell_id` state variable to improve Melody rewind detection by always knowing what the current in-progress Melody song is, rather than relying on the `current_index`, which isn't always an accurate depiction of the casting state.
- Simplified `stop_current_cast()` to interrupt whatever it is currently casting.
- Improved `handle_stop_cast_callback()` to correctly differentiate between the Melody song being interrupted versus some other spell ID that may trigger a stopcast event.
- The checks for auto-skipping targeted songs when missing a target now also supports "Targetted AE"-type spells (for Denon`s Desperate Dirge).

## Notes
- These core changes were split out and refined based on this earlier PR.
  - https://github.com/iamclint/Zeal/pull/81