### PR TITLE
Restrict /useitem to match server side effect list

### DIFF
--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -1475,11 +1475,16 @@ namespace Zeal
 			}
 			if (item->Type != 0 || !item->Common.SpellId)
 			{
-				Zeal::EqGame::print_chat("item %s does not have a spell attached to it.", item->Name);
+				Zeal::EqGame::print_chat("Item %s does not have a spell attached to it.", item->Name);
 				return false;
 			}
-			if (item->Common.EffectType == 2) {
-				Zeal::EqGame::print_chat("item %s has a worn effect.", item->Name);
+			// List of checks copied from eqemu/zone/client_packet.cpp:
+			if ((item->Common.EffectType != Zeal::EqEnums::ItemEffect::ItemEffectClick) &&
+				(item->Common.EffectType != Zeal::EqEnums::ItemEffect::ItemEffectExpendable) &&
+				(item->Common.EffectType != Zeal::EqEnums::ItemEffect::ItemEffectEquipClick) &&
+				(item->Common.EffectType != Zeal::EqEnums::ItemEffect::ItemEffectClick2))
+			{
+				Zeal::EqGame::print_chat("Item %s does not have a click effect.", item->Name);
 				return false;
 			}
 			if (!self->ActorInfo || self->ActorInfo->CastingSpellId != kInvalidSpellId)

--- a/Zeal/EqStructures.h
+++ b/Zeal/EqStructures.h
@@ -216,6 +216,17 @@ namespace Zeal
 
 		};
 
+		enum ItemEffect {
+			ItemEffectCombatProc = 0,
+			ItemEffectClick,
+			ItemEffectWorn,
+			ItemEffectExpendable,
+			ItemEffectEquipClick,
+			ItemEffectClick2, //5		//name unknown
+			ItemEffectFocus,
+			ItemEffectScroll,
+			ItemEffectCount
+		};
 
 	}
 	namespace EqStructures


### PR DESCRIPTION
- Rejects /useitem on combat proc and worn effects using a filter list that matches the server side