### PR TITLE
Update zeal color tab add divider con colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ ___
   - **Description:** Outputs the players buff timers to the chat only if they are using OldUI.
 
 - `/bluecon`
-  - **Description:** Changes the blue con color to usercolor #70 which is otherwise unused, you can edit in the options window.
+  - **Description:** Changes the blue con color to Zeal Color Button #15 which is in the Zeal Options window, Colors Tab.
 
 - `/alarm`
   - **Arguments:** `oldui`

--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -4,12 +4,12 @@
 #include "EqUI.h"
 #include <cstdarg>
 
-#define CON_WHITE D3DCOLOR_ARGB(0x88, 0xf0, 0xf0, 0xf0)
-#define CON_RED D3DCOLOR_ARGB(0x88, 0xf0, 0x0, 0x0)
-#define CON_BLUE ZealService::get_instance()->ui->options->GetColor(14)// D3DCOLOR_ARGB(0x88, 0x0, 0x0, 0xf0)
-#define CON_YELLOW D3DCOLOR_ARGB(0x88, 0xf0, 0xf0, 0x0)
-#define CON_LIGHTBLUE D3DCOLOR_ARGB(0x88, 0x0, 0xf0, 0xf0)
-#define CON_GREEN D3DCOLOR_ARGB(0x88, 0x0, 0xf0, 0x0)
+#define CON_WHITE ZealService::get_instance()->ui->options->GetColor(15) //D3DCOLOR_ARGB(0x88, 0xf0, 0xf0, 0xf0)
+#define CON_RED ZealService::get_instance()->ui->options->GetColor(17) //D3DCOLOR_ARGB(0x88, 0xf0, 0x0, 0x0)
+#define CON_BLUE ZealService::get_instance()->ui->options->GetColor(14)//D3DCOLOR_ARGB(0xff, 0x0, 0x40, 0xf0) Slightly lighter by default
+#define CON_YELLOW ZealService::get_instance()->ui->options->GetColor(16) //D3DCOLOR_ARGB(0x88, 0xf0, 0xf0, 0x0)
+#define CON_LIGHTBLUE ZealService::get_instance()->ui->options->GetColor(13) //D3DCOLOR_ARGB(0x88, 0x0, 0xf0, 0xf0)
+#define CON_GREEN ZealService::get_instance()->ui->options->GetColor(12) //D3DCOLOR_ARGB(0x88, 0x0, 0xf0, 0x0)
 
 enum Stance
 {

--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -22,12 +22,6 @@ void NamePlate::HandleTint(Zeal::EqStructures::Entity* spawn)
 	Zeal::EqStructures::EQARGBCOLOR Adventurercolor = options->GetColor(9); //0xFF3D6BDC; //Not in Guild Member - Default Blue
 	Zeal::EqStructures::EQARGBCOLOR NpcCorpsecolor = options->GetColor(10); //0xFF000000; //Npc Corpse - Black
 	Zeal::EqStructures::EQARGBCOLOR PlayersCorpsecolor = options->GetColor(11); //0xFFFFFFFF; //Players Corpse - White Light Purple
-	Zeal::EqStructures::EQARGBCOLOR BlueConcolor = options->GetColor(14); //BlueCon - Default DarkBlue is ligher than CON_BLUE
-	Zeal::EqStructures::EQARGBCOLOR GreenConcolor = options->GetColor(12); //CON_GREEN
-	Zeal::EqStructures::EQARGBCOLOR LightBlueConcolor = options->GetColor(13); //CON_LIGHTBLUE
-	Zeal::EqStructures::EQARGBCOLOR WhiteConcolor = options->GetColor(15); //CON_WHITE
-	Zeal::EqStructures::EQARGBCOLOR YellowConcolor = options->GetColor(16); //CON_YELLOW
-	Zeal::EqStructures::EQARGBCOLOR RedConcolor = options->GetColor(17); //CON_RED
 	switch (spawn->Type) {
 	case 0: //Players
 		if (nameplateColors) 
@@ -129,30 +123,6 @@ void NamePlate::HandleTint(Zeal::EqStructures::Entity* spawn)
 		if (nameplateconColors) {
 			if (spawn == Zeal::EqGame::get_target()) //Leave blinking indicator on target
 				return;
-			if (Zeal::EqGame::GetLevelCon(spawn) == CON_GREEN) { //Changes NPC Green Con to user selected Color
-				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = GreenConcolor;
-				return;
-			}
-			if (Zeal::EqGame::GetLevelCon(spawn) == CON_LIGHTBLUE) { //Changes NPC Light Blue Con to user selected Color
-				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = LightBlueConcolor;
-				return;
-			}
-			if (Zeal::EqGame::GetLevelCon(spawn) == CON_BLUE){ //Changes NPC DarkBlue Con to user selected Color
-				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = BlueConcolor;
-				return;
-			}
-			if (Zeal::EqGame::GetLevelCon(spawn) == CON_WHITE) { //Changes NPC White Con to user selected Color
-				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = WhiteConcolor;
-				return;
-			}
-			if (Zeal::EqGame::GetLevelCon(spawn) == CON_YELLOW) { //Changes NPC Yellow Con to user selected Color
-				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = YellowConcolor;
-				return;
-			}
-			if (Zeal::EqGame::GetLevelCon(spawn) == CON_RED) { //Changes NPC Red Con to user selected Color
-				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = RedConcolor;
-				return;
-			}
 			if (spawn != Zeal::EqGame::get_self()) //All NPC entities
 				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = Zeal::EqGame::GetLevelCon(spawn); //Level Con Color for NPCs
 		}

--- a/Zeal/uifiles/zeal/EQUI_Tab_Colors.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_Colors.xml
@@ -402,12 +402,62 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
+  <Label item="Section_NameplateNPC">
+    <ScreenID>Section_NameplateNPC</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>132</X>
+      <Y>186</Y>
+    </Location>
+    <Size>
+      <CX>160</CX>
+      <CY>16</CY>
+    </Size>
+    <Text>Nameplate Con Colors</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
+  <Button item="Zeal_BtnDividerNPC">
+    <ScreenID>Zeal_BtnDividerNPC</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>0</X>
+      <Y>206</Y>
+    </Location>
+    <Size>
+      <CX>380</CX>
+      <CY>2</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>-</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
 <Button item="Zeal_Color12">
     <ScreenID>Zeal_Color12</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>164</Y>
+      <Y>216</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -417,7 +467,7 @@
     <Style_HScroll>false</Style_HScroll>
     <Style_Transparent>false</Style_Transparent>
     <Style_Checkbox>false</Style_Checkbox>
-    <Text>13 - Green Con - NPCs</Text>
+    <Text>13 - Green Con</Text>
     <TextColor>
       <R>255</R>
       <G>255</G>
@@ -436,7 +486,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>200</X>
-      <Y>164</Y>
+      <Y>216</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -446,7 +496,7 @@
     <Style_HScroll>false</Style_HScroll>
     <Style_Transparent>false</Style_Transparent>
     <Style_Checkbox>false</Style_Checkbox>
-    <Text>14 - LightBlue Con-NPCs</Text>
+    <Text>14 - LightBlue Con</Text>
     <TextColor>
       <R>255</R>
       <G>255</G>
@@ -465,7 +515,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>186</Y>
+      <Y>238</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -475,7 +525,7 @@
     <Style_HScroll>false</Style_HScroll>
     <Style_Transparent>false</Style_Transparent>
     <Style_Checkbox>false</Style_Checkbox>
-    <Text>15 - Blue Con - NPCS</Text>
+    <Text>15 - Blue Con</Text>
     <TextColor>
       <R>255</R>
       <G>255</G>
@@ -494,7 +544,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>200</X>
-      <Y>186</Y>
+      <Y>238</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -504,7 +554,7 @@
     <Style_HScroll>false</Style_HScroll>
     <Style_Transparent>false</Style_Transparent>
     <Style_Checkbox>false</Style_Checkbox>
-    <Text>16 - White Con - NPCs</Text>
+    <Text>16 - White Con</Text>
     <TextColor>
       <R>255</R>
       <G>255</G>
@@ -523,7 +573,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>208</Y>
+      <Y>260</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -533,7 +583,7 @@
     <Style_HScroll>false</Style_HScroll>
     <Style_Transparent>false</Style_Transparent>
     <Style_Checkbox>false</Style_Checkbox>
-    <Text>17 - Yellow Con - NPCs</Text>
+    <Text>17 - Yellow Con</Text>
     <TextColor>
       <R>255</R>
       <G>255</G>
@@ -552,7 +602,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>200</X>
-      <Y>208</Y>
+      <Y>260</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -562,7 +612,7 @@
     <Style_HScroll>false</Style_HScroll>
     <Style_Transparent>false</Style_Transparent>
     <Style_Checkbox>false</Style_Checkbox>
-    <Text>18 - Red Con - NPCs</Text>
+    <Text>18 - Red Con</Text>
     <TextColor>
       <R>255</R>
       <G>255</G>
@@ -615,7 +665,9 @@
 	<Pieces>Zeal_Color16</Pieces>
 	<Pieces>Zeal_Color17</Pieces>
 	<Pieces>Section_Nameplate</Pieces>
+	<Pieces>Section_NameplateNPC</Pieces>
 	<Pieces>Zeal_BtnDivider</Pieces>
+	<Pieces>Zeal_BtnDividerNPC</Pieces>
 
     <Location>
       <X>0</X>


### PR DESCRIPTION
Fix BlueCon description in Readme to point to new Zeal Color Button#15
Update EqFunctions.h so that six ConColors are same across Zeal
Remove duplicate ConColor code in Nameplate.cpp
Update to XML Zeal Options, Color Tab :  Added divider for Nameplate Con Colors