### PR TITLE
Nameplate colors for new users now have default colors

### DIFF
--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -14,12 +14,12 @@ void NamePlate::HandleTint(Zeal::EqStructures::Entity* spawn)
 	case 0: //Players
 		if (nameplateColors) 
 		{
-			Zeal::EqStructures::EQARGBCOLOR LDcolor = options->GetColor(2); //0xFFFF0000; //LinkDead - Red
-			Zeal::EqStructures::EQARGBCOLOR AFKcolor = options->GetColor(0); //0xFFFF8000; //AFK - Orange
-			Zeal::EqStructures::EQARGBCOLOR LFGcolor = options->GetColor(1); //0x00CFFF00; //LFG - Yellow
-			Zeal::EqStructures::EQARGBCOLOR Groupcolor = options->GetColor(5); //0x0500FF32; //Group Member - Light Green
-			Zeal::EqStructures::EQARGBCOLOR Raidcolor = options->GetColor(4); //0xFFFFFFFF; //Raid Member - White Light Purple
-			Zeal::EqStructures::EQARGBCOLOR Guildcolor = options->GetColor(3); //0x0000FFFF; //Guild Member - Cyan
+			Zeal::EqStructures::EQARGBCOLOR LDcolor = options->GetColor(2); //0xFFFF0000; //LinkDead color Default - Red
+			Zeal::EqStructures::EQARGBCOLOR AFKcolor = options->GetColor(0); //0xFFFF8000; //AFK color Default - Orange
+			Zeal::EqStructures::EQARGBCOLOR LFGcolor = options->GetColor(1); //0xFFCFFF00; //LFG color Default - Yellow
+			Zeal::EqStructures::EQARGBCOLOR Groupcolor = options->GetColor(5); //0xFF00FF32; //Group Member color Default - Light Green
+			Zeal::EqStructures::EQARGBCOLOR Raidcolor = options->GetColor(4); //0xFFFFFFFF; //Raid Member color Default - White Light Purple
+			Zeal::EqStructures::EQARGBCOLOR Guildcolor = options->GetColor(3); //0xFFFF8080; //Guild Member color Default- White Red
 			uint8_t isInGroup = *(uint8_t*)0x7912B0;
 			uint16_t raidSize = *(uint16_t*)0x794F9C;
 			Zeal::EqStructures::Entity* self = Zeal::EqGame::get_self();

--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -10,16 +10,22 @@ void NamePlate::HandleTint(Zeal::EqStructures::Entity* spawn)
 	if (!spawn->ActorInfo->DagHeadPoint) { return; }
 	if (!spawn->ActorInfo->DagHeadPoint->StringSprite) { return; }
 	ui_options* options = ZealService::get_instance()->ui->options.get();
+	Zeal::EqStructures::EQARGBCOLOR LDcolor = options->GetColor(2); //0xFFFF0000; //LinkDead - Red
+	Zeal::EqStructures::EQARGBCOLOR AFKcolor = options->GetColor(0); //0xFFFF8000; //AFK - Orange
+	Zeal::EqStructures::EQARGBCOLOR PVPcolor = options->GetColor(6); //0xFFFF0000; //PVP - Red
+	Zeal::EqStructures::EQARGBCOLOR LFGcolor = options->GetColor(1); //0xFFCFFF00; //LFG - Yellow
+	Zeal::EqStructures::EQARGBCOLOR Groupcolor = options->GetColor(5); //0xFF00FF32; //Group Member - Light Green
+	Zeal::EqStructures::EQARGBCOLOR Raidcolor = options->GetColor(4); //0xFFFFFFFF; //Raid Member - White Light Purple
+	Zeal::EqStructures::EQARGBCOLOR Rolecolor = options->GetColor(7); //0xFF85489C; //Roleplay - Purple
+	Zeal::EqStructures::EQARGBCOLOR MyGuildcolor = options->GetColor(3); //0xFFFF8080; //MyGuild Member - White Red
+	Zeal::EqStructures::EQARGBCOLOR OtherGuildscolor = options->GetColor(8); //0xFFFFFF80; //OtherGuild Member - White Yellow
+	Zeal::EqStructures::EQARGBCOLOR Adventurercolor = options->GetColor(9); //0xFF3D6BDC; //Not in Guild Member - Default Blue
+	Zeal::EqStructures::EQARGBCOLOR NpcCorpsecolor = options->GetColor(10); //0xFF000000; //Npc Corpse - Black
+	Zeal::EqStructures::EQARGBCOLOR PlayersCorpsecolor = options->GetColor(11); //0xFFFFFFFF; //Players Corpse - White Light Purple
 	switch (spawn->Type) {
 	case 0: //Players
 		if (nameplateColors) 
 		{
-			Zeal::EqStructures::EQARGBCOLOR LDcolor = options->GetColor(2); //0xFFFF0000; //LinkDead color Default - Red
-			Zeal::EqStructures::EQARGBCOLOR AFKcolor = options->GetColor(0); //0xFFFF8000; //AFK color Default - Orange
-			Zeal::EqStructures::EQARGBCOLOR LFGcolor = options->GetColor(1); //0xFFCFFF00; //LFG color Default - Yellow
-			Zeal::EqStructures::EQARGBCOLOR Groupcolor = options->GetColor(5); //0xFF00FF32; //Group Member color Default - Light Green
-			Zeal::EqStructures::EQARGBCOLOR Raidcolor = options->GetColor(4); //0xFFFFFFFF; //Raid Member color Default - White Light Purple
-			Zeal::EqStructures::EQARGBCOLOR Guildcolor = options->GetColor(3); //0xFFFF8080; //Guild Member color Default- White Red
 			uint8_t isInGroup = *(uint8_t*)0x7912B0;
 			uint16_t raidSize = *(uint16_t*)0x794F9C;
 			Zeal::EqStructures::Entity* self = Zeal::EqGame::get_self();
@@ -36,6 +42,11 @@ void NamePlate::HandleTint(Zeal::EqStructures::Entity* spawn)
 
 			if (spawn->IsAwayFromKeyboard == 1) {//AFK
 				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = AFKcolor;
+				return;
+			}
+
+			if (spawn->IsPlayerKill == 1){//PVP
+				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = PVPcolor;
 				return;
 			}
 
@@ -85,11 +96,27 @@ void NamePlate::HandleTint(Zeal::EqStructures::Entity* spawn)
 				}
 			}
 
-			//If not in a Guild - keep default color  //If spawn is same Guild as Player
-			if (spawn->GuildId != 0xFFFF && spawn->GuildId == Zeal::EqGame::get_self()->GuildId) {//Guild Member
-				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = Guildcolor;
+			if (spawn->AnonymousState == 2) {//Roleplay
+				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = Rolecolor;
 				return;
 			}
+
+			//If spawn is same Guild as Player
+			if (spawn->GuildId == Zeal::EqGame::get_self()->GuildId && spawn->GuildId != 0xFFFF) {//MyGuild Member
+				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = MyGuildcolor;
+				return;
+			}
+			//If spawn is in different Guild than Player
+			if (spawn->GuildId != Zeal::EqGame::get_self()->GuildId && spawn->GuildId != 0xFFFF) {//OtherGuild Member
+				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = OtherGuildscolor;
+				return;
+			}
+			//If not in a Guild - Adventurer has default color
+			if (spawn->GuildId == 0xFFFF) { //Not in Guild Adventurer   
+				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = Adventurercolor;
+				return;
+			}
+
 		}
 		break;
 	case 1: //NPC
@@ -101,8 +128,16 @@ void NamePlate::HandleTint(Zeal::EqStructures::Entity* spawn)
 		}
 		break;
 	case 2: //NPC Corpse
+		if (nameplateColors) {
+			spawn->ActorInfo->DagHeadPoint->StringSprite->Color = NpcCorpsecolor;
+			return;
+		}
 		break;
 	case 3: //Player Corpse
+		if (nameplateColors) {
+			spawn->ActorInfo->DagHeadPoint->StringSprite->Color = PlayersCorpsecolor;
+			return;
+		}
 		break;
 	default:
 		break;
@@ -113,9 +148,10 @@ int __fastcall SetNameSpriteTint(void* this_ptr, void* not_used, Zeal::EqStructu
 {	
 	int result = ZealService::get_instance()->hooks->hook_map["SetNameSpriteTint"]->original(SetNameSpriteTint)(this_ptr, not_used, spawn);
 	ZealService::get_instance()->nameplate->HandleTint(spawn);
+	if (ZealService::get_instance()->nameplate->nameplateColors && Zeal::EqGame::get_gamestate() == GAMESTATE_CHARSELECT && Zeal::EqGame::get_self())
+		Zeal::EqGame::get_self()->ActorInfo->DagHeadPoint->StringSprite->Color = 0xFF00FF32; //Green indication Namecolors on at Character Select
 	return result;
 }
-
 void NamePlate::colors_set_enabled(bool _enabled)
 {
 	ZealService::get_instance()->ini->setValue<bool>("Zeal", "NameplateColors", _enabled);

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -75,6 +75,15 @@ void ui_options::LoadColors()
 	{
 		if (ini->exists("ZealColors", "Color" + std::to_string(index)))
 			btn->TextColor.ARGB = ini->getValue<DWORD>("ZealColors", "Color" + std::to_string(index));
+		if (!ini->exists("ZealColors", "Color" + std::to_string(index))) //Adds default Nameplate colors for new users
+		{
+			color_buttons[0]->TextColor.ARGB = 0xFFFF8000; //AFK - Orange
+			color_buttons[1]->TextColor.ARGB = 0xFFCFFF00; //LFG - Yellow
+			color_buttons[2]->TextColor.ARGB = 0xFFFF0000; //LinkDead - Red
+			color_buttons[3]->TextColor.ARGB = 0xFFFF8080; //Guild Member - White Red
+			color_buttons[4]->TextColor.ARGB = 0xFFFFFFFF; //Raid Member - White Light Purple
+			color_buttons[5]->TextColor.ARGB = 0xFF00FF32; //Group Member - Light Green
+		}
 	}
 }
 

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -83,6 +83,12 @@ void ui_options::LoadColors()
 			color_buttons[3]->TextColor.ARGB = 0xFFFF8080; //Guild Member - White Red
 			color_buttons[4]->TextColor.ARGB = 0xFFFFFFFF; //Raid Member - White Light Purple
 			color_buttons[5]->TextColor.ARGB = 0xFF00FF32; //Group Member - Light Green
+			color_buttons[6]->TextColor.ARGB = 0xFFFF0000; //PVP - Red
+			color_buttons[7]->TextColor.ARGB = 0xFF85489C; //Roleplay - Purple
+			color_buttons[8]->TextColor.ARGB = 0xFFFFFF80; //OtherGuild Member - White Yellow
+			color_buttons[9]->TextColor.ARGB = 0xFF3D6BDC; //Not in Guild Member - Default Blue
+			color_buttons[10]->TextColor.ARGB = 0xFF000000; //Npc Corpse - Black
+			color_buttons[11]->TextColor.ARGB = 0xFFFFFFFF; //Players Corpse - White Light Purple
 		}
 	}
 }

--- a/Zeal/uifiles/zeal/EQUI_Tab_Colors.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_Colors.xml
@@ -54,7 +54,7 @@
     </ButtonDrawTemplate>
   </Button>
   
-  <Button item="Zeal_Color0">
+ <Button item="Zeal_Color0">
     <ScreenID>Zeal_Color0</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
@@ -156,7 +156,7 @@
     <Style_HScroll>false</Style_HScroll>
     <Style_Transparent>false</Style_Transparent>
     <Style_Checkbox>false</Style_Checkbox>
-    <Text>3 - Guild</Text>
+    <Text>3 - MyGuild</Text>
     <TextColor>
       <R>255</R>
       <G>255</G>
@@ -228,6 +228,180 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
+  <Button item="Zeal_Color6">
+    <ScreenID>Zeal_Color6</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>98</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>6 - PVP</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_Color7">
+    <ScreenID>Zeal_Color7</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>200</X>
+      <Y>98</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>7 - Roleplay</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+   <Button item="Zeal_Color8">
+    <ScreenID>Zeal_Color8</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>120</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>8 - OtherGuilds</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_Color9">
+    <ScreenID>Zeal_Color9</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>200</X>
+      <Y>120</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>9 - DefaultAdventurer</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+    <Button item="Zeal_Color10">
+    <ScreenID>Zeal_Color10</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>142</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>10 - NpcCorpse</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+      <Button item="Zeal_Color11">
+    <ScreenID>Zeal_Color11</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>200</X>
+      <Y>142</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>11 - PlayersCorpse</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
   <Page item="Tab_Colors">
 	<ScreenID>Tab_Colors</ScreenID>
 	 <RelativePosition>true</RelativePosition>
@@ -254,6 +428,12 @@
 	<Pieces>Zeal_Color3</Pieces>
 	<Pieces>Zeal_Color4</Pieces>
 	<Pieces>Zeal_Color5</Pieces>
+	<Pieces>Zeal_Color6</Pieces>
+	<Pieces>Zeal_Color7</Pieces>
+	<Pieces>Zeal_Color8</Pieces>
+	<Pieces>Zeal_Color9</Pieces>
+	<Pieces>Zeal_Color10</Pieces>
+	<Pieces>Zeal_Color11</Pieces>
 	<Pieces>Section_Nameplate</Pieces>
 	<Pieces>Zeal_BtnDivider</Pieces>
 


### PR DESCRIPTION
This adds in default Nameplate colors for new users of Zeal rather than blank slate.  Once a user changes their Nameplate color the ini file still remembers their new choices.  Also updated commentary in both files changed for future reference