### PR TITLE
Show Nameplate Options at Charcacter Selection Screen

### DIFF
--- a/Zeal/nameplate.h
+++ b/Zeal/nameplate.h
@@ -12,17 +12,20 @@ public:
 	bool nameplateSelf = false;
 	bool nameplateX = false;
 	bool nameplateRaidPets = false;
+	bool nameplateCharSelect = false;
 
 	bool colors_is_enabled() const { return nameplateColors; }
 	bool con_colors_is_enabled() const { return nameplateconColors; }
 	bool self_is_enabled() const { return nameplateSelf; }
 	bool x_is_enabled() const { return nameplateX; }
 	bool raidpets_is_enabled() const { return nameplateRaidPets; }
+	bool charselect_is_enabled() const { return nameplateCharSelect; }
 	void colors_set_enabled(bool enabled);	
 	void con_colors_set_enabled(bool enabled);
 	void self_set_enabled(bool enabled);
 	void x_set_enabled(bool enabled);
 	void raidpets_set_enabled(bool enabled);
+	void charselect_set_enabled(bool enabled);
 	void HandleState(void* this_ptr, void* not_used, Zeal::EqStructures::Entity* spawn);
 	void HandleTint(Zeal::EqStructures::Entity* spawn);
 	NamePlate(class ZealService* zeal, class IO_ini* ini);

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -462,6 +462,7 @@ void ui_options::InitNameplate()
 	ui->AddCheckboxCallback(wnd, "Zeal_NameplateSelf", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->self_set_enabled(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_NameplateX", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->x_set_enabled(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_NameplateRaidPets", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->raidpets_set_enabled(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_NameplateCharSelect", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->charselect_set_enabled(wnd->Checked); });
 }
 
 void ui_options::UpdateOptions()
@@ -558,6 +559,7 @@ void ui_options::UpdateOptionsNameplate()
 	ui->SetChecked("Zeal_NameplateSelf", ZealService::get_instance()->nameplate->nameplateSelf);
 	ui->SetChecked("Zeal_NameplateX", ZealService::get_instance()->nameplate->nameplateX);
 	ui->SetChecked("Zeal_NameplateRaidpets", ZealService::get_instance()->nameplate->nameplateRaidPets);
+	ui->SetChecked("Zeal_NameplateCharSelect", ZealService::get_instance()->nameplate->nameplateCharSelect);
 }
 
 void ui_options::UpdateOptionsMap()

--- a/Zeal/uifiles/zeal/EQUI_Tab_Colors.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_Colors.xml
@@ -413,7 +413,7 @@
       <CX>160</CX>
       <CY>16</CY>
     </Size>
-    <Text>Nameplate Con Colors</Text>
+    <Text>Con Colors</Text>
     <TextColor>
       <R>255</R>
       <G>255</G>

--- a/Zeal/uifiles/zeal/EQUI_Tab_Nameplate.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_Nameplate.xml
@@ -152,6 +152,36 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
+<Button item="Zeal_NameplateCharSelect">
+    <ScreenID>Zeal_NameplateCharSelect</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>156</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Show Nameplate Options at Character Selection Screen</TooltipReference>
+    <Text>Character Select Screen</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
 
     <Page item="Tab_Nameplate">
     <ScreenID>Tab_Nameplate</ScreenID>
@@ -178,7 +208,7 @@
 	<Pieces>Zeal_NameplateSelf</Pieces>
 	<Pieces>Zeal_NameplateX</Pieces>
 	<Pieces>Zeal_NameplateRaidPets</Pieces>
-
+	<Pieces>Zeal_NameplateCharSelect</Pieces>
     <Location>
       <X>0</X>
       <Y>22</Y>


### PR DESCRIPTION
Adds Character Selection Screen button to the Nameplate Tab
-Gives the player the option for their Nameplate choices to display at the Character Selection Screen.

Default is set to disabled. Player will have to click button or use the /nameplatecharselect command to set their Nameplate choices to the Character Selection Screen.