### PR TITLE
Improve /lead and consolidate raid/group info

### DIFF
--- a/Zeal/EqAddresses.h
+++ b/Zeal/EqAddresses.h
@@ -17,8 +17,8 @@ namespace Zeal
 		static EqStructures::Entity* Active_Corpse = (Zeal::EqStructures::Entity*)0x7f9500;
 		static EqStructures::Entity* EntListPtr = (Zeal::EqStructures::Entity*)0x7f9498;
 		static EqStructures::CameraInfo* CameraInfo = (Zeal::EqStructures::CameraInfo*)0x63B928;
-		static EqStructures::Entity* GroupList = (Zeal::EqStructures::Entity*)0x7913F8;
-		static char* GroupLeaderName = (char*)(0x0079140c);  // Empty string is ungrouped.
+		static EqStructures::GroupInfo* GroupInfo = (Zeal::EqStructures::GroupInfo*)0x007912B0;
+		static EqStructures::RaidInfo* RaidInfo = (EqStructures::RaidInfo*)0x7914D0;
 		static EqStructures::ViewActor* ViewActor = (EqStructures::ViewActor*)0x63D6C0;
 		static EqStructures::KeyboardModifiers* KeyMods = (EqStructures::KeyboardModifiers*)0x799738;
 		static EqUI::pInstWindows* Windows = (EqUI::pInstWindows*)0x63D5CC;
@@ -43,8 +43,7 @@ namespace Zeal
 		static int max_pitch = 0x5e86d0;
 		static EqStructures::KeyboardInput* KeyInput = (EqStructures::KeyboardInput*)0x7ce058;
 		static char* in_game = (char*)0x798550;
-		static int RaidMemberList = 0x791518;
-		
+
 		//Vec3* camera_position = *(Vec3**)0x9c08128;
 	}
 }

--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -164,6 +164,13 @@ namespace Zeal
 		int get_region_from_pos(Vec3* pos);
 		EqUI::CXWndManager* get_wnd_manager();
 		std::vector<Zeal::EqStructures::RaidMember*> get_raid_list();
+		DWORD get_raid_group_number();
+		int get_raid_group_count(DWORD group_number);
+		std::string get_raid_group_leader(DWORD group_number);
+		void print_group_leader();
+		void print_raid_leaders(bool show_all_groups = false, bool show_open_groups = false);
+		void print_raid_ungrouped();
+		void dump_raid_state();
 		std::string generateTimestamp();
 		bool use_item(int item_index);
 	}

--- a/Zeal/EqStructures.h
+++ b/Zeal/EqStructures.h
@@ -777,18 +777,48 @@ namespace Zeal
 		{
 			char name[512][0x60];
 		};
+		struct GroupInfo
+		{
+			// Unlike RaidInfo this is not treated as a monolithic structure in the code
+			// but this is the memory layout for the variables below.
+			/* 0x0000 */ BYTE IsValidList[EQ_NUM_GROUP_MEMBERS];  // 1 = Valid group member, 0 = empty.
+		    /* 0x0005 */ CHAR Names[EQ_NUM_GROUP_MEMBERS][64];
+			/* 0x0145 */ CHAR Unknown0143[3];  // Alignment padding probably.
+			/* 0x0148 */ struct Entity* EntityList[EQ_NUM_GROUP_MEMBERS];
+			/* 0x015C */ CHAR LeaderName[64];  // Empty string is ungrouped.
+
+			bool is_in_group() const { return (LeaderName[0] != 0); }
+		};
 		struct RaidMember // starts at 0x791518, size 0x00D0
 		{			
+			static constexpr int kRaidUngrouped = 0xffffffff;
 			/* 0x0000 */ CHAR Name[64];
-			/* 0x0040 */ CHAR PlayerLevel[2];
-			/* 0x0042 */ BYTE Unknown0042[6];
-			/* 0x0048 */ CHAR Class[64];
-			/* 0x0088 */ BYTE Unknown0048[64];
-			/* 0x00C8 */ BYTE Unknown00C8; // always 2 ?
-			/* 0x00C9 */ BYTE Unknown00C9;
+			/* 0x0040 */ CHAR PlayerLevel[8];  // Level in text.
+			/* 0x0048 */ CHAR Class[64];       // Class text label.
+			/* 0x0088 */ BYTE Unknown0088[64];
+			/* 0x00C8 */ USHORT ClassValue;    // Binary enum value of Class
 			/* 0x00CA */ BYTE Unknown00CA;
 			/* 0x00CB */ BYTE IsGroupLeader; // 0: not leader 1: leader
 			/* 0x00CC */ DWORD GroupNumber; // FFFFFFFF if ungrouped
+		};
+		struct RaidInfo {
+			static constexpr int kRaidMaxMembers = 72;
+			static constexpr int kRaidMaxLooters = 9;  // Calculated from memset of 0x240 bytes.
+			/* 0x0000 */ CHAR Unknown0000[72];  // Set to 0 at reset.
+			/* 0x0048 */ RaidMember MemberList[kRaidMaxMembers];
+			/* 0x3ac8 */ DWORD Id;
+			/* 0x3acc */ DWORD MemberCount;    // # of raid members
+			/* 0x3ad0 */ CHAR LeaderName[64];  // Name of raid leader
+			/* 0x3b10 */ CHAR Unknown3B10[64];
+			/* 0x3b50 */ DWORD Unknown3B50;    // Set to 1 when empty, 4 when programmed?
+			/* 0x3b54 */ CHAR Unknown3B54;
+			/* 0x3b55 */ CHAR IsLeader;        // 1 = Leader of raid
+			/* 0x3b56 */ CHAR Unknown3B56[2];
+			/* 0x3b58 */ DWORD Unknown3B58;    // Set to 0xffffffff at reset.
+			/* 0x3b5c */ DWORD LootType;       // Raid loot 
+			/* 0x3b60 */ CHAR LooterNames[kRaidMaxLooters][64];  // See 0x240 cleared to zero.
+
+			bool is_in_raid() const { return (MemberCount > 0); }
 		};
 		struct MouseDelta
 		{

--- a/Zeal/commands.cpp
+++ b/Zeal/commands.cpp
@@ -418,9 +418,21 @@ ChatCommands::ChatCommands(ZealService* zeal)
 				}
 			return false;
 		});
-		Add("/lead", {}, "Print current group leader", [this, zeal](std::vector<std::string>& args) {
-			const char* leader = Zeal::EqGame::GroupLeaderName;
-			Zeal::EqGame::print_chat("Group leader: %s", *leader ? leader : "Not in a group");
+		Add("/lead", {}, "Print current group and raid leaders", [this, zeal](std::vector<std::string>& args) {
+			Zeal::EqStructures::RaidInfo* raid_info = Zeal::EqGame::RaidInfo;
+
+			if (raid_info->is_in_raid())
+			{
+				bool show_all = (args.size() == 2 && args[1] == "all");
+				bool show_open = (args.size() == 2 && args[1] == "open");
+				Zeal::EqGame::print_raid_leaders(show_all, show_open);
+			}
+			else
+				Zeal::EqGame::print_group_leader();
+
+			if (args.size() == 2 && args[1] == "dump")
+				Zeal::EqGame::dump_raid_state();
+
 			return true;
 			});
 		Add("/help", { "/hel" }, "Adds zeal to the help list.",

--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -26,11 +26,11 @@ void NamePlate::HandleTint(Zeal::EqStructures::Entity* spawn)
 	case 0: //Players
 		if (nameplateColors) 
 		{
-			uint8_t isInGroup = *(uint8_t*)0x7912B0;
-			uint16_t raidSize = *(uint16_t*)0x794F9C;
+			uint8_t isInGroup = Zeal::EqGame::GroupInfo->is_in_group();
+			auto raidSize = Zeal::EqGame::RaidInfo->MemberCount;
 			Zeal::EqStructures::Entity* self = Zeal::EqGame::get_self();
-			Zeal::EqStructures::Entity** groupmembers = reinterpret_cast<Zeal::EqStructures::Entity**>(Zeal::EqGame::GroupList);
-			Zeal::EqStructures::RaidMember* raidMembers = reinterpret_cast<Zeal::EqStructures::RaidMember*>(Zeal::EqGame::RaidMemberList);
+			Zeal::EqStructures::Entity** groupmembers = reinterpret_cast<Zeal::EqStructures::Entity**>(Zeal::EqGame::GroupInfo->EntityList);
+			const Zeal::EqStructures::RaidMember* raidMembers = &(Zeal::EqGame::RaidInfo->MemberList[0]);
 
 			if (spawn == Zeal::EqGame::get_target()) //Leave blinking indicator on target
 				return;
@@ -80,9 +80,9 @@ void NamePlate::HandleTint(Zeal::EqStructures::Entity* spawn)
 					self->ActorInfo->DagHeadPoint->StringSprite->Color = Raidcolor;
 					return;
 				}
-				for (int i = 0; i < 72; ++i) //Raid Member loop
+				for (int i = 0; i < Zeal::EqStructures::RaidInfo::kRaidMaxMembers; ++i) //Raid Member loop
 				{
-					Zeal::EqStructures::RaidMember member = raidMembers[i];
+					const Zeal::EqStructures::RaidMember& member = raidMembers[i];
 					if ((member.GroupNumber == 0xFFFFFFFF - 1) || (strlen(member.Name) == 0) || (strcmp(member.Name, Zeal::EqGame::get_self()->Name) == 0))
 						continue;
 					Zeal::EqStructures::Entity* raidMember = ZealService::get_instance()->entity_manager->Get(member.Name);
@@ -169,7 +169,7 @@ void NamePlate::HandleState(void* this_ptr, void* not_used, Zeal::EqStructures::
 	if (!spawn->ActorInfo->DagHeadPoint) { return; }
 	if (!spawn->ActorInfo->DagHeadPoint->StringSprite) { return; }
 	DWORD fontTexture = *(DWORD*)(*(DWORD*)0x7F9510 + 0x2E08); //get the font texture
-	Zeal::EqStructures::RaidMember* raidMembers = reinterpret_cast<Zeal::EqStructures::RaidMember*>(Zeal::EqGame::RaidMemberList);
+	const Zeal::EqStructures::RaidMember* raidMembers = &(Zeal::EqGame::RaidInfo->MemberList[0]);
 	if (spawn == Zeal::EqGame::get_self())
 	{
 		if (nameplateSelf)
@@ -202,9 +202,9 @@ void NamePlate::HandleState(void* this_ptr, void* not_used, Zeal::EqStructures::
 			SetNameSpriteTint(this_ptr, not_used, spawn);
 			return;
 		}
-		for (int i = 0; i < 72; ++i) //Raid Member loop
+		for (int i = 0; i < Zeal::EqStructures::RaidInfo::kRaidMaxMembers; ++i) //Raid Member loop
 		{
-			Zeal::EqStructures::RaidMember member = raidMembers[i];
+			const Zeal::EqStructures::RaidMember& member = raidMembers[i];
 			if ((member.GroupNumber == 0xFFFFFFFF - 1) || (strlen(member.Name) == 0) || (strcmp(member.Name, Zeal::EqGame::get_self()->Name) == 0))
 				continue;
 			Zeal::EqStructures::Entity* raidMember = ZealService::get_instance()->entity_manager->Get(member.Name);

--- a/Zeal/ui_group.cpp
+++ b/Zeal/ui_group.cpp
@@ -6,11 +6,7 @@
 #include "string_util.h"
 #include <algorithm>
 #include <cctype>
-using NameArrayType = char[0x40];
-using PtrArrayType = Zeal::EqStructures::Entity*;
 
-PtrArrayType* ptrArray = reinterpret_cast<PtrArrayType*>(0x7913F8);
-NameArrayType* nameArray = reinterpret_cast<NameArrayType*>(0x7912B5);
 
 void ui_group::InitUI()
 {
@@ -18,16 +14,17 @@ void ui_group::InitUI()
 }
 void ui_group::swap(UINT index1, UINT index2)
 {
+	auto* group_info = Zeal::EqGame::GroupInfo;
 	if (index1 < 5 && index2 < 5)
 	{
-		std::pair<std::string, Zeal::EqStructures::Entity*> Ent1 = std::make_pair(nameArray[index1], ptrArray[index1]);
-		std::pair<std::string, Zeal::EqStructures::Entity*> Ent2 = std::make_pair(nameArray[index2], ptrArray[index2]);
+		std::pair<std::string, Zeal::EqStructures::Entity*> Ent1 = std::make_pair(group_info->Names[index1], group_info->EntityList[index1]);
+		std::pair<std::string, Zeal::EqStructures::Entity*> Ent2 = std::make_pair(group_info->Names[index2], group_info->EntityList[index2]);
 
 		//move the strings
-		mem::copy((DWORD)(nameArray[index1]), (DWORD)Ent2.first.c_str(), Ent2.first.length()+1); //+1 don't forget string terminator
-		mem::copy((DWORD)(nameArray[index2]), (DWORD)Ent1.first.c_str(), Ent1.first.length()+1);
-		ptrArray[index1] = Ent2.second;
-		ptrArray[index2] = Ent1.second;
+		mem::copy((DWORD)(group_info->Names[index1]), (DWORD)Ent2.first.c_str(), Ent2.first.length()+1); //+1 don't forget string terminator
+		mem::copy((DWORD)(group_info->Names[index2]), (DWORD)Ent1.first.c_str(), Ent1.first.length()+1);
+		group_info->EntityList[index1] = Ent2.second;
+		group_info->EntityList[index2] = Ent1.second;
 	}
 	else
 	{
@@ -36,11 +33,12 @@ void ui_group::swap(UINT index1, UINT index2)
 }
 void ui_group::sort()
 {
+	auto* group_info = Zeal::EqGame::GroupInfo;
 	std::vector<std::pair<std::string, Zeal::EqStructures::Entity*>> group_members_sorted;
 	for (int i = 0; i < 5; i++)
 	{
-		std::pair<std::string, Zeal::EqStructures::Entity*> ent_pair = std::make_pair(nameArray[i], ptrArray[i]);
-		group_members_sorted.push_back({ nameArray[i], ptrArray[i]});
+		std::pair<std::string, Zeal::EqStructures::Entity*> ent_pair = std::make_pair(group_info->Names[i], group_info->EntityList[i]);
+		group_members_sorted.push_back({ group_info->Names[i], group_info->EntityList[i]});
 	}
 	std::sort(group_members_sorted.begin(), group_members_sorted.end(),
 		[](const std::pair<std::string, Zeal::EqStructures::Entity*>& a, const std::pair<std::string, Zeal::EqStructures::Entity*>& b) {
@@ -61,11 +59,11 @@ void ui_group::sort()
 
 			return lower_a < lower_b; 
 		});
-	mem::set(0x7913F8, 0, 20);//erase the pointer array 4 bytes * 5 members = 20 bytes
-	mem::set(0x7912B5, 0, 320);//erase the entire name array 64 characters * 5 members = 320 bytes
+	mem::set((uint32_t)group_info->EntityList, 0, sizeof(group_info->EntityList));//erase the pointer array
+	mem::set((uint32_t)group_info->Names, 0, sizeof(group_info->Names));//erase the pointer array
 	for (int i = 0; i < group_members_sorted.size(); ++i) {
-		mem::copy((DWORD)(nameArray[i]), (DWORD)group_members_sorted[i].first.c_str(), group_members_sorted[i].first.length());
-		ptrArray[i] = group_members_sorted[i].second;
+		mem::copy((DWORD)(group_info->Names[i]), (DWORD)group_members_sorted[i].first.c_str(), group_members_sorted[i].first.length());
+		group_info->EntityList[i] = group_members_sorted[i].second;
 	}
 }
 ui_group::~ui_group()


### PR DESCRIPTION
- Improved the output of the /lead command to handle raid groups as well as normal groups
- Added /lead open, all, dump to provide more raid info
- Consolidated the raid and group game info into two memory structures for easier / more consistent accesses and some additional fields