### PR TITLE
Prevent /useitem from trying to cast "(worn)" effects

### DIFF
--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -1446,6 +1446,10 @@ namespace Zeal
 				Zeal::EqGame::print_chat("item %s does not have a spell attached to it.", item->Name);
 				return false;
 			}
+			if (item->Common.EffectType == 2) {
+				Zeal::EqGame::print_chat("item %s has a worn effect.", item->Name);
+				return false;
+			}
 			if (!self->ActorInfo || self->ActorInfo->CastingSpellId != kInvalidSpellId)
 			{
 				Zeal::EqGame::print_chat(USERCOLOR_SPELLS, "You must stop casting to cast this spell!");


### PR DESCRIPTION
Getting the index wrong with `/useitem` can make it try to accidentally cast a worn item. The client attempts to "cast" the worn effect. The server rejects it properly, but I'm curious if this triggers any of it's MQ Detection flags as well.
![image](https://github.com/user-attachments/assets/bf2ba046-6221-4b5d-983e-775ca47162c1)

Definitely something we should block client-side from happening.