### PR TITLE
Add map markers for group members

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ from the repo using github actions, providing clear transparency on the contents
 - Additional commands (melody, useitem, autoinventory)
 - Additional ui support (new gauges, bag control, looting, spellsets, targetrings)
 - Third party tool support (silent log messages, direct ZealPipes)
-- Integrated (in-game) map
+- Integrated map (see In-game Map section below)
 - Various bug fixes
 - Unique npc naming for better parsing
 
@@ -124,19 +124,8 @@ ___
 
 - `/map`
   - **Arguments:** `on`, `off`, `size`, `alignment`, `marker`, `background`, `zoom`, `poi`, `labels`, `level`
-  - **Example:** `/map` toggles map on and off
-  - **Example:** `/map marker 500 -100` sets a target marker at loc 500, -100 (default size)
-  - **Example:** `/map marker 500 -100 3` sets a target marker at loc 500, -100 with size = 3% of screen
-  - **Example:** `/map 500 -100` shortcut for map marker 500 -100
-  - **Example:** `/map 0` shortcut for map marker 0 0 0 (clears marker)
-  - **Example:** `/map zoom 200` sets map scaling to 200% (2x)
-  - **Example:** `/map size 2 3 50 60` map window top=2% left=3% height=50% width=60% of screen dimensions
-  - **Example:** `/map alignment center` aligns the aspect ratio constrained map to the top center of the window
-  - **Example:** `/map poi` lists points of interest, use `/map poi 2` to drop marker at index [2] of list
-  - **Example:** `/map search_term` searches poi list for 'search_term' and drops a marker at first match
-  - **Example:** `/map labels summary` adds a selected summary list of poi text labels to the map
-  - **Example:** `/map data_mode external` loads external custom map files (Brewall format) from map_files directory
-  - **Description:** controls map enable, size, and markers
+  - **Example:** See In-game map section below
+  - **Description:** controls map enable, size, labels, zoom, and markers
     
 - `/pandelay`
   - **Arguments:** `ms delay`, `none`
@@ -301,4 +290,131 @@ ___
 #### Local builds
 Build in 32bit x86 mode using Microsoft Visual Studio 2022 (free Community edition works)
 
+
+### In-game Map
+#### Setup and configuration
+Zeal 4.0 and later includes an integrated in-game map that contains the map data for
+all zones through Planes of Power. The map is drawn into the game's DirectX viewport
+as part of the rendering sequence and is currently not 'clickable'.
+
+The map is controlled through three interfaces:
+* Dedicated EQ options window tab (requires `EQUI_Options.xml`, see Installation notes above)
+* Key binds for frequent map actions (configure in Options->Keyboard->UI)
+* The /map command
+
+The default map settings are stored in the EQClient.ini file of the root Everquest directory.
+The defaults are updated when adjusting settings in the EQ options tab. The key binds and
+/map commands are temporary changes unless the `/map save_ini` command is used.
+
+It is recommended to use the Options tab to adjust the basic map settings to the preferred
+defaults (size, position, background, marker sizes) and then use the keybinds for more
+frequent map adjustments (on/off, toggle zoom, toggle backgrounds, toggle labels,
+toggle visible levels).  The /map commands include extra options like poi search.
+
+#### Enabling the map
+* UI options checkbox
+* Key bind: "Toggle Map" - Toggles map on and off
+* Command examples:
+  - `/map` - Toggles map on and off
+  - `/map on` - Turns map on
+  - `/map off` - Turns map off
+
+#### Map size, position, and alignment
+The map is drawn to fit within rectangular limits view defined by a top left corner,
+a height, and a width. The zones have different aspect ratios, so some zones will scale
+to fill the height and others the width.  The alignment setting controls where
+the map goes when it is height constrained (top left, top center, top right).
+
+* UI options sliders for top, left, height, and width and a combobox for alignment
+* Command examples:
+  - `/map size 2 3 50 60` map window top=2% left=3% height=50% width=60% of screen dimensions
+  - `/map alignment center` aligns the aspect ratio constrained map to the top center of the window
+
+#### Map background
+The map supports four different options for the map background for contrast enhancement:
+clear (0) , dark (1), light (2), or tan (3).  Additionally, it supports alpha transparency.
+
+* UI options combo box for map background and slider for setting alpha as a percent
+* Key bind: "Toggle Map Background" - toggles through the four settings
+* Command examples:
+  - `/map background 1` sets the background to dark with no change to alpha
+  - `/map background 2 40` sets the background to light with 40% alpha
+
+#### Map zoom
+The default 100% map scale makes the entire zone visible sized to the height or width constraint.
+In zoom, the map draws all available data that fits within the rectangular viewport. The 
+view re-centers when the position marker is within 20% of an edge and moving towards that edge.
+
+* UI options slider
+* Key bind: "Toggle Map Zoom" - toggles through 100%, 200%, 400%, 800% zoom
+* Command examples:
+  - `/map zoom 200` sets map scaling to 200% (2x)
+
+#### Showing group members
+The map supports showing the live position of other group members. The group members are colored
+in this order relative to their group listing: red, orange, green, blue, purple.
+
+* UI options checkbox to enable / disable
+* Command examples:
+  - `/map show_group` toggles it on and off
+
+#### Showing map levels
+The map supports showing different levels based on the Brewall map color standards. Not all of
+the zones are properly colored, but it does work well in some of the 3-D overlapping zones.
+
+* Key bind: "Toggle Map Level Up", "Toggle Map Level Down" - toggles up or down the visible level
+* Command examples:
+  - `/map level` shows the current zone's map data level info
+  - `/map level 0` shows default of all levels
+  - `/map level 2` shows the current zone's level 2 data
+
+#### Position marker
+The map supports adding a position marker to easier identification of target coordinates.
+
+* UI options slider to adjust the marker size
+* Command examples:
+  - `/map marker 1100 -500` sets a map marker at /loc of 1100, -500
+  - `/map 1100 -500` is a shortcut for the command above to set a marker at 1100, -500
+  - `/map marker` clears the marker
+  - `/map 0` is a shortcut for clearing the marker
+
+#### Map points of interest (poi), labels, and search
+The map supports listing the available points of interest and adding them as labels to the map.
+
+Note that DirectX rendering of text is slow and this is unoptimized, so using the all setting
+for the labels can have a significant framerate impact (use keybind to toggle on and off).
+
+* UI combobox for setting the labels mode (off, summary, all)
+* Key bind: "Toggle Map Labels" - toggles through the labels modes
+* Command examples:
+  - `/map poi` lists the available poi's, including their indices
+  - `/map poi 4` drops a marker on index [4] of the `/map poi` list
+  - `/map poi butcherblock` performs a text search of the poi list for butcherblock, reports 
+     any matches, and drops a marker on the first one
+  - `/map butcherblock` shortcut for above (does not work for terms that match other commands)
+  - `/map labels summary` enables the summary labels (other options are `off` or `all`)
+
+#### Map data source
+The map has simple support for external map data files. The map data_mode can be set to `internal`,
+`both`, or `external`. In `both`, the internal maps are combined with any available data from an
+external file for that zone. In `external`, the internal map data for the zone is ignored if
+external file data exists for that zone. In all cases internal data is used if external data is
+not present.
+
+Note that some features, such as level recognition, are not currently supported with external data.
+
+The external map files must be placed in a `map_files` directory in the root everquest directory
+with zones named to match their short names (ie `map_files/commons.txt` contains the data for
+West Commonlands).  An optional, `_1.txt` file (ie `map_files/commons_1.txt`) will also be
+parsed if present, so Brewall map files with POIs can be directly dropped in.
+
+The external map support requires a format compatible with Brewall map data.
+```
+L x0, y0, z0, x1, y1, z1, red, green, blue
+P x, y, z, red, green, blue, ignored, label_string
+```
+
+* Command examples:
+  - `/map data_mode both` adds external zone map file data if present to internal maps
+  - `/map data_mode external` uses external zone map files if present to replace internal maps
 

--- a/Zeal/GameXML/EQUI_OptionsWindow.xml
+++ b/Zeal/GameXML/EQUI_OptionsWindow.xml
@@ -5506,6 +5506,37 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
+  <!-- Zeal Map On/Off-->
+  <Button item="Zeal_MapShowGroup">
+    <ScreenID>Zeal_MapShowGroup</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>252</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Shows group members on map</TooltipReference>
+    <Text>Show Group</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
   <!-- Zeal Map Left -->
   <Label item="Zeal_MapLeft_Label">
     <ScreenID>Zeal_MapLeft_Label</ScreenID>
@@ -6050,7 +6081,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>268</Y>
+      <Y>282</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -6133,6 +6164,7 @@
     </TabTextActiveColor>
     <Style_Sizable>true</Style_Sizable>
     <Pieces>Zeal_Map</Pieces>
+    <Pieces>Zeal_MapShowGroup</Pieces>
     <Pieces>Zeal_MapLeft_Label</Pieces>
     <Pieces>Zeal_MapLeft_Slider</Pieces>
     <Pieces>Zeal_MapLeft_Value</Pieces>

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -37,6 +37,7 @@ void ui_options::InitUI()
 	ui->AddCheckboxCallback(Zeal::EqGame::Windows->Options, "Zeal_ClassicClasses", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->chat_hook->set_classes(wnd->Checked); });
 	ui->AddCheckboxCallback(Zeal::EqGame::Windows->Options, "Zeal_TellWindows", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->tells->SetEnabled(wnd->Checked); });
 	ui->AddCheckboxCallback(Zeal::EqGame::Windows->Options, "Zeal_Map", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->zone_map->set_enabled(wnd->Checked, true); });
+	ui->AddCheckboxCallback(Zeal::EqGame::Windows->Options, "Zeal_MapShowGroup", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->zone_map->set_show_group(wnd->Checked); });
 	ui->AddComboCallback(Zeal::EqGame::Windows->Options, "Zeal_Timestamps_Combobox", [this](Zeal::EqUI::BasicWnd* wnd, int value) { ZealService::get_instance()->chat_hook->set_timestamp(value); });
 	ui->AddComboCallback(Zeal::EqGame::Windows->Options, "Zeal_MapBackground_Combobox", [this](Zeal::EqUI::BasicWnd* wnd, int value) { ZealService::get_instance()->zone_map->set_background(value); });
 	ui->AddComboCallback(Zeal::EqGame::Windows->Options, "Zeal_MapAlignment_Combobox", [this](Zeal::EqUI::BasicWnd* wnd, int value) { ZealService::get_instance()->zone_map->set_alignment(value); });
@@ -178,6 +179,7 @@ void ui_options::UpdateOptions()
 void ui_options::UpdateOptionsMapOnly()
 {
 	ui->SetChecked("Zeal_Map", ZealService::get_instance()->zone_map->is_enabled());
+	ui->SetChecked("Zeal_MapShowGroup", ZealService::get_instance()->zone_map->is_show_group_enabled());
 	ui->SetComboValue("Zeal_MapBackground_Combobox", ZealService::get_instance()->zone_map->get_background());
 	ui->SetComboValue("Zeal_MapAlignment_Combobox", ZealService::get_instance()->zone_map->get_alignment());
 	ui->SetComboValue("Zeal_MapLabels_Combobox", ZealService::get_instance()->zone_map->get_labels_mode());

--- a/Zeal/zone_map.cpp
+++ b/Zeal/zone_map.cpp
@@ -665,7 +665,7 @@ void ZoneMap::add_group_member_position_vertices(std::vector<MapVertex>& vertice
     for (int i = 0; i < EQ_NUM_GROUP_MEMBERS; ++i) {
         Zeal::EqStructures::Entity* member = groupEntityPtrs[i];
         if ((strlen(groupNames[i]) == 0) || !member)
-            continue;  // Not a valid group member.
+            continue;  // Not a valid group member (or member = nullptr when out of zone).
 
         float screen_y = -member->Position.x * scale_factor + offset_y;  // Position is y,x,z.
         float screen_x = -member->Position.y * scale_factor + offset_x;

--- a/Zeal/zone_map.h
+++ b/Zeal/zone_map.h
@@ -13,6 +13,11 @@
 class ZoneMap
 {
 public:
+	struct MapVertex {
+		float x, y, z, rhw;  // Position coordinates and rhw (D3DFVF_XYZRHW).
+		D3DCOLOR color; // Color from the D3DFVF_DIFFUSE flag.
+	};
+
 	struct AlignmentType { enum e : int { kLeft = 0, kCenter, kRight, kFirst = kLeft, kLast = kRight }; };
 	struct BackgroundType { enum e : int { kClear = 0, kDark, kLight, kTan, kFirst = kClear, kLast = kTan }; };
 	struct LabelsMode { enum e : int { kOff = 0, kSummary, kAll, kFirst = kOff, kLast = kAll }; };
@@ -29,6 +34,7 @@ public:
 	// Setting update_default stores to the ini. All trigger a ui_options update.
 	bool is_enabled() const { return enabled; }
 	void set_enabled(bool enable, bool update_default = false);
+	void set_show_group(bool enable, bool update_default = true);
 	bool set_map_data_mode(int new_mode, bool update_default = true);
 	bool set_background(int new_state, bool update_default = true); // [clear, dark, light, tan]
 	bool set_background_alpha(int percent, bool update_default = true);
@@ -44,6 +50,7 @@ public:
 	bool set_marker_size(int new_size_percent, bool update_default = true);
 	bool set_zoom(int zoom_percent);  // Note: 100% = 1x.
 
+	bool is_show_group_enabled() const { return map_show_group; }
 	int get_map_data_mode() const { return static_cast<int>(map_data_mode); }
 	int get_background() const { return static_cast<int>(map_background_state); }
 	int get_background_alpha() const { return static_cast<int>(map_background_alpha * 100 + 0.5f); }
@@ -110,6 +117,7 @@ private:
 	void parse_labels(const std::vector<std::string>& args);
 	void parse_level(const std::vector<std::string>& args);
 	void parse_map_data_mode(const std::vector<std::string>& args);
+	void parse_show_group(const std::vector<std::string>& args);
 	void parse_poi(const std::vector<std::string>& args);
 	bool search_poi(const std::string& search);
 	void set_marker(int y, int x);
@@ -136,6 +144,10 @@ private:
 	void render_update_marker_buffer();
 	void render_labels();
 	void render_label_text(const char* label, int y, int x, D3DCOLOR font_color);
+	bool render_check_for_zoom_recenter();
+	void add_position_marker_vertices(float screen_y, float screen_x, float heading, float size,
+		D3DCOLOR color, std::vector<MapVertex>& vertices) const;
+	void add_group_member_position_vertices(std::vector<MapVertex>& vertices) const;
 
 	const ZoneMapData* get_zone_map(int zone_id);
 	void add_map_data_from_internal(const ZoneMapData& internal_map, CustomMapData& map_data);
@@ -143,6 +155,7 @@ private:
 	void assemble_zone_map(const char* zone_name, CustomMapData& map_data);
 
 	bool enabled = false;
+	bool map_show_group = false;
 	BackgroundType::e map_background_state = BackgroundType::kClear;
 	float map_background_alpha = kDefaultBackgroundAlpha;
 	AlignmentType::e map_alignment_state = AlignmentType::kFirst;
@@ -150,7 +163,6 @@ private:
 	MapDataMode::e map_data_mode = MapDataMode::kInternal;
 	int zone_id = kInvalidZoneId;
 	int marker_zone_id = kInvalidZoneId;
-	int zoom_recenter_zone_id = kInvalidZoneId;
 	bool always_align_to_center = false;
 	int marker_x = 0;
 	int marker_y = 0;


### PR DESCRIPTION
- Added additional position markers to show group members on map
 - Group member markers are 80%-sized and roygbiv colored
- Updated options xml to have a "Show group" checkbox and added a /map show_group toggle
- Refined the re-center trigger logic some more