### PR TITLE
Nameplate update   new nameplate options

### DIFF
--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -23,6 +23,11 @@ void NamePlate::HandleTint(Zeal::EqStructures::Entity* spawn)
 	Zeal::EqStructures::EQARGBCOLOR NpcCorpsecolor = options->GetColor(10); //0xFF000000; //Npc Corpse - Black
 	Zeal::EqStructures::EQARGBCOLOR PlayersCorpsecolor = options->GetColor(11); //0xFFFFFFFF; //Players Corpse - White Light Purple
 	Zeal::EqStructures::EQARGBCOLOR BlueConcolor = options->GetColor(12); //BlueCon - Default DarkBlue is ligher than CON_BLUE
+	Zeal::EqStructures::EQARGBCOLOR GreenConcolor = options->GetColor(13); //CON_GREEN
+	Zeal::EqStructures::EQARGBCOLOR LightBlueConcolor = options->GetColor(14); //CON_LIGHTBLUE
+	Zeal::EqStructures::EQARGBCOLOR WhiteConcolor = options->GetColor(15); //CON_WHITE
+	Zeal::EqStructures::EQARGBCOLOR YellowConcolor = options->GetColor(16); //CON_YELLOW
+	Zeal::EqStructures::EQARGBCOLOR RedConcolor = options->GetColor(17); //CON_RED
 	switch (spawn->Type) {
 	case 0: //Players
 		if (nameplateColors) 
@@ -124,8 +129,28 @@ void NamePlate::HandleTint(Zeal::EqStructures::Entity* spawn)
 		if (nameplateconColors) {
 			if (spawn == Zeal::EqGame::get_target()) //Leave blinking indicator on target
 				return;
+			if (Zeal::EqGame::GetLevelCon(spawn) == CON_GREEN) { //Changes NPC Green Con to user selected Color
+				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = GreenConcolor;
+				return;
+			}
+			if (Zeal::EqGame::GetLevelCon(spawn) == CON_LIGHTBLUE) { //Changes NPC Light Blue Con to user selected Color
+				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = LightBlueConcolor;
+				return;
+			}
 			if (Zeal::EqGame::GetLevelCon(spawn) == CON_BLUE){ //Changes NPC DarkBlue Con to user selected Color
 				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = BlueConcolor;
+				return;
+			}
+			if (Zeal::EqGame::GetLevelCon(spawn) == CON_WHITE) { //Changes NPC White Con to user selected Color
+				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = WhiteConcolor;
+				return;
+			}
+			if (Zeal::EqGame::GetLevelCon(spawn) == CON_YELLOW) { //Changes NPC Yellow Con to user selected Color
+				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = YellowConcolor;
+				return;
+			}
+			if (Zeal::EqGame::GetLevelCon(spawn) == CON_RED) { //Changes NPC Red Con to user selected Color
+				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = RedConcolor;
 				return;
 			}
 			if (spawn != Zeal::EqGame::get_self()) //All NPC entities
@@ -163,14 +188,74 @@ char* trim_name(char* spawnName)
 	return reinterpret_cast<char* (__thiscall*)(int CEverquest_ptr, char* spawnName)>(0x537D39)(*(int*)0x809478, spawnName);
 }
 
-int __fastcall SetNameSpriteState(void* this_ptr, void* not_used, Zeal::EqStructures::Entity* spawn, bool show)
+void NamePlate::HandleState(void* this_ptr, void* not_used, Zeal::EqStructures::Entity* spawn)
 {
-	int result = ZealService::get_instance()->hooks->hook_map["SetNameSpriteState"]->original(SetNameSpriteState)(this_ptr, not_used, spawn, show);
+	if (!spawn) { return; }
+	if (!spawn->ActorInfo) { return; }
+	if (!spawn->ActorInfo->DagHeadPoint) { return; }
+	if (!spawn->ActorInfo->DagHeadPoint->StringSprite) { return; }
 	DWORD fontTexture = *(DWORD*)(*(DWORD*)0x7F9510 + 0x2E08); //get the font texture
+	Zeal::EqStructures::RaidMember* raidMembers = reinterpret_cast<Zeal::EqStructures::RaidMember*>(Zeal::EqGame::RaidMemberList);
+	if (spawn == Zeal::EqGame::get_self())
+	{
+		if (nameplateSelf)
+		{
+			reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_self()->ActorInfo->DagHeadPoint, fontTexture, (char*)"");
+			SetNameSpriteTint(this_ptr, not_used, Zeal::EqGame::get_self());
+			return;
+		}
+		if (nameplateX) 
+		{
+			if (spawn->IsHidden == 0) //Visible
+			{
+				reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_self()->ActorInfo->DagHeadPoint, fontTexture, (char*)"X");
+				SetNameSpriteTint(this_ptr, not_used, Zeal::EqGame::get_self());
+				return;
+			}
+			if (spawn->IsHidden == 1) //Invisible
+			{
+				reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_self()->ActorInfo->DagHeadPoint, fontTexture, (char*)"(X)");
+				SetNameSpriteTint(this_ptr, not_used, Zeal::EqGame::get_self());
+				return;
+			}
+		}
+	}
+	if (nameplateRaidPets)
+	{
+		if (spawn->PetOwnerSpawnId == Zeal::EqGame::get_self()->SpawnId)
+		{
+			reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, spawn->ActorInfo->DagHeadPoint, fontTexture, (char*)"");
+			SetNameSpriteTint(this_ptr, not_used, spawn);
+			return;
+		}
+		for (int i = 0; i < 72; ++i) //Raid Member loop
+		{
+			Zeal::EqStructures::RaidMember member = raidMembers[i];
+			if ((member.GroupNumber == 0xFFFFFFFF - 1) || (strlen(member.Name) == 0) || (strcmp(member.Name, Zeal::EqGame::get_self()->Name) == 0))
+				continue;
+			Zeal::EqStructures::Entity* raidMember = ZealService::get_instance()->entity_manager->Get(member.Name);
+			if (!raidMember)
+				continue;
+			if (spawn->PetOwnerSpawnId == raidMember->SpawnId)
+			{
+				reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, spawn->ActorInfo->DagHeadPoint, fontTexture, (char*)"");
+				SetNameSpriteTint(this_ptr, not_used, spawn);
+				return;
+			}
+		}
+	}
 	if ((spawn->Type == 2 || spawn->Type == 3) && spawn->Race == 60) { //Skeleton Corpse - Nameplate fix
 		reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, spawn->ActorInfo->DagHeadPoint, fontTexture, trim_name(spawn->Name));
 		SetNameSpriteTint(this_ptr, not_used, spawn);
+		return;
 	}
+
+}
+
+int __fastcall SetNameSpriteState(void* this_ptr, void* not_used, Zeal::EqStructures::Entity* spawn, bool show)
+{
+	int result = ZealService::get_instance()->hooks->hook_map["SetNameSpriteState"]->original(SetNameSpriteState)(this_ptr, not_used, spawn, show);
+	ZealService::get_instance()->nameplate->HandleState(this_ptr, not_used, spawn);
 	return result;
 }
 
@@ -188,6 +273,27 @@ void NamePlate::con_colors_set_enabled(bool _enabled)
 	nameplateconColors = _enabled;
 }
 
+void NamePlate::self_set_enabled(bool _enabled)
+{
+	ZealService::get_instance()->ini->setValue<bool>("Zeal", "NameplateSelf", _enabled);
+	Zeal::EqGame::print_chat("Nameplate for Self is %s", _enabled ? "Disabled" : "Enabled");
+	nameplateSelf = _enabled;
+}
+
+void NamePlate::x_set_enabled(bool _enabled)
+{
+	ZealService::get_instance()->ini->setValue<bool>("Zeal", "NameplateX", _enabled);
+	Zeal::EqGame::print_chat("Nameplate for Self set to X is %s", _enabled ? "Enabled" : "Disabled");
+	nameplateX = _enabled;
+}
+
+void NamePlate::raidpets_set_enabled(bool _enabled)
+{
+	ZealService::get_instance()->ini->setValue<bool>("Zeal", "NameplateRaidPets", _enabled);
+	Zeal::EqGame::print_chat("Nameplates for RaidPets are %s", _enabled ? "Disabled" : "Enabled");
+	nameplateRaidPets = _enabled;
+}
+
 NamePlate::NamePlate(ZealService* zeal, IO_ini* ini)
 {
 	//HMODULE eqfx = GetModuleHandleA("eqgfx_dx8.dll");
@@ -196,16 +302,25 @@ NamePlate::NamePlate(ZealService* zeal, IO_ini* ini)
 	//if (eqfx) 
 		//zeal->hooks->Add("DeferCachedNameTagTextW", (DWORD)eqfx + 0x70A00, DeferCachedNameTagTextW, hook_type_detour);
 
-	zeal->hooks->Add("SetNameSpriteTint", 0x4B114D, SetNameSpriteTint, hook_type_detour);
 	zeal->hooks->Add("SetNameSpriteState", 0x4B0BD9, SetNameSpriteState, hook_type_detour);
+	zeal->hooks->Add("SetNameSpriteTint", 0x4B114D, SetNameSpriteTint, hook_type_detour);
 	
 	if (!ini->exists("Zeal", "NameplateColors")) 
 		ini->setValue<bool>("Zeal", "NameplateColors", false);
 	if (!ini->exists("Zeal", "NameplateConColors"))
 		ini->setValue<bool>("Zeal", "NameplateConColors", false);
+	if (!ini->exists("Zeal", "NameplateSelf"))
+		ini->setValue<bool>("Zeal", "NameplateSelf", false);
+	if (!ini->exists("Zeal", "NameplateX"))
+		ini->setValue<bool>("Zeal", "NameplateX", false);
+	if (!ini->exists("Zeal", "NameplateRaidPets"))
+		ini->setValue<bool>("Zeal", "NameplateRaidPets", false);
 
 	nameplateColors = ini->getValue<bool>("Zeal", "NameplateColors");
 	nameplateconColors = ini->getValue<bool>("Zeal", "NameplateConColors");
+	nameplateSelf = ini->getValue<bool>("Zeal", "NameplateSelf");
+	nameplateX = ini->getValue<bool>("Zeal", "NameplateX");
+	nameplateRaidPets = ini->getValue<bool>("Zeal", "NameplateRaidPets");
 
 	zeal->commands_hook->Add("/nameplatecolors", {}, "Toggles Nameplate Colors",
 		[this](std::vector<std::string>& args) {
@@ -215,6 +330,21 @@ NamePlate::NamePlate(ZealService* zeal, IO_ini* ini)
 	zeal->commands_hook->Add("/nameplateconcolors", {}, "Toggles Nameplate Colors",
 		[this](std::vector<std::string>& args) {
 			con_colors_set_enabled(!ZealService::get_instance()->nameplate->con_colors_is_enabled());
+			return true;
+		});
+	zeal->commands_hook->Add("/nameplateself", {}, "Toggles Nameplate Colors",
+		[this](std::vector<std::string>& args) {
+			colors_set_enabled(!ZealService::get_instance()->nameplate->self_is_enabled());
+			return true;
+		});
+	zeal->commands_hook->Add("/nameplatex", {}, "Toggles Nameplate Colors",
+		[this](std::vector<std::string>& args) {
+			con_colors_set_enabled(!ZealService::get_instance()->nameplate->x_is_enabled());
+			return true;
+		});
+	zeal->commands_hook->Add("/nameplateraidpets", {}, "Toggles Nameplate Colors",
+		[this](std::vector<std::string>& args) {
+			colors_set_enabled(!ZealService::get_instance()->nameplate->raidpets_is_enabled());
 			return true;
 		});
 }

--- a/Zeal/nameplate.h
+++ b/Zeal/nameplate.h
@@ -9,14 +9,23 @@ class NamePlate
 public:
 	bool nameplateColors = false;
 	bool nameplateconColors = false;
+	bool nameplateSelf = false;
+	bool nameplateX = false;
+	bool nameplateRaidPets = false;
 
 	bool colors_is_enabled() const { return nameplateColors; }
 	bool con_colors_is_enabled() const { return nameplateconColors; }
+	bool self_is_enabled() const { return nameplateSelf; }
+	bool x_is_enabled() const { return nameplateX; }
+	bool raidpets_is_enabled() const { return nameplateRaidPets; }
 	void colors_set_enabled(bool enabled);	
 	void con_colors_set_enabled(bool enabled);
+	void self_set_enabled(bool enabled);
+	void x_set_enabled(bool enabled);
+	void raidpets_set_enabled(bool enabled);
+	void HandleState(void* this_ptr, void* not_used, Zeal::EqStructures::Entity* spawn);
 	void HandleTint(Zeal::EqStructures::Entity* spawn);
 	NamePlate(class ZealService* zeal, class IO_ini* ini);
 	~NamePlate();
 private:
 };
-

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -89,10 +89,15 @@ void ui_options::LoadColors()
 			color_buttons[9]->TextColor.ARGB = 0xFF3D6BDC; //Not in Guild Member - Default Blue
 			color_buttons[10]->TextColor.ARGB = 0xFF000000; //Npc Corpse - Black
 			color_buttons[11]->TextColor.ARGB = 0xFFFFFFFF; //Players Corpse - White Light Purple
+			color_buttons[12]->TextColor.ARGB = CON_GREEN; //GreenCon
+			color_buttons[13]->TextColor.ARGB = CON_LIGHTBLUE; //LightBlueCon
 			if (ZealService::get_instance()->ini->getValue<bool>("Zeal", "Bluecon"))
-				color_buttons[12]->TextColor.ARGB = Zeal::EqGame::get_user_color(70); //BlueCon - Keeps original BlueCon if set from old Options menu
+				color_buttons[14]->TextColor.ARGB = Zeal::EqGame::get_user_color(70); //BlueCon - Keeps original BlueCon if set from old Options menu
 			if (!ZealService::get_instance()->ini->getValue<bool>("Zeal", "Bluecon"))
-				color_buttons[12]->TextColor.ARGB = 0xFF0040FF; //BlueCon - Default DarkBlue is ligher than CON_BLUE for new users
+				color_buttons[14]->TextColor.ARGB = 0xFF0040FF; //BlueCon - Default DarkBlue is ligher than CON_BLUE for new users
+			color_buttons[15]->TextColor.ARGB = CON_WHITE; //WhiteCon
+			color_buttons[16]->TextColor.ARGB = CON_YELLOW; //YellowCon
+			color_buttons[17]->TextColor.ARGB = CON_RED; //RedCon
 		}
 	}
 }
@@ -119,6 +124,7 @@ void ui_options::InitUI()
 	InitMap();
 	InitTargetRing();
 	InitColors();
+	InitNameplate();
 
 	isReady = true;
 	/*set the current states*/
@@ -188,9 +194,7 @@ void ui_options::InitGeneral()
 	ui->AddCheckboxCallback(wnd, "Zeal_SpellbookAutoStand", [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->movement->set_spellbook_autostand(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_FloatingDamage", [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->floating_damage->set_enabled(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_ClassicClasses", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->chat_hook->set_classes(wnd->Checked); });
-	ui->AddCheckboxCallback(wnd, "Zeal_NameplateColors", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->colors_set_enabled(wnd->Checked); });
-	ui->AddCheckboxCallback(wnd, "Zeal_NameplateConColors", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->con_colors_set_enabled(wnd->Checked); });
-	
+
 	ui->AddCheckboxCallback(wnd, "Zeal_TellWindows", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->tells->SetEnabled(wnd->Checked); });
 	ui->AddComboCallback(wnd, "Zeal_Timestamps_Combobox", [this](Zeal::EqUI::BasicWnd* wnd, int value) { ZealService::get_instance()->chat_hook->set_timestamp(value); });
 	ui->AddSliderCallback(wnd, "Zeal_HoverTimeout_Slider", [this](Zeal::EqUI::SliderWnd* wnd, int value) {
@@ -351,6 +355,20 @@ void ui_options::InitTargetRing()
 
 }
 
+void ui_options::InitNameplate()
+{
+	if (!wnd)
+	{
+		PrintUIError();
+		return;
+	}
+	ui->AddCheckboxCallback(wnd, "Zeal_NameplateColors", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->colors_set_enabled(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_NameplateConColors", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->con_colors_set_enabled(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_NameplateSelf", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->self_set_enabled(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_NameplateX", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->x_set_enabled(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_NameplateRaidPets", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->raidpets_set_enabled(wnd->Checked); });
+}
+
 void ui_options::UpdateOptions()
 {
 	if (!isReady)
@@ -364,6 +382,7 @@ void ui_options::UpdateOptions()
 	UpdateOptionsCamera();
 	UpdateOptionsGeneral();
 	UpdateOptionsTargetRing();
+	UpdateOptionsNameplate();
 	UpdateOptionsMap();
 
 }
@@ -389,8 +408,6 @@ void ui_options::UpdateOptionsGeneral()
 	ui->SetChecked("Zeal_AltContainerTooltips", ZealService::get_instance()->tooltips->all_containers);
 	ui->SetChecked("Zeal_SpellbookAutoStand", ZealService::get_instance()->movement->spellbook_autostand);
 	ui->SetChecked("Zeal_FloatingDamage", ZealService::get_instance()->floating_damage->enabled);
-	ui->SetChecked("Zeal_NameplateColors", ZealService::get_instance()->nameplate->nameplateColors);
-	ui->SetChecked("Zeal_NameplateConColors", ZealService::get_instance()->nameplate->nameplateconColors);
 }
 void ui_options::UpdateOptionsCamera()
 {
@@ -433,6 +450,21 @@ void ui_options::UpdateOptionsTargetRing()
 	ui->SetLabelValue("Zeal_TargetRingRotation_Value", "%.2f", ZealService::get_instance()->target_ring->get_rotation_speed());
 	ui->SetLabelValue("Zeal_TargetRingSize_Value", "%.2f", ZealService::get_instance()->target_ring->get_size());
 }
+
+void ui_options::UpdateOptionsNameplate()
+{
+	if (!wnd)
+	{
+		PrintUIError();
+		return;
+	}
+	ui->SetChecked("Zeal_NameplateColors", ZealService::get_instance()->nameplate->nameplateColors);
+	ui->SetChecked("Zeal_NameplateConColors", ZealService::get_instance()->nameplate->nameplateconColors);
+	ui->SetChecked("Zeal_NameplateSelf", ZealService::get_instance()->nameplate->nameplateSelf);
+	ui->SetChecked("Zeal_NameplateX", ZealService::get_instance()->nameplate->nameplateX);
+	ui->SetChecked("Zeal_NameplateRaidpets", ZealService::get_instance()->nameplate->nameplateRaidPets);
+}
+
 void ui_options::UpdateOptionsMap()
 {
 	if (!wnd)

--- a/Zeal/ui_options.h
+++ b/Zeal/ui_options.h
@@ -10,6 +10,7 @@ public:
 	void UpdateOptions();
 	void UpdateOptionsMap();
 	void UpdateOptionsTargetRing();
+	void UpdateOptionsNameplate();
 	void UpdateOptionsCamera();
 	void UpdateOptionsGeneral();
 	void InitColors();
@@ -17,6 +18,7 @@ public:
 	void InitMap();
 	void InitCamera();
 	void InitTargetRing();
+	void InitNameplate();
 	void SaveColors();
 	void LoadColors();
 	DWORD GetColor(int index);

--- a/Zeal/uifiles/zeal/EQUI_Tab_Colors.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_Colors.xml
@@ -417,7 +417,303 @@
     <Style_HScroll>false</Style_HScroll>
     <Style_Transparent>false</Style_Transparent>
     <Style_Checkbox>false</Style_Checkbox>
-    <Text>12 - Blue Con for NPCs</Text>
+    <Text>12 - Green Con - NPCs</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+<Button item="Zeal_Color13">
+    <ScreenID>Zeal_Color13</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>200</X>
+      <Y>164</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>13 - LightBlue Con-NPCs</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+<Button item="Zeal_Color14">
+    <ScreenID>Zeal_Color14</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>186</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>14 - Blue Con - NPCS</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+<Button item="Zeal_Color15">
+    <ScreenID>Zeal_Color15</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>200</X>
+      <Y>186</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>15 - White Con - NPCs</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+<Button item="Zeal_Color16">
+    <ScreenID>Zeal_Color16</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>208</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>16 - Yellow Con - NPCs</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+<Button item="Zeal_Color17">
+    <ScreenID>Zeal_Color17</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>200</X>
+      <Y>208</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>17 - Red Con - NPCs</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+<!-- Zeal Nameplates -->
+  <Button item="Zeal_NameplateColors">
+    <ScreenID>Zeal_NameplateColors</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>252</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Adds custom coloring to player nameplates, choose colors from this tab</TooltipReference>
+    <Text>Player Name colors</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+    <Button item="Zeal_NameplateConColors">
+    <ScreenID>Zeal_NameplateConColors</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>200</X>
+      <Y>252</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Renders npc names in the color of your con</TooltipReference>
+    <Text>NPC Name Con Colors</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+<Button item="Zeal_NameplateSelf">
+    <ScreenID>Zeal_NameplateSelf</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>274</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Toggle Self Nameplate</TooltipReference>
+    <Text>Player Name</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+<Button item="Zeal_NameplateX">
+    <ScreenID>Zeal_NameplateX</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>200</X>
+      <Y>274</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Render Self Nameplate as X</TooltipReference>
+    <Text>Player Name X</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+<Button item="Zeal_NameplateRaidPets">
+    <ScreenID>Zeal_NameplateRaidPets</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>296</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Toggle Raid Pet Nameplates</TooltipReference>
+    <Text>Name Raid Pets</Text>
     <TextColor>
       <R>255</R>
       <G>255</G>
@@ -464,6 +760,16 @@
 	<Pieces>Zeal_Color10</Pieces>
 	<Pieces>Zeal_Color11</Pieces>
 	<Pieces>Zeal_Color12</Pieces>
+	<Pieces>Zeal_Color13</Pieces>
+	<Pieces>Zeal_Color14</Pieces>
+	<Pieces>Zeal_Color15</Pieces>
+	<Pieces>Zeal_Color16</Pieces>
+	<Pieces>Zeal_Color17</Pieces>
+	<Pieces>Zeal_NameplateColors</Pieces>
+	<Pieces>Zeal_NameplateConColors</Pieces>
+	<Pieces>Zeal_NameplateSelf</Pieces>
+	<Pieces>Zeal_NameplateX</Pieces>
+	<Pieces>Zeal_NameplateRaidPets</Pieces>
 	<Pieces>Section_Nameplate</Pieces>
 	<Pieces>Zeal_BtnDivider</Pieces>
 

--- a/Zeal/uifiles/zeal/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_General.xml
@@ -422,68 +422,7 @@
     </ButtonDrawTemplate>
   </Button>
   <!-- end -->
-    <!-- Zeal Nameplates -->
-  <Button item="Zeal_NameplateColors">
-    <ScreenID>Zeal_NameplateColors</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>10</X>
-      <Y>266</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>20</CY>
-    </Size>
-    <Style_VScroll>false</Style_VScroll>
-    <Style_HScroll>false</Style_HScroll>
-    <Style_Transparent>false</Style_Transparent>
-    <Style_Checkbox>true</Style_Checkbox>
-    <TooltipReference>Adds custom coloring to raid, group, afk and ld</TooltipReference>
-    <Text>Player Name colors</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <ButtonDrawTemplate>
-      <Normal>A_BtnNormal</Normal>
-      <Pressed>A_BtnPressed</Pressed>
-      <Flyby>A_BtnFlyby</Flyby>
-      <Disabled>A_BtnDisabled</Disabled>
-      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
-    </ButtonDrawTemplate>
-  </Button>
-    <Button item="Zeal_NameplateConColors">
-    <ScreenID>Zeal_NameplateConColors</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>10</X>
-      <Y>288</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>20</CY>
-    </Size>
-    <Style_VScroll>false</Style_VScroll>
-    <Style_HScroll>false</Style_HScroll>
-    <Style_Transparent>false</Style_Transparent>
-    <Style_Checkbox>true</Style_Checkbox>
-    <TooltipReference>Renders npc names in the color of your con</TooltipReference>
-    <Text>Name Con Colors</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <ButtonDrawTemplate>
-      <Normal>A_BtnNormal</Normal>
-      <Pressed>A_BtnPressed</Pressed>
-      <Flyby>A_BtnFlyby</Flyby>
-      <Disabled>A_BtnDisabled</Disabled>
-      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
-    </ButtonDrawTemplate>
-  </Button>
-  
+    
   <Page item="Tab_General">
     <ScreenID>Tab_General</ScreenID>
     <RelativePosition>true</RelativePosition>
@@ -522,8 +461,6 @@
     <Pieces>Zeal_RaidEscapeLock</Pieces>
     <Pieces>Zeal_ClassicClasses</Pieces>
     <Pieces>Zeal_TellWindows</Pieces>
-	<Pieces>Zeal_NameplateColors</Pieces>
-	<Pieces>Zeal_NameplateConColors</Pieces>
     <Pieces>Zeal_Timestamps_Combobox</Pieces>
     <Location>
       <X>0</X>


### PR DESCRIPTION
Nameplate options update: (Zeal Color Tab)

Moved Nameplate Options off Zeal General tab to Zeal Colors Tab
Added six new colors - Con Colors - in case other color changes clash with Con Colors
Added 3 commands, /nameplateself /nameplatex /nameplateraidpets
Zeal Colors Tab has new buttons for the new commands
Has skeleton nameplate fix for skeleton corpses, both pc and npc
Player now has more control over Nameplates.
-A player can turn their own Nameplate off and on.
-A player can replace their nameplate with an X.
-A player can turn off pet Nameplates for self and other Raid members.

Re-opened after properly updating to master on Zeals main page