### PR TITLE
Added NameplateColors to Zeal

### DIFF
--- a/Zeal/EqStructures.h
+++ b/Zeal/EqStructures.h
@@ -98,7 +98,6 @@
 #define USERCOLOR_ECHO_CHAT_8           0xFF +  67 //  67 - chat 8 echo
 #define USERCOLOR_ECHO_CHAT_9           0xFF +  68 //  68 - chat 9 echo
 #define USERCOLOR_ECHO_CHAT_10          0xFF +  69 //  69 - chat 10 echo
-#define USERCOLOR_ECHO_AUTOSPLIT        0xFF +  73 
 
 constexpr WORD kInvalidSpellId = 0xffff; // spell_id used when not casting or empty spell gem
 
@@ -367,6 +366,43 @@ namespace Zeal
 			/* 0x00EC */ struct _EQDAGCHILDREN* Children;
 			/* ...... */
 		};
+		struct _EQARGBCOLOR {
+			union {
+				struct {
+					BYTE B;
+					BYTE G;
+					BYTE R;
+					BYTE A;
+				};
+				DWORD ARGB;
+			};
+			_EQARGBCOLOR(BYTE _R, BYTE _G, BYTE _B, BYTE _A) : A(_A), R(_R), G(_G), B(_B) {};
+			_EQARGBCOLOR(DWORD _ARGB) : ARGB(_ARGB) {};
+			_EQARGBCOLOR() : A{}, R{}, G{}, B{} {};
+
+		};
+		typedef struct _EQSTRINGSPRITE
+		{
+			/* 0x0000 */ DWORD Unknown0000;
+			/* 0x0004 */ DWORD Unknown0004;
+			/* 0x0008 */ DWORD Unknown0008;
+			/* 0x000C */ DWORD Unknown000C;
+			/* 0x0010 */ DWORD Unknown0010;
+			/* 0x0014 */ PVOID Unknown0014;
+			/* 0x0018 */ PCHAR Text;
+			/* 0x001C */ DWORD TextLength;
+			/* 0x0020 */ DWORD Unknown0020;
+			/* 0x0024 */ DWORD MaxScaleFactor1;
+			/* 0x0028 */ FLOAT MaxScaleFactor2;
+			/* 0x002C */ FLOAT MaxScaleFactor3;
+			/* 0x0030 */ DWORD IsYonClipEnabled;
+			/* 0x0034 */ DWORD YonClipDistance;
+			/* 0x0038 */ FLOAT Unknown0038;
+			/* 0x003C */ DWORD Width;
+			/* 0x0040 */ DWORD Height;
+			/* 0x0044 */ FLOAT Unknown0044;
+			/* 0x0048 */ Zeal::EqStructures::_EQARGBCOLOR Color;
+		} EQSTRINGSPRITE, * PEQSTRINGSPRITE;
 		struct ActorInfo
 		{
 			//UINT ModifyAttackSpeed()

--- a/Zeal/EqStructures.h
+++ b/Zeal/EqStructures.h
@@ -367,7 +367,7 @@ namespace Zeal
 			/* 0x00EC */ struct _EQDAGCHILDREN* Children;
 			/* ...... */
 		};
-		struct _EQARGBCOLOR {
+		typedef struct _EQARGBCOLOR {
 			union {
 				struct {
 					BYTE B;
@@ -381,7 +381,7 @@ namespace Zeal
 			_EQARGBCOLOR(DWORD _ARGB) : ARGB(_ARGB) {};
 			_EQARGBCOLOR() : A{}, R{}, G{}, B{} {};
 
-		};
+		} EQARGBCOLOR;
 		typedef struct _EQSTRINGSPRITE
 		{
 			/* 0x0000 */ DWORD Unknown0000;
@@ -402,7 +402,7 @@ namespace Zeal
 			/* 0x003C */ DWORD Width;
 			/* 0x0040 */ DWORD Height;
 			/* 0x0044 */ FLOAT Unknown0044;
-			/* 0x0048 */ Zeal::EqStructures::_EQARGBCOLOR Color;
+			/* 0x0048 */ EQARGBCOLOR Color;
 		} EQSTRINGSPRITE, * PEQSTRINGSPRITE;
 		struct ActorInfo
 		{

--- a/Zeal/EqStructures.h
+++ b/Zeal/EqStructures.h
@@ -367,7 +367,7 @@ namespace Zeal
 			/* 0x00EC */ struct _EQDAGCHILDREN* Children;
 			/* ...... */
 		};
-		typedef struct _EQARGBCOLOR {
+				typedef struct _EQARGBCOLOR {
 			union {
 				struct {
 					BYTE B;

--- a/Zeal/EqStructures.h
+++ b/Zeal/EqStructures.h
@@ -98,6 +98,7 @@
 #define USERCOLOR_ECHO_CHAT_8           0xFF +  67 //  67 - chat 8 echo
 #define USERCOLOR_ECHO_CHAT_9           0xFF +  68 //  68 - chat 9 echo
 #define USERCOLOR_ECHO_CHAT_10          0xFF +  69 //  69 - chat 10 echo
+#define USERCOLOR_ECHO_AUTOSPLIT        0xFF +  73 
 
 constexpr WORD kInvalidSpellId = 0xffff; // spell_id used when not casting or empty spell gem
 

--- a/Zeal/binds.cpp
+++ b/Zeal/binds.cpp
@@ -233,7 +233,7 @@ void Binds::add_binds()
 	add_bind(225, "Auto Fire", "AutoFire", key_category::Commands, [this](int key_down) {
 		if (key_down && !Zeal::EqGame::EqGameInternal::UI_ChatInputCheck())
 		{
-			ZealService::get_instance()->autofire->SetAutoFire(!ZealService::get_instance()->autofire->autofire, true);
+			ZealService::get_instance()->autofire->SetAutoFire(!ZealService::get_instance()->autofire->autofire);
 		}
 		});
 	add_bind(226, "Target Nearest NPC Corpse", "TargetNPCCorpse", key_category::Target, [](int key_down) {
@@ -294,6 +294,10 @@ void Binds::add_binds()
 			ZealService::get_instance()->zone_map->set_show_raid(
 				!ZealService::get_instance()->zone_map->is_show_raid_enabled(), false);
 		}
+		});
+	add_bind(235, "Toggle Nameplate Colors", "ToggleNameplateColors", key_category::Target, [this](int key_down) {
+		if (key_down && !Zeal::EqGame::EqGameInternal::UI_ChatInputCheck())
+			ZealService::get_instance()->nameplate->set_enabled(!ZealService::get_instance()->nameplate->is_enabled());
 		});
 	add_bind(255, "Auto Inventory", "AutoInventory", key_category::Commands | key_category::Macros, [](int key_down)
 	{

--- a/Zeal/binds.cpp
+++ b/Zeal/binds.cpp
@@ -297,7 +297,11 @@ void Binds::add_binds()
 		});
 	add_bind(235, "Toggle Nameplate Colors", "ToggleNameplateColors", key_category::Target, [this](int key_down) {
 		if (key_down && !Zeal::EqGame::EqGameInternal::UI_ChatInputCheck())
-			ZealService::get_instance()->nameplate->set_enabled(!ZealService::get_instance()->nameplate->is_enabled());
+			ZealService::get_instance()->nameplate->colors_set_enabled(!ZealService::get_instance()->nameplate->colors_is_enabled());
+		});
+	add_bind(236, "Toggle Nameplate Con Colors", "ToggleNameplateConColors", key_category::Target, [this](int key_down) {
+		if (key_down && !Zeal::EqGame::EqGameInternal::UI_ChatInputCheck())
+			ZealService::get_instance()->nameplate->con_colors_set_enabled(!ZealService::get_instance()->nameplate->con_colors_is_enabled());
 		});
 	add_bind(255, "Auto Inventory", "AutoInventory", key_category::Commands | key_category::Macros, [](int key_down)
 	{

--- a/Zeal/binds.cpp
+++ b/Zeal/binds.cpp
@@ -295,7 +295,7 @@ void Binds::add_binds()
 				!ZealService::get_instance()->zone_map->is_show_raid_enabled(), false);
 		}
 		});
-	add_bind(235, "Toggle Nameplate Colors", "ToggleNameplateColors", key_category::Target, [this](int key_down) {
+			add_bind(235, "Toggle Nameplate Colors", "ToggleNameplateColors", key_category::Target, [this](int key_down) {
 		if (key_down && !Zeal::EqGame::EqGameInternal::UI_ChatInputCheck())
 			ZealService::get_instance()->nameplate->colors_set_enabled(!ZealService::get_instance()->nameplate->colors_is_enabled());
 		});

--- a/Zeal/binds.cpp
+++ b/Zeal/binds.cpp
@@ -233,7 +233,7 @@ void Binds::add_binds()
 	add_bind(225, "Auto Fire", "AutoFire", key_category::Commands, [this](int key_down) {
 		if (key_down && !Zeal::EqGame::EqGameInternal::UI_ChatInputCheck())
 		{
-			ZealService::get_instance()->autofire->SetAutoFire(!ZealService::get_instance()->autofire->autofire);
+			ZealService::get_instance()->autofire->SetAutoFire(!ZealService::get_instance()->autofire->autofire, true);
 		}
 		});
 	add_bind(226, "Target Nearest NPC Corpse", "TargetNPCCorpse", key_category::Target, [](int key_down) {

--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -3,6 +3,8 @@
 #include "EqAddresses.h"
 #include "string_util.h"
 
+bool nameplatecolorsEnabled = true;
+
 struct CachedNameData
 {
 	int unk1;
@@ -37,11 +39,90 @@ int DeferCachedNameTagTextW(int font_size, CachedNameData* cnd, int a1, int a2, 
 	//}
 }
 
+int __fastcall SetNameSpriteTint(void* this_ptr, void* not_used, Zeal::EqStructures::Entity* spawn)
+{	
+	int result = ZealService::get_instance()->hooks->hook_map["SetNameSpriteTint"]->original(SetNameSpriteTint)(this_ptr, not_used, spawn);
+	if (spawn == NULL) { return result; }
+	if (spawn->ActorInfo->DagHeadPoint == NULL) { return result; }
+	if (spawn->ActorInfo->DagHeadPoint->StringSprite == NULL) { return result; }
+	if (nameplatecolorsEnabled) {
+		int maxGroupMembers = 5;
+		int maxRaidMembers = 72;
+		Zeal::EqStructures::Entity** groupmembers = reinterpret_cast<Zeal::EqStructures::Entity**>(Zeal::EqGame::GroupList);
+		Zeal::EqStructures::RaidMember* raidMembers = reinterpret_cast<Zeal::EqStructures::RaidMember*>(Zeal::EqGame::RaidMemberList);
+		switch (spawn->Type) {
+		case 0: //Players
+			if (spawn == Zeal::EqGame::get_target()) //Leave blinking indicator on target
+				return result;
+			if (raidMembers){
+				for (int i = 0; i < maxRaidMembers; ++i) //Raid Member loop
+				{
+					Zeal::EqStructures::RaidMember member = raidMembers[i];
+					if ((member.GroupNumber == 0xFFFFFFFE) || (strlen(member.Name) == 0) || (strcmp(member.Name, Zeal::EqGame::get_self()->Name) == 0))
+						continue;
+					Zeal::EqStructures::Entity* raidMember = ZealService::get_instance()->entity_manager->Get(member.Name);
+					if (!raidMember)
+						continue;
+					if (spawn == raidMember)
+						raidMember->ActorInfo->DagHeadPoint->StringSprite->Color = 0xFF000000; //Raid Member-Black
+				}
+			}
+			if (spawn->GuildId == Zeal::EqGame::get_self()->GuildId) //Guild Member
+				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = 0xFF00FF80; //Guild Member-Greenish Blue
+				//spawn->ActorInfo->DagHeadPoint->StringSprite->Color = 0xFF80FF80; //Guild Member-White Green
+			if (groupmembers) {
+				for (int i = 0; i < maxGroupMembers; ++i) //Group Member loop
+				{
+					Zeal::EqStructures::Entity* groupmember = groupmembers[i];
+					if (spawn == groupmember)
+						spawn->ActorInfo->DagHeadPoint->StringSprite->Color = 0x0500FF32; //Group Member-Light Green 
+					continue;
+				}
+			}
+			if (spawn->IsLinkDead == 1) //LinkDead
+				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = 0xFFFF0000; //LinkDead - Red
+			else if (spawn->IsAwayFromKeyboard == 1) //AFK
+				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = 0xFFFF8000; //AFK - Orange	
+			break;
+		case 1: //NPC
+			break;
+		case 2: //NPC Corpse
+			break;
+		case 3: //Player Corpse
+			break;
+		default:
+			break;
+		}
+	}
+	return result;
+}
+
+void NamePlate::set_enabled(bool _enabled)
+{
+	_enabled = !nameplatecolorsEnabled;
+	ZealService::get_instance()->ini->setValue<bool>("Zeal", "NameplateColors", _enabled);
+	nameplatecolorsEnabled = !nameplatecolorsEnabled;
+	Zeal::EqGame::print_chat("NameplateColors are %s", _enabled ? "Enabled" : "Disabled");
+}
+
 NamePlate::NamePlate(ZealService* zeal, IO_ini* ini)
 {
 	HMODULE eqfx = GetModuleHandleA("eqgfx_dx8.dll");
 	if (eqfx)
 		zeal->hooks->Add("DeferCachedNameTagTextW", (DWORD)eqfx + 0x70A00, DeferCachedNameTagTextW, hook_type_detour);
+	if (nameplatecolorsEnabled)
+		zeal->hooks->Add("SetNameSpriteTint", 0x4B114D, SetNameSpriteTint, hook_type_detour);
+	
+	if (!ini->exists("Zeal", "NameplateColors")) 
+		ini->setValue<bool>("Zeal", "NameplateColors", false);
+	if (ini->exists("Zeal", "NameplateColors"))
+		nameplatecolorsEnabled = ini->getValue<bool>("Zeal", "NameplateColors");
+
+	zeal->commands_hook->Add("/nameplatecolors", {}, "Toggles Nameplate Colors",
+		[this](std::vector<std::string>& args) {
+			set_enabled(!ZealService::get_instance()->nameplate->is_enabled());
+			return true;
+		});
 }
 
 NamePlate::~NamePlate()

--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -135,7 +135,7 @@ NamePlate::NamePlate(ZealService* zeal, IO_ini* ini)
 	if (!ini->exists("Zeal", "NameplateConColors"))
 		ini->setValue<bool>("Zeal", "NameplateConColors", false);
 	if (ini->exists("Zeal", "NameplateConColors"))
-		nameplatecolorsEnabled = ini->getValue<bool>("Zeal", "NameplateConColors");
+		nameplateconcolorsEnabled = ini->getValue<bool>("Zeal", "NameplateConColors");
 
 	zeal->commands_hook->Add("/nameplatecolors", {}, "Toggles Nameplate Colors",
 		[this](std::vector<std::string>& args) {

--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -46,44 +46,45 @@ int __fastcall SetNameSpriteTint(void* this_ptr, void* not_used, Zeal::EqStructu
 	if (spawn == NULL) { return result; }
 	if (spawn->ActorInfo->DagHeadPoint == NULL) { return result; }
 	if (spawn->ActorInfo->DagHeadPoint->StringSprite == NULL) { return result; }
-	if (nameplatecolorsEnabled) {
-		int maxGroupMembers = 5;
-		int maxRaidMembers = 72;
-		Zeal::EqStructures::Entity** groupmembers = reinterpret_cast<Zeal::EqStructures::Entity**>(Zeal::EqGame::GroupList);
-		Zeal::EqStructures::RaidMember* raidMembers = reinterpret_cast<Zeal::EqStructures::RaidMember*>(Zeal::EqGame::RaidMemberList);
-		switch (spawn->Type) {
+	switch (spawn->Type) {
 		case 0: //Players
-			if (spawn == Zeal::EqGame::get_target()) //Leave blinking indicator on target
-				return result;
-			if (raidMembers){
-				for (int i = 0; i < maxRaidMembers; ++i) //Raid Member loop
-				{
-					Zeal::EqStructures::RaidMember member = raidMembers[i];
-					if ((member.GroupNumber == 0xFFFFFFFE) || (strlen(member.Name) == 0) || (strcmp(member.Name, Zeal::EqGame::get_self()->Name) == 0))
-						continue;
-					Zeal::EqStructures::Entity* raidMember = ZealService::get_instance()->entity_manager->Get(member.Name);
-					if (!raidMember)
-						continue;
-					if (spawn == raidMember)
-						raidMember->ActorInfo->DagHeadPoint->StringSprite->Color = 0xFF000000; //Raid Member-Black
+			if (nameplatecolorsEnabled) {
+				int maxGroupMembers = 5;
+				int maxRaidMembers = 72;
+				Zeal::EqStructures::Entity** groupmembers = reinterpret_cast<Zeal::EqStructures::Entity**>(Zeal::EqGame::GroupList);
+				Zeal::EqStructures::RaidMember* raidMembers = reinterpret_cast<Zeal::EqStructures::RaidMember*>(Zeal::EqGame::RaidMemberList);
+				if (spawn == Zeal::EqGame::get_target()) //Leave blinking indicator on target
+					return result;
+				if (raidMembers){
+					for (int i = 0; i < maxRaidMembers; ++i) //Raid Member loop
+					{
+						Zeal::EqStructures::RaidMember member = raidMembers[i];
+						if ((member.GroupNumber == 0xFFFFFFFE) || (strlen(member.Name) == 0) || (strcmp(member.Name, Zeal::EqGame::get_self()->Name) == 0))
+							continue;
+						Zeal::EqStructures::Entity* raidMember = ZealService::get_instance()->entity_manager->Get(member.Name);
+						if (!raidMember)
+							continue;
+						if (spawn == raidMember)
+							raidMember->ActorInfo->DagHeadPoint->StringSprite->Color = 0xFF000000; //Raid Member-Black
+					}
 				}
-			}
-			if (spawn->GuildId == Zeal::EqGame::get_self()->GuildId) //Guild Member
-				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = 0xFF00FF80; //Guild Member-Greenish Blue
-				//spawn->ActorInfo->DagHeadPoint->StringSprite->Color = 0xFF80FF80; //Guild Member-White Green
-			if (groupmembers) {
-				for (int i = 0; i < maxGroupMembers; ++i) //Group Member loop
-				{
-					Zeal::EqStructures::Entity* groupmember = groupmembers[i];
-					if (spawn == groupmember)
-						spawn->ActorInfo->DagHeadPoint->StringSprite->Color = 0x0500FF32; //Group Member-Light Green 
-					continue;
+				if (spawn->GuildId == Zeal::EqGame::get_self()->GuildId) //Guild Member
+					spawn->ActorInfo->DagHeadPoint->StringSprite->Color = 0xFF00FF80; //Guild Member-Greenish Blue
+					//spawn->ActorInfo->DagHeadPoint->StringSprite->Color = 0xFF80FF80; //Guild Member-White Green
+				if (groupmembers) {
+					for (int i = 0; i < maxGroupMembers; ++i) //Group Member loop
+					{
+						Zeal::EqStructures::Entity* groupmember = groupmembers[i];
+						if (spawn == groupmember)
+							spawn->ActorInfo->DagHeadPoint->StringSprite->Color = 0x0500FF32; //Group Member-Light Green 
+						continue;
+					}
 				}
+				if (spawn->IsLinkDead == 1) //LinkDead
+					spawn->ActorInfo->DagHeadPoint->StringSprite->Color = 0xFFFF0000; //LinkDead - Red
+				else if (spawn->IsAwayFromKeyboard == 1) //AFK
+					spawn->ActorInfo->DagHeadPoint->StringSprite->Color = 0xFFFF8000; //AFK - Orange	
 			}
-			if (spawn->IsLinkDead == 1) //LinkDead
-				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = 0xFFFF0000; //LinkDead - Red
-			else if (spawn->IsAwayFromKeyboard == 1) //AFK
-				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = 0xFFFF8000; //AFK - Orange	
 			break;
 		case 1: //NPC
 			if (nameplatconcolorsEnabled) {
@@ -99,8 +100,7 @@ int __fastcall SetNameSpriteTint(void* this_ptr, void* not_used, Zeal::EqStructu
 			break;
 		default:
 			break;
-		}
-	}
+	}	
 	return result;
 }
 
@@ -125,7 +125,7 @@ NamePlate::NamePlate(ZealService* zeal, IO_ini* ini)
 	HMODULE eqfx = GetModuleHandleA("eqgfx_dx8.dll");
 	if (eqfx)
 		zeal->hooks->Add("DeferCachedNameTagTextW", (DWORD)eqfx + 0x70A00, DeferCachedNameTagTextW, hook_type_detour);
-	if (nameplatecolorsEnabled)
+		if (nameplatecolorsEnabled)
 		zeal->hooks->Add("SetNameSpriteTint", 0x4B114D, SetNameSpriteTint, hook_type_detour);
 	
 	if (!ini->exists("Zeal", "NameplateColors")) 
@@ -135,7 +135,7 @@ NamePlate::NamePlate(ZealService* zeal, IO_ini* ini)
 	if (!ini->exists("Zeal", "NameplateConColors"))
 		ini->setValue<bool>("Zeal", "NameplateConColors", false);
 	if (ini->exists("Zeal", "NameplateConColors"))
-		nameplatecolorsEnabled = ini->getValue<bool>("Zeal", "NameplateColors");
+		nameplatecolorsEnabled = ini->getValue<bool>("Zeal", "NameplateConColors");
 
 	zeal->commands_hook->Add("/nameplatecolors", {}, "Toggles Nameplate Colors",
 		[this](std::vector<std::string>& args) {

--- a/Zeal/nameplate.h
+++ b/Zeal/nameplate.h
@@ -3,9 +3,13 @@
 #include "memory.h"
 #include <stdint.h>
 #include "EqStructures.h"
+
 class NamePlate
 {
 public:
+	bool nameplateColors = false;
+	bool is_enabled() const { return nameplateColors; }
+	void set_enabled(bool enabled);	
 	NamePlate(class ZealService* zeal, class IO_ini* ini);
 	~NamePlate();
 private:

--- a/Zeal/nameplate.h
+++ b/Zeal/nameplate.h
@@ -8,8 +8,11 @@ class NamePlate
 {
 public:
 	bool nameplateColors = false;
-	bool is_enabled() const { return nameplateColors; }
-	void set_enabled(bool enabled);	
+	bool nameplateconColors = false;
+	bool colors_is_enabled() const { return nameplateColors; }
+	bool con_colors_is_enabled() const { return nameplateconColors; }
+	void colors_set_enabled(bool enabled);	
+	void con_colors_set_enabled(bool enabled);
 	NamePlate(class ZealService* zeal, class IO_ini* ini);
 	~NamePlate();
 private:

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -106,9 +106,10 @@ void ui_options::InitGeneral()
 	ui->AddCheckboxCallback(wnd, "Zeal_SpellbookAutoStand", [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->movement->set_spellbook_autostand(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_FloatingDamage", [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->floating_damage->set_enabled(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_ClassicClasses", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->chat_hook->set_classes(wnd->Checked); });
+	ui->AddCheckboxCallback(Zeal::EqGame::Windows->Options, "Zeal_MapShowRaid", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->zone_map->set_show_raid(wnd->Checked); });
+	ui->AddCheckboxCallback(Zeal::EqGame::Windows->Options, "Zeal_NameplateColors", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->colors_set_enabled(wnd->Checked); });
+	
 	ui->AddCheckboxCallback(wnd, "Zeal_TellWindows", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->tells->SetEnabled(wnd->Checked); });
-	ui->AddCheckboxCallback(wnd, "Zeal_NameplateColors", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->colors_set_enabled(wnd->Checked); });
-	ui->AddCheckboxCallback(wnd, "Zeal_NameplateConColors", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->con_colors_set_enabled(wnd->Checked); });
 	ui->AddComboCallback(wnd, "Zeal_Timestamps_Combobox", [this](Zeal::EqUI::BasicWnd* wnd, int value) { ZealService::get_instance()->chat_hook->set_timestamp(value); });
 	ui->AddSliderCallback(wnd, "Zeal_HoverTimeout_Slider", [this](Zeal::EqUI::SliderWnd* wnd, int value) {
 		int val = value * 5;

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -107,6 +107,8 @@ void ui_options::InitGeneral()
 	ui->AddCheckboxCallback(wnd, "Zeal_FloatingDamage", [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->floating_damage->set_enabled(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_ClassicClasses", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->chat_hook->set_classes(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_TellWindows", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->tells->SetEnabled(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_NameplateColors", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->colors_set_enabled(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_NameplateConColors", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->con_colors_set_enabled(wnd->Checked); });
 	ui->AddComboCallback(wnd, "Zeal_Timestamps_Combobox", [this](Zeal::EqUI::BasicWnd* wnd, int value) { ZealService::get_instance()->chat_hook->set_timestamp(value); });
 	ui->AddSliderCallback(wnd, "Zeal_HoverTimeout_Slider", [this](Zeal::EqUI::SliderWnd* wnd, int value) {
 		int val = value * 5;
@@ -283,6 +285,8 @@ void ui_options::UpdateOptionsGeneral()
 	ui->SetChecked("Zeal_AltContainerTooltips", ZealService::get_instance()->tooltips->all_containers);
 	ui->SetChecked("Zeal_SpellbookAutoStand", ZealService::get_instance()->movement->spellbook_autostand);
 	ui->SetChecked("Zeal_FloatingDamage", ZealService::get_instance()->floating_damage->enabled);
+	ui->SetChecked("Zeal_NameplateColors", ZealService::get_instance()->nameplate->nameplateColors);
+	ui->SetChecked("Zeal_NameplateConColors", ZealService::get_instance()->nameplate->nameplateconColors);
 }
 void ui_options::UpdateOptionsCamera()
 {

--- a/nameplate.cpp
+++ b/nameplate.cpp
@@ -1,0 +1,154 @@
+#include "nameplate.h"
+#include "Zeal.h"
+#include "EqAddresses.h"
+#include "string_util.h"
+
+bool nameplatecolorsEnabled = true;
+bool nameplateconcolorsEnabled = true;
+
+struct CachedNameData
+{
+	int unk1;
+	int unk2;
+	int name_len;
+	int unk3;
+	int fontptr;
+	char name[30];
+};
+
+int DeferCachedNameTagTextW(int font_size, CachedNameData* cnd, int a1, int a2, int a3, int a4, double a5, int a6)
+{
+	//if (GetAsyncKeyState(VK_END))
+	//{
+	//	Zeal::EqGame::print_chat("font: [%i] name: [%s] a1: [%i] a2: [%i] a3: [%i] a4: [%i] a5: [%f] a6: [%i]", font_size, cnd->name, a1, a2, a3, a4, a5, a6);
+	//}
+	//if (Zeal::EqGame::get_self())
+	//{
+	//	std::string name = cnd->name;
+	//	name = Zeal::String::split(name, " ").front();
+	//	std::string me = Zeal::EqGame::get_self()->Name;
+	//	me = Zeal::String::trim_and_reduce_spaces(me);
+	//	if (name == me)
+	//	{
+	//		cnd->unk1 = 0;
+	//	}
+	//	return ZealService::get_instance()->hooks->hook_map["DeferCachedNameTagTextW"]->original(DeferCachedNameTagTextW)(font_size, cnd, a1, a2, a3, a4, a5, a6);
+	//}
+	//else
+	//{
+		return ZealService::get_instance()->hooks->hook_map["DeferCachedNameTagTextW"]->original(DeferCachedNameTagTextW)(font_size, cnd, a1, a2, a3, a4, a5, a6);
+	//}
+}
+
+int __fastcall SetNameSpriteTint(void* this_ptr, void* not_used, Zeal::EqStructures::Entity* spawn)
+{	
+	int result = ZealService::get_instance()->hooks->hook_map["SetNameSpriteTint"]->original(SetNameSpriteTint)(this_ptr, not_used, spawn);
+	if (spawn == NULL) { return result; }
+	if (spawn->ActorInfo->DagHeadPoint == NULL) { return result; }
+	if (spawn->ActorInfo->DagHeadPoint->StringSprite == NULL) { return result; }
+	switch (spawn->Type) {
+		case 0: //Players
+			if (nameplatecolorsEnabled) {
+				int maxGroupMembers = 5;
+				int maxRaidMembers = 72;
+				Zeal::EqStructures::Entity** groupmembers = reinterpret_cast<Zeal::EqStructures::Entity**>(Zeal::EqGame::GroupList);
+				Zeal::EqStructures::RaidMember* raidMembers = reinterpret_cast<Zeal::EqStructures::RaidMember*>(Zeal::EqGame::RaidMemberList);
+				if (spawn == Zeal::EqGame::get_target()) //Leave blinking indicator on target
+					return result;
+				if (raidMembers){
+					for (int i = 0; i < maxRaidMembers; ++i) //Raid Member loop
+					{
+						Zeal::EqStructures::RaidMember member = raidMembers[i];
+						if ((member.GroupNumber == 0xFFFFFFFE) || (strlen(member.Name) == 0) || (strcmp(member.Name, Zeal::EqGame::get_self()->Name) == 0))
+							continue;
+						Zeal::EqStructures::Entity* raidMember = ZealService::get_instance()->entity_manager->Get(member.Name);
+						if (!raidMember)
+							continue;
+						if (spawn == raidMember)
+							raidMember->ActorInfo->DagHeadPoint->StringSprite->Color = 0xFF000000; //Raid Member-Black
+					}
+				}
+				if (spawn->GuildId == Zeal::EqGame::get_self()->GuildId) //Guild Member
+					spawn->ActorInfo->DagHeadPoint->StringSprite->Color = 0xFF00FF80; //Guild Member-Greenish Blue
+					//spawn->ActorInfo->DagHeadPoint->StringSprite->Color = 0xFF80FF80; //Guild Member-White Green
+				if (groupmembers) {
+					for (int i = 0; i < maxGroupMembers; ++i) //Group Member loop
+					{
+						Zeal::EqStructures::Entity* groupmember = groupmembers[i];
+						if (spawn == groupmember)
+							spawn->ActorInfo->DagHeadPoint->StringSprite->Color = 0x0500FF32; //Group Member-Light Green 
+						continue;
+					}
+				}
+				if (spawn->IsLinkDead == 1) //LinkDead
+					spawn->ActorInfo->DagHeadPoint->StringSprite->Color = 0xFFFF0000; //LinkDead - Red
+				else if (spawn->IsAwayFromKeyboard == 1) //AFK
+					spawn->ActorInfo->DagHeadPoint->StringSprite->Color = 0xFFFF8000; //AFK - Orange	
+			}
+			break;
+		case 1: //NPC
+			if (nameplateconcolorsEnabled) {
+				if (spawn == Zeal::EqGame::get_target()) //Leave blinking indicator on target
+					return result;
+				if (spawn != Zeal::EqGame::get_self()) //All NPC entities
+					spawn->ActorInfo->DagHeadPoint->StringSprite->Color = Zeal::EqGame::GetLevelCon(spawn); //Level Con Color for NPCs
+			}
+			break;
+		case 2: //NPC Corpse
+			break;
+		case 3: //Player Corpse
+			break;
+		default:
+			break;
+	}	
+	return result;
+}
+
+void NamePlate::colors_set_enabled(bool _enabled)
+{
+	_enabled = !nameplatecolorsEnabled;
+	ZealService::get_instance()->ini->setValue<bool>("Zeal", "NameplateColors", _enabled);
+	Zeal::EqGame::print_chat("NameplateColors are %s", _enabled ? "Enabled" : "Disabled");
+	nameplatecolorsEnabled = !nameplatecolorsEnabled;
+}
+
+void NamePlate::con_colors_set_enabled(bool _enabled)
+{
+	_enabled = !nameplateconcolorsEnabled;
+	ZealService::get_instance()->ini->setValue<bool>("Zeal", "NameplateConColors", _enabled);
+	Zeal::EqGame::print_chat("NameplateConColors are %s", _enabled ? "Enabled" : "Disabled");
+	nameplateconcolorsEnabled = !nameplateconcolorsEnabled;
+}
+
+NamePlate::NamePlate(ZealService* zeal, IO_ini* ini)
+{
+	HMODULE eqfx = GetModuleHandleA("eqgfx_dx8.dll");
+	if (eqfx)
+		zeal->hooks->Add("DeferCachedNameTagTextW", (DWORD)eqfx + 0x70A00, DeferCachedNameTagTextW, hook_type_detour);
+		if (nameplatecolorsEnabled)
+		zeal->hooks->Add("SetNameSpriteTint", 0x4B114D, SetNameSpriteTint, hook_type_detour);
+	
+	if (!ini->exists("Zeal", "NameplateColors")) 
+		ini->setValue<bool>("Zeal", "NameplateColors", false);
+	if (ini->exists("Zeal", "NameplateColors"))
+		nameplatecolorsEnabled = ini->getValue<bool>("Zeal", "NameplateColors");
+	if (!ini->exists("Zeal", "NameplateConColors"))
+		ini->setValue<bool>("Zeal", "NameplateConColors", false);
+	if (ini->exists("Zeal", "NameplateConColors"))
+		nameplateconcolorsEnabled = ini->getValue<bool>("Zeal", "NameplateConColors");
+
+	zeal->commands_hook->Add("/nameplatecolors", {}, "Toggles Nameplate Colors",
+		[this](std::vector<std::string>& args) {
+			colors_set_enabled(!ZealService::get_instance()->nameplate->colors_is_enabled());
+			return true;
+		});
+	zeal->commands_hook->Add("/nameplateconcolors", {}, "Toggles Nameplate Colors",
+		[this](std::vector<std::string>& args) {
+			con_colors_set_enabled(!ZealService::get_instance()->nameplate->con_colors_is_enabled());
+			return true;
+		});
+}
+
+NamePlate::~NamePlate()
+{
+}


### PR DESCRIPTION
Feature adds better visibility to Nameplate Colors for Raids, Guilds, Groups, AFK, and LD situations. A player on Discord had requested I submit what I had done so far.

Two ways to use feature currently:
1. /nameplatecolors command to toggle feature
2. bind key available to toggle feature

Feature adds itself the the eqclient.ini and remembers the bool setting that player sets for next gaming session.

When feature is off the client has normal hardcoded Nameplate Colors.

When feature is on the client has the following Nameplate Colors for better visibility in game:

Raid Members:  Black
Guild Members: Light Green
Group Members: Greenish Blue
Away from Keyboard-AFK:  Orange
Linkdead-LD:  Red

Open to future enhancements, mods, and feedback.