### PR TITLE
Add map markers for raid members

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 ### Description
 Zeal adds quality of life functionality to the legacy (2002) Everquest client
 used by most TAKP EqEMU players. The Miles Sound System used by that client
-supports plug-ins for arbitrary filtering, and Zeal injects itself into the
+supports plug-ins for arbitrary audio filtering, and Zeal injects itself into the
 client like a standard dll by using the .asi extension in the EQ root directory.
 It can then patch itself into the client's processing loop and callbacks to
 add new functionality and smooth out issues in the old client.
 
 Zeal custom code is entirely open source and the releases are built directly
-from the repo using github actions, providing clear transparency on the contents.
+from the repo using github actions, providing full transparency on the contents.
 
 ### Features
-- Camera motion improvements
+- Camera motion improvements (major improvements to third person view)
 - Additional key binds (tab targeting, strafe, pet)
 - Additional commands (melody, useitem, autoinventory)
 - Additional ui support (new gauges, bag control, looting, spellsets, targetrings)
@@ -350,13 +350,19 @@ view re-centers when the position marker is within 20% of an edge and moving tow
 * Command examples:
   - `/map zoom 200` sets map scaling to 200% (2x)
 
-#### Showing group members
-The map supports showing the live position of other group members. The group members are colored
-in this order relative to their group listing: red, orange, green, blue, purple.
+#### Showing group and raid members
+The map supports showing the live position of other group and raid members. The group
+member markers are slighly shrunken player position markers and colored in this order
+relative to their group listing: red, orange, green, blue, purple. The raid member
+markers are simple fixed triangles with varying color.  Since there are a high number
+of potential raid members, it is recommended to not use the persistent Show Raid checkbox
+in the options tab and instead use the key bind to situationally toggle it on and off.
 
-* UI options checkbox to enable / disable
+* UI options checkbox to enable / disable (one each for group and raid)
+* Key bind: "Toggle Show Raid" - Toggles visibility of raid members
 * Command examples:
-  - `/map show_group` toggles it on and off
+  - `/map show_group` toggles the group member markers on and off
+  - `/map show_raid` toggles the raid member markers on and off
 
 #### Showing map levels
 The map supports showing different levels based on the Brewall map color standards. Not all of

--- a/Zeal/EntityManager.cpp
+++ b/Zeal/EntityManager.cpp
@@ -21,6 +21,16 @@ void EntityManager::Remove(struct Zeal::EqStructures::Entity* ent)
 	}
 }
 
+Zeal::EqStructures::Entity* EntityManager::Get(const char* name) const {
+	auto it = player_map.find(name);
+	return (it == player_map.end()) ? nullptr : it->second;
+}
+
+void EntityManager::Dump() const {
+	for (const auto& [key, value] : player_map)
+		Zeal::EqGame::print_chat("name: %s, entity: 0x%08x", key.c_str(), reinterpret_cast<uint32_t>(value));
+}
+
 EntityManager::EntityManager(class ZealService* zeal, class IO_ini* ini)
 {
 	zeal->callbacks->AddEntity([this](struct Zeal::EqStructures::Entity* ent) { Remove(ent); }, callback_type::EntityDespawn );

--- a/Zeal/EntityManager.h
+++ b/Zeal/EntityManager.h
@@ -3,13 +3,19 @@
 #include "EqStructures.h"
 #include <stdint.h>
 #include <unordered_map>
+#include <string>
+
 class EntityManager
 {
 public:
-	std::unordered_map<const char*, struct Zeal::EqStructures::Entity*> player_map;
 	EntityManager(class ZealService* zeal, class IO_ini* ini);
 	~EntityManager();
 	void Add(struct Zeal::EqStructures::Entity*);
 	void Remove(struct Zeal::EqStructures::Entity*);
+	Zeal::EqStructures::Entity* Get(const char* name) const;  // Returns nullptr if not found.
+	void Dump() const;
+
+private:
+	std::unordered_map<std::string, struct Zeal::EqStructures::Entity*> player_map;
 };
 

--- a/Zeal/GameXML/EQUI_OptionsWindow.xml
+++ b/Zeal/GameXML/EQUI_OptionsWindow.xml
@@ -5506,7 +5506,7 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
-  <!-- Zeal Map On/Off-->
+  <!-- Zeal Map Show Group Members-->
   <Button item="Zeal_MapShowGroup">
     <ScreenID>Zeal_MapShowGroup</ScreenID>
     <RelativePosition>true</RelativePosition>
@@ -5524,6 +5524,37 @@
     <Style_Checkbox>true</Style_Checkbox>
     <TooltipReference>Shows group members on map</TooltipReference>
     <Text>Show Group</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <!-- Zeal Map Show Raid Members-->
+  <Button item="Zeal_MapShowRaid">
+    <ScreenID>Zeal_MapShowRaid</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>282</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Shows raid members on map</TooltipReference>
+    <Text>Show Raid</Text>
     <TextColor>
       <R>255</R>
       <G>255</G>
@@ -6081,7 +6112,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>282</Y>
+      <Y>312</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -6165,6 +6196,7 @@
     <Style_Sizable>true</Style_Sizable>
     <Pieces>Zeal_Map</Pieces>
     <Pieces>Zeal_MapShowGroup</Pieces>
+    <Pieces>Zeal_MapShowRaid</Pieces>
     <Pieces>Zeal_MapLeft_Label</Pieces>
     <Pieces>Zeal_MapLeft_Slider</Pieces>
     <Pieces>Zeal_MapLeft_Value</Pieces>

--- a/Zeal/binds.cpp
+++ b/Zeal/binds.cpp
@@ -288,6 +288,13 @@ void Binds::add_binds()
 			ZealService::get_instance()->zone_map->toggle_level_down();
 		}
 		});
+	add_bind(234, "Toggle Show Raid", "ToggleShowRaid", key_category::UI, [this](int key_down) {
+		if (key_down && !Zeal::EqGame::EqGameInternal::UI_ChatInputCheck())
+		{
+			ZealService::get_instance()->zone_map->set_show_raid(
+				!ZealService::get_instance()->zone_map->is_show_raid_enabled(), false);
+		}
+		});
 	add_bind(255, "Auto Inventory", "AutoInventory", key_category::Commands | key_category::Macros, [](int key_down)
 	{
 		if (key_down)

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -38,6 +38,7 @@ void ui_options::InitUI()
 	ui->AddCheckboxCallback(Zeal::EqGame::Windows->Options, "Zeal_TellWindows", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->tells->SetEnabled(wnd->Checked); });
 	ui->AddCheckboxCallback(Zeal::EqGame::Windows->Options, "Zeal_Map", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->zone_map->set_enabled(wnd->Checked, true); });
 	ui->AddCheckboxCallback(Zeal::EqGame::Windows->Options, "Zeal_MapShowGroup", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->zone_map->set_show_group(wnd->Checked); });
+	ui->AddCheckboxCallback(Zeal::EqGame::Windows->Options, "Zeal_MapShowRaid", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->zone_map->set_show_raid(wnd->Checked); });
 	ui->AddComboCallback(Zeal::EqGame::Windows->Options, "Zeal_Timestamps_Combobox", [this](Zeal::EqUI::BasicWnd* wnd, int value) { ZealService::get_instance()->chat_hook->set_timestamp(value); });
 	ui->AddComboCallback(Zeal::EqGame::Windows->Options, "Zeal_MapBackground_Combobox", [this](Zeal::EqUI::BasicWnd* wnd, int value) { ZealService::get_instance()->zone_map->set_background(value); });
 	ui->AddComboCallback(Zeal::EqGame::Windows->Options, "Zeal_MapAlignment_Combobox", [this](Zeal::EqUI::BasicWnd* wnd, int value) { ZealService::get_instance()->zone_map->set_alignment(value); });
@@ -181,6 +182,7 @@ void ui_options::UpdateOptionsMapOnly()
 {
 	ui->SetChecked("Zeal_Map", ZealService::get_instance()->zone_map->is_enabled());
 	ui->SetChecked("Zeal_MapShowGroup", ZealService::get_instance()->zone_map->is_show_group_enabled());
+	ui->SetChecked("Zeal_MapShowRaid", ZealService::get_instance()->zone_map->is_show_raid_enabled());
 	ui->SetComboValue("Zeal_MapBackground_Combobox", ZealService::get_instance()->zone_map->get_background());
 	ui->SetComboValue("Zeal_MapAlignment_Combobox", ZealService::get_instance()->zone_map->get_alignment());
 	ui->SetComboValue("Zeal_MapLabels_Combobox", ZealService::get_instance()->zone_map->get_labels_mode());

--- a/Zeal/zone_map.h
+++ b/Zeal/zone_map.h
@@ -155,7 +155,7 @@ private:
 	void add_raid_marker_vertices(float screen_y, float screen_x, float size,
 		D3DCOLOR color, std::vector<MapVertex>& vertices) const;
 
-		const ZoneMapData* get_zone_map(int zone_id);
+	const ZoneMapData* get_zone_map(int zone_id);
 	void add_map_data_from_internal(const ZoneMapData& internal_map, CustomMapData& map_data);
 	bool add_map_data_from_file(const std::string& filename, CustomMapData& map_data);
 	void assemble_zone_map(const char* zone_name, CustomMapData& map_data);

--- a/Zeal/zone_map.h
+++ b/Zeal/zone_map.h
@@ -35,6 +35,7 @@ public:
 	bool is_enabled() const { return enabled; }
 	void set_enabled(bool enable, bool update_default = false);
 	void set_show_group(bool enable, bool update_default = true);
+	void set_show_raid(bool enable, bool update_default = true);
 	bool set_map_data_mode(int new_mode, bool update_default = true);
 	bool set_background(int new_state, bool update_default = true); // [clear, dark, light, tan]
 	bool set_background_alpha(int percent, bool update_default = true);
@@ -51,6 +52,7 @@ public:
 	bool set_zoom(int zoom_percent);  // Note: 100% = 1x.
 
 	bool is_show_group_enabled() const { return map_show_group; }
+	bool is_show_raid_enabled() const { return map_show_raid; }
 	int get_map_data_mode() const { return static_cast<int>(map_data_mode); }
 	int get_background() const { return static_cast<int>(map_background_state); }
 	int get_background_alpha() const { return static_cast<int>(map_background_alpha * 100 + 0.5f); }
@@ -118,6 +120,7 @@ private:
 	void parse_level(const std::vector<std::string>& args);
 	void parse_map_data_mode(const std::vector<std::string>& args);
 	void parse_show_group(const std::vector<std::string>& args);
+	void parse_show_raid(const std::vector<std::string>& args);
 	void parse_poi(const std::vector<std::string>& args);
 	bool search_poi(const std::string& search);
 	void set_marker(int y, int x);
@@ -148,14 +151,18 @@ private:
 	void add_position_marker_vertices(float screen_y, float screen_x, float heading, float size,
 		D3DCOLOR color, std::vector<MapVertex>& vertices) const;
 	void add_group_member_position_vertices(std::vector<MapVertex>& vertices) const;
+	void add_raid_member_position_vertices(std::vector<MapVertex>& vertices) const;
+	void add_raid_marker_vertices(float screen_y, float screen_x, float size,
+		D3DCOLOR color, std::vector<MapVertex>& vertices) const;
 
-	const ZoneMapData* get_zone_map(int zone_id);
+		const ZoneMapData* get_zone_map(int zone_id);
 	void add_map_data_from_internal(const ZoneMapData& internal_map, CustomMapData& map_data);
 	bool add_map_data_from_file(const std::string& filename, CustomMapData& map_data);
 	void assemble_zone_map(const char* zone_name, CustomMapData& map_data);
 
 	bool enabled = false;
 	bool map_show_group = false;
+	bool map_show_raid = false;
 	BackgroundType::e map_background_state = BackgroundType::kClear;
 	float map_background_alpha = kDefaultBackgroundAlpha;
 	AlignmentType::e map_alignment_state = AlignmentType::kFirst;


### PR DESCRIPTION
- Added additional position markers to show raid members on map
  - Raid member markers are small simple fixed triangles with some color coding per leader and per group
  - Updated options xml to have a "Show raid" checkbox and added a /map show_raid toggle