### PR TITLE
Add a 'marker_only' map labels mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ ___
 8. After the green checkmark appears, go back to the main workspace and verify the content of the new release tag.
 
 #### Local builds
-Build in 32bit x86 mode using Microsoft Visual Studio 2022 (free Community edition works)
+Build in `Release` `x86` (32bit) mode using Microsoft Visual Studio 2022 (free Community edition works)
 
 
 ### In-game Map
@@ -438,7 +438,7 @@ for the labels can have a significant framerate impact (use keybind to toggle on
   - `/map poi butcherblock` performs a text search of the poi list for butcherblock, reports 
      any matches, and drops a marker on the first one
   - `/map butcherblock` shortcut for above (does not work for terms that match other commands)
-  - `/map labels summary` enables the summary labels (other options are `off` or `all`)
+  - `/map labels summary` enables the summary labels (other options are `off`, `all`, or `marker`)
 
 #### Map data source
 The map has simple support for external map data files. The map data_mode can be set to `internal`,

--- a/Zeal/uifiles/zeal/EQUI_Tab_Map.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_Map.xml
@@ -661,6 +661,7 @@
     <Choices>Off (no penalty)</Choices>
     <Choices>Summary (some)</Choices>
     <Choices>All (significant)</Choices>
+    <Choices>Marker only (some)</Choices>
   </Combobox>
   <!-- Zeal Map Keybinds Reminder -->
   <Label item="Zeal_MapKeyBinds_Label">

--- a/Zeal/zone_map.cpp
+++ b/Zeal/zone_map.cpp
@@ -570,8 +570,10 @@ void ZoneMap::render_labels() {
         return;
 
     label_font->Begin();  // Minor 10% performance improvement with Begin/End.
-    for (const ZoneMapLabel* label : labels_list)
-        render_label_text(label->label, label->y, label->x, D3DCOLOR_XRGB(label->red, label->green, label->blue));
+    for (const ZoneMapLabel* label : labels_list) {
+        const char* text_label = (map_labels_mode == LabelsMode::kMarkerOnly) ? "+" : label->label;
+        render_label_text(text_label, label->y, label->x, D3DCOLOR_XRGB(label->red, label->green, label->blue));
+    }
 
     ULONGLONG timestamp = GetTickCount64();
     for (auto it = dynamic_labels_list.begin(); it != dynamic_labels_list.end();) {
@@ -1742,10 +1744,12 @@ void ZoneMap::parse_labels(const std::vector<std::string>& args) {
             labels = LabelsMode::kSummary;
         else if (args[2] == "all")
             labels = LabelsMode::kAll;
+        else if (args[2] == "marker")
+            labels = LabelsMode::kMarkerOnly;
     }
 
     if ((labels < LabelsMode::kFirst) || !set_labels_mode(labels, false)) {
-        Zeal::EqGame::print_chat("Usage: /map labels off,summary,all");
+        Zeal::EqGame::print_chat("Usage: /map labels off,summary,all,marker");
     }
 }
 

--- a/Zeal/zone_map.h
+++ b/Zeal/zone_map.h
@@ -23,7 +23,7 @@ public:
 
 	struct AlignmentType { enum e : int { kLeft = 0, kCenter, kRight, kFirst = kLeft, kLast = kRight }; };
 	struct BackgroundType { enum e : int { kClear = 0, kDark, kLight, kTan, kFirst = kClear, kLast = kTan }; };
-	struct LabelsMode { enum e : int { kOff = 0, kSummary, kAll, kFirst = kOff, kLast = kAll }; };
+	struct LabelsMode { enum e : int { kOff = 0, kSummary, kAll, kMarkerOnly, kFirst = kOff, kLast = kMarkerOnly }; };
 	struct MapDataMode { enum e : int { kInternal = 0, kBoth, kExternal, kFirst = kInternal, kLast = kExternal }; };
 
 	static constexpr float kMaxPositionSize = 0.05f;  // In fraction of screen size.


### PR DESCRIPTION
- Added a simple mode that only puts a '+' instead of the full label to make it easier to locate the precise location (like ground spawns)