### PR TITLE
Add map grid option, adjustable length map names, and multiple map markers with labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,15 @@ background will scroll with the player centered in the viewport.
 * Command examples:
   - `/map zoom 200` sets map scaling to 200% (2x)
 
+#### Map grid
+A simple background grid aligned at a selectable pitch is available. The x == 0 and y == 0 axes
+are colored orange.
+
+* Command examples:
+  - `/map grid` toggles grid on and off
+  - `/map grid 500` sets the grid pitch to 500 loc units (lines at multiples of 500)
+  - `/map save_ini` saves the currently set grid enable and pitch as defaults
+
 #### Showing group and raid members
 The map supports showing the live position of other group and raid members. The group
 member markers are slighly shrunken player position markers and colored in this order

--- a/README.md
+++ b/README.md
@@ -476,15 +476,19 @@ the zones are properly colored, but it does work well in some of the 3-D overlap
   - `/map level 0` shows default of all levels
   - `/map level 2` shows the current zone's level 2 data
 
-#### Position marker
-The map supports adding a position marker to easier identification of target coordinates.
+#### Position markers
+The map supports adding position markers for easier identification of target coordinates. The
+markers have a label centered above them, with the default set to the marker loc values. There
+is no set limit to the number of markers. See how to clear them below.
 
 * Zeal options slider to adjust the marker size
 * Command examples:
-  - `/map marker 1100 -500` sets a map marker at /loc of 1100, -500
+  - `/map marker 1100 -500` adds a map marker at /loc of 1100, -500 labeled "(1100, -500)"
   - `/map 1100 -500` is a shortcut for the command above to set a marker at 1100, -500
-  - `/map marker` clears the marker
-  - `/map 0` is a shortcut for clearing the marker
+  - `/map marker -300 200 camp` adds a map marker at /loc of -300, 200 labeled "camp"
+  - `/map marker` clears all markers
+  - `/map 0` is a shortcut for clearing all markers
+  - `/map marker size 40` sets the marker size to "40%"
 
 #### Map font
 The map supports selecting a "spritefont" formatted bitmap font file. A few sizes of arial
@@ -506,9 +510,9 @@ up the map even in zoom. The keybind to toggle through the label modes is recomm
 * Key bind: "Toggle Map Labels" - toggles through the labels modes
 * Command examples:
   - `/map poi` lists the available poi's, including their indices
-  - `/map poi 4` drops a marker on index [4] of the `/map poi` list
+  - `/map poi 4` adds a marker on index [4] of the `/map poi` list
   - `/map poi butcherblock` performs a text search of the poi list for butcherblock, reports 
-     any matches, and drops a marker on the first one
+     any matches, and adds a marker on the first one
   - `/map butcherblock` shortcut for above (does not work for terms that match other commands)
   - `/map labels summary` enables the summary labels (other options are `off`, `all`, or `marker`)
 

--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ in the options tab and instead use the key bind to situationally toggle it on an
   - `/map show_group labels_off` disables group member labels
   - `/map show_group numbers` enables numeric (F2-F6) group member labels (uses nameplate colors)
   - `/map show_group names` enables shortened group member names (uses nameplate colors)
+  - `/map show_group length 8` sets the shortened length of group and raid member names to 8
   - `/map show_raid` toggles the raid member markers on and off
 
 #### Showing map levels

--- a/Zeal/zone_map.h
+++ b/Zeal/zone_map.h
@@ -43,6 +43,8 @@ public:
 	void set_show_group(bool enable, bool update_default = true);
 	void set_show_raid(bool enable, bool update_default = true);
 	void set_show_all_names_override(bool flag);  // Override to enable showing group and raid names.
+	void set_show_grid(bool enable, bool update_default = true);
+	bool set_grid_pitch(int new_pitch, bool update_default = true);
 	bool set_map_data_mode(int new_mode, bool update_default = true);
 	bool set_background(int new_state, bool update_default = true); // [clear, dark, light, tan]
 	bool set_background_alpha(int percent, bool update_default = true);
@@ -62,6 +64,8 @@ public:
 	bool is_external_enabled() const { return external_enabled; }
 	bool is_show_group_enabled() const { return map_show_group; }
 	bool is_show_raid_enabled() const { return map_show_raid; }
+	bool is_show_grid_enabled() const { return map_show_grid; }
+	int get_grid_pitch() const { return map_grid_pitch; }
 	int get_map_data_mode() const { return static_cast<int>(map_data_mode); }
 	int get_background() const { return static_cast<int>(map_background_state); }
 	int get_background_alpha() const { return static_cast<int>(map_background_alpha * 100 + 0.5f); }
@@ -110,6 +114,7 @@ private:
 	};
 
 	static constexpr int kInvalidZoneId = 0;
+	static constexpr int kDefaultGridPitch = 1000;
 	static constexpr float kDefaultBackgroundAlpha = 0.5f;
 	static constexpr float kDefaultRectTop = 0.1f;
 	static constexpr float kDefaultRectLeft = 0.1f;
@@ -134,6 +139,7 @@ private:
 	void parse_map_data_mode(const std::vector<std::string>& args);
 	void parse_show_group(const std::vector<std::string>& args);
 	void parse_show_raid(const std::vector<std::string>& args);
+	void parse_grid(const std::vector<std::string>& args);
 	void parse_font(const std::vector<std::string>& args);
 	void parse_poi(const std::vector<std::string>& args);
 	bool search_poi(const std::string& search);
@@ -160,6 +166,7 @@ private:
 	void render_load_labels(IDirect3DDevice8& device, const ZoneMapData& zone_map_data);
 	void render_map(IDirect3DDevice8& device);
 	void render_background(IDirect3DDevice8& device);
+	void render_grid(IDirect3DDevice8& device);
 	void render_positions(IDirect3DDevice8& device);
 	void render_group_member_labels(IDirect3DDevice8& device);
 	void render_raid_member_labels(IDirect3DDevice8& device);
@@ -167,6 +174,7 @@ private:
 	void render_labels(IDirect3DDevice8& device);
 	void render_label_text(const char* label, int map_y, int map_x, D3DCOLOR font_color,
 		LabelType label_type = LabelType::Normal, Vec2 offset_pixels = { 0,0 });
+	std::vector<ZoneMap::MapVertex> calculate_grid_vertices(const ZoneMapData& zone_map_data) const;
 	void add_position_marker_vertices(float map_y, float map_x, float heading, float size,
 		D3DCOLOR color, std::vector<MapVertex>& vertices) const;
 	void add_group_member_position_vertices(std::vector<MapVertex>& vertices) const;
@@ -186,6 +194,8 @@ private:
 
 	bool enabled = false;
 	bool external_enabled = false;  // External map window enable and sizes.
+	bool map_show_grid = false;
+	int map_grid_pitch = kDefaultGridPitch;  // Pitch when grid is visible.
 	bool map_show_group = false;
 	bool map_show_raid = false;
 	bool map_show_all_names_override = false;  // Meant as a temporary override to flash names.
@@ -226,6 +236,7 @@ private:
 
 	std::vector<const ZoneMapLabel*> labels_list;  // List of pointers to visible map labels.
 	int line_count = 0;  // # of primitives in line buffer.
+	int grid_line_count;  // # of primitives at end of line buffer.
 	IDirect3DVertexBuffer8* line_vertex_buffer = nullptr;
 	IDirect3DVertexBuffer8* position_vertex_buffer = nullptr;
 	IDirect3DVertexBuffer8* marker_vertex_buffer = nullptr;

--- a/Zeal/zone_map.h
+++ b/Zeal/zone_map.h
@@ -106,6 +106,12 @@ private:
 		D3DCOLOR color = 0;
 	};
 
+	struct Marker {
+		int loc_y = 0;
+		int loc_x = 0;
+		std::string label;
+	};
+
 	struct CustomMapData {
 		std::vector<ZoneMapLine> lines;  // Contains heap memory for zone_map_data.
 		std::vector<ZoneMapLabel> labels;
@@ -146,8 +152,8 @@ private:
 	void parse_font(const std::vector<std::string>& args);
 	void parse_poi(const std::vector<std::string>& args);
 	bool search_poi(const std::string& search);
-	void set_marker(int y, int x);
-	void clear_marker(bool invalidate_zone_id = true);
+	void set_marker(int y, int x, const char* label = nullptr);
+	void clear_markers(bool erase_list = true);
 	bool set_map_rect(float top, float left, float bottom, float right, bool update_default = false);
 	bool set_level(int level);  // Set to 0 to show all levels.
 	void update_ui_options();
@@ -170,6 +176,7 @@ private:
 	void render_map(IDirect3DDevice8& device);
 	void render_background(IDirect3DDevice8& device);
 	void render_grid(IDirect3DDevice8& device);
+	void render_markers(IDirect3DDevice8& device);
 	void render_positions(IDirect3DDevice8& device);
 	void render_group_member_labels(IDirect3DDevice8& device);
 	void render_raid_member_labels(IDirect3DDevice8& device);
@@ -210,10 +217,8 @@ private:
 	GroupLabelsMode::e map_group_labels_mode = GroupLabelsMode::kOff;
 	MapDataMode::e map_data_mode = MapDataMode::kInternal;
 	int zone_id = kInvalidZoneId;
-	int marker_zone_id = kInvalidZoneId;
+	std::vector<Marker> markers_list;
 	bool always_align_to_center = false;
-	int marker_x = 0;
-	int marker_y = 0;
 	int map_level_zone_id = kInvalidZoneId;
 	int map_level_index = 0;
 	int dynamic_labels_zone_id = kInvalidZoneId;

--- a/Zeal/zone_map.h
+++ b/Zeal/zone_map.h
@@ -45,6 +45,7 @@ public:
 	void set_show_all_names_override(bool flag);  // Override to enable showing group and raid names.
 	void set_show_grid(bool enable, bool update_default = true);
 	bool set_grid_pitch(int new_pitch, bool update_default = true);
+	bool set_name_length(int new_length, bool update_default = true);
 	bool set_map_data_mode(int new_mode, bool update_default = true);
 	bool set_background(int new_state, bool update_default = true); // [clear, dark, light, tan]
 	bool set_background_alpha(int percent, bool update_default = true);
@@ -115,6 +116,8 @@ private:
 
 	static constexpr int kInvalidZoneId = 0;
 	static constexpr int kDefaultGridPitch = 1000;
+	static constexpr int kDefaultNameLength = 5;
+	static constexpr int kMaxNameLength = 20;  // Name buffer is >= 30.
 	static constexpr float kDefaultBackgroundAlpha = 0.5f;
 	static constexpr float kDefaultRectTop = 0.1f;
 	static constexpr float kDefaultRectLeft = 0.1f;
@@ -196,6 +199,7 @@ private:
 	bool external_enabled = false;  // External map window enable and sizes.
 	bool map_show_grid = false;
 	int map_grid_pitch = kDefaultGridPitch;  // Pitch when grid is visible.
+	int map_name_length = kDefaultNameLength;  // Number of characters in name labels.
 	bool map_show_group = false;
 	bool map_show_raid = false;
 	bool map_show_all_names_override = false;  // Meant as a temporary override to flash names.


### PR DESCRIPTION
 Add multiple map markers with labels support
    - Modified markers interface to support multiple markers (no hard
      limit)
    - Markers now have a text label above them, which is either the
      default loc coordinates or a user specified label

Make map group and raid name length adjustable
    - Added a map show_group length # command to set the
      length of the labels

Add a simple map grid option
    - Adds the /map grid command which enables a background
      coordinate grid at a selectable pitch