### PR TITLE
[melody] Allow /useitem during melody

### DIFF
--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -155,5 +155,6 @@ namespace Zeal
 		EqUI::CXWndManager* get_wnd_manager();
 		std::vector<Zeal::EqStructures::RaidMember*> get_raid_list();
 		std::string generateTimestamp();
+		bool use_item(int item_index);
 	}
 }

--- a/Zeal/melody.h
+++ b/Zeal/melody.h
@@ -9,6 +9,7 @@ public:
 	bool start(const std::vector<int>& new_songs); //returns true if no errors
 	void end();
 	void handle_stop_cast_callback(BYTE reason, WORD spell_id);
+	bool use_item(int item_index); // asks Melody to handle /useitem command. Returns true if melody handled the command.
 	Melody(class ZealService* pHookWrapper, class IO_ini* ini);
 	~Melody();
 private:
@@ -18,5 +19,6 @@ private:
 	std::vector<int> songs; // Gem indices (base 0) for melody.
 	int retry_count = 0; // Tracks unsuccessful song casts.
 	WORD casting_melody_spell_id = kInvalidSpellId; // Current melody song being cast. Is only a valid id while cast window is visible (actively casting).
+	int use_item_index = -1; // The pending use_item() to try.
+	ULONGLONG use_item_timeout = 0; // The max timestamp until the pending use_item() gives up.
 };
-


### PR DESCRIPTION
# Rules / Behavior
- `/useitem` will be allowing during melody.
- Before use, there is a 150ms delay (from the end of the song) until the click happens.
- After use, there is a 150ms delay before the Melody resumes.
- Activating an item manually (e.g. Right clicking UI or Hotbutton) still has no effect (to prevent client issues).

# Why
The reason for introducing this support is to get feature parity will old bard song twisting. Gaps in casting used to exist when twisting songs (between `/stopsong` and `/cast #`), and it was possible to use a clicky item in this gap if timed correctly. This was actually sort of trivial to perform if you bound your Song button and your item button to the same keybind, and just double tapped it.

Due to the complex nature of Melody and the Client casting state manipulation, this capability was lost due to its current implementation. With this new change, we can again have limited support for using clickies in this time interval between songs via the `/useitem` command.

# Implementation Notes
We took this approach in order to have better safety and preserve client integrity. By going through /useitem, this allows us to control safe timing gaps between songs and clickies. This avoids triggering spell timing vulnerabilities in the client.

This is also more balanced from a design side as well, by introducing a tradeoff/penalty of an additional 150ms extra delay when using a clicky item between melody songs. This wouldn't have been enforceable if players manually activated items with the native UI, and also would have been more error prone for issues/bugs.

By using the `/useitem` command, we can make sure the two code paths (useitem and Melody) are aware of each other and therefore avoid trying to both act at the same time. They can coordinate their timing to ensure the clicky is done safely each time, with predictable timing.

Directly right-clicking an item during a melody will be ignored as usual, to avoid unexpected behavior. This is handled automatically because the Melody will keep the client thinking it is in a casting/singing state at all times.

# Other Changes
- Moved `/useitem` implementation to `Zeal::EqGame::use_item(..)` so it can be shared between `/useitem` and Melody's use of it.