### PR TITLE
Add map labels support; sharpen position marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ ___
   - **Description:** plays songs in order until interrupted in any fashion.
 
 - `/map`
-  - **Arguments:** `on`, `off`, `size`, `alignment`, `marker`, `background`, `zoom`, `poi`
+  - **Arguments:** `on`, `off`, `size`, `alignment`, `marker`, `background`, `zoom`, `poi`, `labels`
   - **Example:** `/map` toggles map on and off
   - **Example:** `/map marker 500 -100` sets a target marker at loc 500, -100 (default size)
   - **Example:** `/map marker 500 -100 3` sets a target marker at loc 500, -100 with size = 3% of screen

--- a/Zeal/GameXML/EQUI_OptionsWindow.xml
+++ b/Zeal/GameXML/EQUI_OptionsWindow.xml
@@ -5999,6 +5999,72 @@
     <Choices>Top Center</Choices>
     <Choices>Top Right</Choices>
   </Combobox>
+  <!-- Zeal Map Labels Combobox -->
+  <Label item="Zeal_MapLabels_Label">
+    <ScreenID>Zeal_MapLabels_Label</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>197</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>14</CY>
+    </Size>
+    <Text>Labels (FPS penalty)</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
+  <Combobox item="Zeal_MapLabels_Combobox">
+    <ScreenID>Zeal_MapLabels_Combobox</ScreenID>
+    <DrawTemplate>WDT_Inner</DrawTemplate>
+    <Location>
+      <X>10</X>
+      <Y>217</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>24</CY>
+    </Size>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ListHeight>70</ListHeight>
+    <Button>BDT_Combo</Button>
+    <Style_Border>true</Style_Border>
+    <Choices>Off (no penalty)</Choices>
+    <Choices>Summary (some)</Choices>
+    <Choices>All (significant)</Choices>
+  </Combobox>
+  <!-- Zeal Map Keybinds Reminder -->
+  <Label item="Zeal_MapKeyBinds_Label">
+    <ScreenID>Zeal_MapKeyBinds_Label</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>268</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>32</CY>
+    </Size>
+    <Text>See Keyboard->UI for Map Keybinds (recommended)</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
   <!-- Zeal Map Background Combobox -->
   <Label item="Zeal_MapBackground_Label">
     <ScreenID>Zeal_MapBackground_Label</ScreenID>
@@ -6088,6 +6154,9 @@
     <Pieces>Zeal_MapZoom_Label</Pieces>
     <Pieces>Zeal_MapZoom_Slider</Pieces>
     <Pieces>Zeal_MapZoom_Value</Pieces>
+    <Pieces>Zeal_MapKeyBinds_Label</Pieces>
+    <Pieces>Zeal_MapLabels_Label</Pieces>
+    <Pieces>Zeal_MapLabels_Combobox</Pieces>
     <Pieces>Zeal_MapBackgroundAlpha_Label</Pieces>
     <Pieces>Zeal_MapBackgroundAlpha_Slider</Pieces>
     <Pieces>Zeal_MapBackgroundAlpha_Value</Pieces>

--- a/Zeal/Zeal.vcxproj
+++ b/Zeal/Zeal.vcxproj
@@ -117,7 +117,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>winmm.lib;Dbghelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>winmm.lib;Dbghelp.lib;legacy_stdio_definitions.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
   </ItemDefinitionGroup>

--- a/Zeal/binds.cpp
+++ b/Zeal/binds.cpp
@@ -270,6 +270,12 @@ void Binds::add_binds()
 			ZealService::get_instance()->zone_map->toggle_zoom();
 		}
 		});
+	add_bind(231, "Toggle Map Labels", "ToggleMapLabels", key_category::UI, [this](int key_down) {
+		if (key_down && !Zeal::EqGame::EqGameInternal::UI_ChatInputCheck())
+		{
+			ZealService::get_instance()->zone_map->toggle_labels();
+		}
+		});
 	add_bind(255, "Auto Inventory", "AutoInventory", key_category::Commands | key_category::Macros, [](int key_down)
 	{
 		if (key_down)

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -40,6 +40,7 @@ void ui_options::InitUI()
 	ui->AddComboCallback(Zeal::EqGame::Windows->Options, "Zeal_Timestamps_Combobox", [this](Zeal::EqUI::BasicWnd* wnd, int value) { ZealService::get_instance()->chat_hook->set_timestamp(value); });
 	ui->AddComboCallback(Zeal::EqGame::Windows->Options, "Zeal_MapBackground_Combobox", [this](Zeal::EqUI::BasicWnd* wnd, int value) { ZealService::get_instance()->zone_map->set_background(value); });
 	ui->AddComboCallback(Zeal::EqGame::Windows->Options, "Zeal_MapAlignment_Combobox", [this](Zeal::EqUI::BasicWnd* wnd, int value) { ZealService::get_instance()->zone_map->set_alignment(value); });
+	ui->AddComboCallback(Zeal::EqGame::Windows->Options, "Zeal_MapLabels_Combobox", [this](Zeal::EqUI::BasicWnd* wnd, int value) { ZealService::get_instance()->zone_map->set_labels_mode(value); });
 	ui->AddSliderCallback(Zeal::EqGame::Windows->Options, "Zeal_PanDelaySlider", [this](Zeal::EqUI::SliderWnd* wnd, int value) {
 		ZealService::get_instance()->camera_mods->set_pan_delay(value*4); 
 		ui->SetLabelValue("Zeal_PanDelayValueLabel", "%d ms", ZealService::get_instance()->camera_mods->pan_delay);
@@ -179,6 +180,7 @@ void ui_options::UpdateOptionsMapOnly()
 	ui->SetChecked("Zeal_Map", ZealService::get_instance()->zone_map->is_enabled());
 	ui->SetComboValue("Zeal_MapBackground_Combobox", ZealService::get_instance()->zone_map->get_background());
 	ui->SetComboValue("Zeal_MapAlignment_Combobox", ZealService::get_instance()->zone_map->get_alignment());
+	ui->SetComboValue("Zeal_MapLabels_Combobox", ZealService::get_instance()->zone_map->get_labels_mode());
 	ui->SetSliderValue("Zeal_MapZoom_Slider", (ZealService::get_instance()->zone_map->get_zoom() - 100)/15);  // 100 to 1600%
 	ui->SetSliderValue("Zeal_MapLeft_Slider", ZealService::get_instance()->zone_map->get_map_left());
 	ui->SetSliderValue("Zeal_MapWidth_Slider", ZealService::get_instance()->zone_map->get_map_width());

--- a/Zeal/zone_map.h
+++ b/Zeal/zone_map.h
@@ -4,12 +4,14 @@
 #include "EqStructures.h"
 #include "EqUI.h"
 #include "directx.h"
+#include "zone_map_data.h"
 
 class ZoneMap
 {
 public:
 	struct AlignmentType { enum e: int{ kLeft = 0, kCenter, kRight, kFirst = kLeft, kLast = kRight }; };
 	struct BackgroundType { enum e: int { kClear = 0, kDark, kLight, kTan, kFirst = kClear, kLast = kTan }; };
+	struct LabelsMode { enum e : int { kOff = 0, kSummary, kAll, kFirst = kOff, kLast = kAll }; };
 
 	static constexpr float kMaxPositionSize = 0.05f;  // In fraction of screen size.
 	static constexpr float kMaxMarkerSize = 0.05f;
@@ -19,12 +21,13 @@ public:
 
 	// UI control interface.
 	// Rect and sizes are in percentages of screen dimensions (0 to 100).
-	// Setting update_default stores to the ini and triggers a ui update.
+	// Setting update_default stores to the ini. All trigger a ui_options update.
 	bool is_enabled() const { return enabled; }
 	void set_enabled(bool enable, bool update_default = false);
 	bool set_background(int new_state, bool update_default = true); // [clear, dark, light, tan]
 	bool set_background_alpha(int percent, bool update_default = true);
 	bool set_alignment(int new_state, bool update_default = true); // [left, center, right]
+	bool set_labels_mode(int new_mode, bool update_default = true);  // [off, summary, all]
 	bool set_map_top(int top_percent, bool update_default = true, bool preserve_height = true);
 	bool set_map_left(int left_percent, bool update_default = true, bool preserve_width = true);
 	bool set_map_bottom(int bottom_percent, bool update_default = true);
@@ -38,6 +41,7 @@ public:
 	int get_background() const { return static_cast<int>(map_background_state); }
 	int get_background_alpha() const { return static_cast<int>(map_background_alpha * 100 + 0.5f); }
 	int get_alignment() const { return static_cast<int>(map_alignment_state); }
+	int get_labels_mode() const { return static_cast<int>(map_labels_mode); }
 	int get_map_top() const { return static_cast<int>(map_rect_top * 100 + 0.5f); }
 	int get_map_left() const { return static_cast<int>(map_rect_left * 100 + 0.5f); }
 	int get_map_bottom() const { return static_cast<int>(map_rect_bottom * 100 + 0.5f); }
@@ -50,6 +54,7 @@ public:
 
 	void toggle_background();
 	void toggle_zoom();
+	void toggle_labels();
 	void callback_render();
 
 private:
@@ -72,6 +77,7 @@ private:
 	void parse_marker(const std::vector<std::string>& args);
 	void parse_background(const std::vector<std::string>& args);
 	void parse_zoom(const std::vector<std::string>& args);
+	void parse_labels(const std::vector<std::string>& args);
 	void parse_poi(const std::vector<std::string>& args);
 	bool search_poi(const std::string& search);
 	void set_marker(int y, int x);
@@ -85,15 +91,19 @@ private:
 	// The following methods execute as part of callback_render().
 	void render_release_resources();
 	void render_load_map();
+	void render_load_font();
+	void render_load_labels(const ZoneMapData& zone_map_data);
 	void render_map();
 	void render_background();
 	int render_update_position_buffer();
 	void render_update_marker_buffer();
+	void render_labels();
 
 	bool enabled = false;
 	BackgroundType::e map_background_state = BackgroundType::kClear;
 	float map_background_alpha = kDefaultBackgroundAlpha;
 	AlignmentType::e map_alignment_state = AlignmentType::kFirst;
+	LabelsMode::e map_labels_mode = LabelsMode::kOff;
 	int zone_id = kInvalidZoneId;
 	int marker_zone_id = kInvalidZoneId;
 	int zoom_recenter_zone_id = kInvalidZoneId;
@@ -115,10 +125,12 @@ private:
 	float position_size = kDefaultPositionSize;
 	float marker_size = kDefaultMarkerSize;
 
+	std::vector<const ZoneMapLabel*> labels_list;  // List of pointers to visible map labels.
 	int line_count = 0;  // # of primitives in line buffer.
 	IDirect3DVertexBuffer8* line_vertex_buffer = nullptr;
 	IDirect3DVertexBuffer8* position_vertex_buffer = nullptr;
 	IDirect3DVertexBuffer8* marker_vertex_buffer = nullptr;
+	ID3DXFont* label_font = nullptr;
 };
 
 


### PR DESCRIPTION
- Modified the position marker so the directionality is more obvious
- Added map labels support and associated options window and command line control knobs
  - /map labels off,summmary,all
- DirectX 8 rendering of text is not very efficient, so there is a fps hit (especially for all), but there is zero penalty when off
- Added another keybind for toggling through label modes since it is useful to be able to toggle them on/off quickly
- DirectX drawtext required snprintf linkage so had to add legacy_stdio_definitions.lib to the project linker inputs