### PR TITLE
Account for aa rank title in target nameplate logic (for Luclin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,18 @@ ___
 
 - `/nameplateraidpets`
   - **Description:** toggles nameplate for raid pets and your pet (on/off)
+ 
+- `/nameplatecharselect`
+  - **Description:** toggles nameplate choices shown at character selection screen on and off (on/off)
+
+- `/nameplatetargetcolor`
+  - **Description:** toggles target nameplate color on and off (on/off)
+ 
+- `/nameplatetargetmarker`
+  - **Description:** toggles target nameplate marker on and off (on/off)
+ 
+- `/nameplatetargethealth`
+  - **Description:** toggles target nameplate health on and off (on/off)
 ___
 ### Binds
 - Cycle through nearest NPCs
@@ -266,6 +278,10 @@ ___
 - Toggle nameplate for self on/off
 - Toggle nameplate for self as X on/off
 - Toggle nameplate for raid pets and your pet on/off
+- Toggle nameplate choices that are shown at character selection screen on and off
+- Toggle target nameplate color on and off
+- Toggle target nameplate marker on and off
+- Toggle target nameplate health on and off
 ___
 ### UI
 - **Gauge EqType's**
@@ -341,13 +357,17 @@ The nameplate is controlled through three interfaces:
 * The `/nameplateself` command - Toggles Player Nameplate on and off
 * The `/nameplatex` command - Toggles Player Nameplate as X on and off
 * The `/nameplateraidpets` command - Toggles NPC Raid Pets Nameplate on and off
+* The `/nameplatecharselect` command - Toggles Nameplate Choices Shown at Character Selection Screen on and off
+* The `/nameplatetargetcolor` command - Toggles Target Nameplate Color on and off
+* The `/nameplatetargetmarker` command - Toggles Target Nameplate Marker on and off
+* The `/nameplatetargethealth` command - Toggles Target Nameplate Health on and off
 
 #### Changing the Color of Nameplates
 Zeal allows players to change the colors of the Nameplates of Players and NPCs in game.
 The Color Selector is available in the Zeal Colors Tab of the Zeal Options menu.
 The following 18 Nameplate Colors can be changed to custom colors.
 * AFK, LFG, LD, MyGuild, Raid, Group, PVP, Roleplay, OtherGuilds, DefaultAdventurer
-* NPC Corpse, Player Corpse, GreenCon, LightBlueCon, BlueCon, WhiteCon, YellowCon, RedCon
+* NPC Corpse, Player Corpse, GreenCon, LightBlueCon, BlueCon, WhiteCon, YellowCon, RedCon, Target Color
 
 #### Default Colors of Nameplates when using Nameplate Colors system
 * 1 - AFK - Orange                   
@@ -367,7 +387,8 @@ The following 18 Nameplate Colors can be changed to custom colors.
 * 15 - Blue Con NPCs - Default DarkBlue is lighter than CON_BLUE
 * 16 - White Con NPCs - CON_WHITE
 * 17 - Yellow Con NPCs - CON_YELLOW
-* 18 - Red Con NPCs- CON_RED
+* 18 - Red Con NPCs - CON_RED
+* 19 - Target Color - Default Pink
 
 ### In-game Map
 #### Map data source

--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -1781,9 +1781,9 @@ namespace Zeal
 			switch (class_id)
 			{
 			case Zeal::EqEnums::ClassTypes::Warrior:
-				if (aa_rank == 1 && gender_id == 1)
+				if (aa_rank == 1 && gender_id == 0)
 					title_name = "Barron";
-				if (aa_rank == 1 && gender_id == 2)
+				if (aa_rank == 1 && gender_id == 1)
 					title_name = "Barroness";
 				if (aa_rank == 2)
 					title_name = "Veteran";
@@ -1791,9 +1791,9 @@ namespace Zeal
 					title_name = "Marshall";	
 				break;
 			case Zeal::EqEnums::ClassTypes::Cleric:
-				if (aa_rank == 1 && gender_id == 1)
+				if (aa_rank == 1 && gender_id == 0)
 					title_name = "Barron";
-				if (aa_rank == 1 && gender_id == 2)
+				if (aa_rank == 1 && gender_id == 1)
 					title_name = "Barroness";
 				if (aa_rank == 2)
 					title_name = "Venerable";
@@ -1801,49 +1801,49 @@ namespace Zeal
 					title_name = "Exarch";
 				break;
 			case Zeal::EqEnums::ClassTypes::Paladin:
-				if (aa_rank == 1 && gender_id == 1)
+				if (aa_rank == 1 && gender_id == 0)
 					title_name = "Barron";
-				if (aa_rank == 1 && gender_id == 2)
+				if (aa_rank == 1 && gender_id == 1)
 					title_name = "Barroness";
-				if (aa_rank == 2 && gender_id == 1)
+				if (aa_rank == 2 && gender_id == 0)
 					title_name = "Sir";
-				if (aa_rank == 2 && gender_id == 2)
+				if (aa_rank == 2 && gender_id == 1)
 					title_name = "Lady";
-				if (aa_rank == 3 && gender_id == 1)
+				if (aa_rank == 3 && gender_id == 0)
 					title_name = "Duke";
-				if (aa_rank == 3 && gender_id == 2)
+				if (aa_rank == 3 && gender_id == 1)
 					title_name = "Duchess";
 				break;
 			case Zeal::EqEnums::ClassTypes::Ranger:
-				if (aa_rank == 1 && gender_id == 1)
+				if (aa_rank == 1 && gender_id == 0)
 					title_name = "Barron";
-				if (aa_rank == 1 && gender_id == 2)
+				if (aa_rank == 1 && gender_id == 1)
 					title_name = "Barroness";
 				if (aa_rank == 2)
 					title_name = "Veteran";
-				if (aa_rank == 3 && gender_id == 1)
+				if (aa_rank == 3 && gender_id == 0)
 					title_name = "Hunter";
-				if (aa_rank == 3 && gender_id == 2)
+				if (aa_rank == 3 && gender_id == 1)
 					title_name = "Huntress";
 				break;
 			case Zeal::EqEnums::ClassTypes::Shadowknight:
-				if (aa_rank == 1 && gender_id == 1)
+				if (aa_rank == 1 && gender_id == 0)
 					title_name = "Barron";
-				if (aa_rank == 1 && gender_id == 2)
+				if (aa_rank == 1 && gender_id == 1)
 					title_name = "Barroness";
-				if (aa_rank == 2 && gender_id == 1)
+				if (aa_rank == 2 && gender_id == 0)
 					title_name = "Sir";
-				if (aa_rank == 2 && gender_id == 2)
+				if (aa_rank == 2 && gender_id == 1)
 					title_name = "Lady";
-				if (aa_rank == 3 && gender_id == 1)
+				if (aa_rank == 3 && gender_id == 0)
 					title_name = "Duke";
-				if (aa_rank == 3 && gender_id == 2)
+				if (aa_rank == 3 && gender_id == 1)
 					title_name = "Duchess";
 				break;
 			case Zeal::EqEnums::ClassTypes::Druid:
-				if (aa_rank == 1 && gender_id == 1)
+				if (aa_rank == 1 && gender_id == 0)
 					title_name = "Barron";
-				if (aa_rank == 1 && gender_id == 2)
+				if (aa_rank == 1 && gender_id == 1)
 					title_name = "Barroness";
 				if (aa_rank == 2)
 					title_name = "Venerable";
@@ -1851,33 +1851,33 @@ namespace Zeal
 					title_name = "Elder";
 				break;
 			case Zeal::EqEnums::ClassTypes::Monk:
-				if (aa_rank == 1 && gender_id == 1)
+				if (aa_rank == 1 && gender_id == 0)
 					title_name = "Barron";
-				if (aa_rank == 1 && gender_id == 2)
+				if (aa_rank == 1 && gender_id == 1)
 					title_name = "Barroness";
-				if (aa_rank == 2 && gender_id == 1)
+				if (aa_rank == 2 && gender_id == 0)
 					title_name = "Brother";
-				if (aa_rank == 2 && gender_id == 2)
+				if (aa_rank == 2 && gender_id == 1)
 					title_name = "Sister";
 				if (aa_rank == 3)
 					title_name = "Sensei";
 				break;
 			case Zeal::EqEnums::ClassTypes::Bard:
-				if (aa_rank == 1 && gender_id == 1)
+				if (aa_rank == 1 && gender_id == 0)
 					title_name = "Barron";
-				if (aa_rank == 1 && gender_id == 2)
+				if (aa_rank == 1 && gender_id == 1)
 					title_name = "Barroness";
 				if (aa_rank == 2)
 					title_name = "Veteran";
-				if (aa_rank == 3 && gender_id == 1)
+				if (aa_rank == 3 && gender_id == 0)
 					title_name = "Impresario";
-				if (aa_rank == 3 && gender_id == 2)
+				if (aa_rank == 3 && gender_id == 1)
 					title_name = "Muse";
 				break;
 			case Zeal::EqEnums::ClassTypes::Rogue:
-				if (aa_rank == 1 && gender_id == 1)
+				if (aa_rank == 1 && gender_id == 0)
 					title_name = "Barron";
-				if (aa_rank == 1 && gender_id == 2)
+				if (aa_rank == 1 && gender_id == 1)
 					title_name = "Barroness";
 				if (aa_rank == 2)
 					title_name = "Veteran";
@@ -1885,9 +1885,9 @@ namespace Zeal
 					title_name = "Marauder";
 				break;
 			case Zeal::EqEnums::ClassTypes::Shaman:
-				if (aa_rank == 1 && gender_id == 1)
+				if (aa_rank == 1 && gender_id == 0)
 					title_name = "Barron";
-				if (aa_rank == 1 && gender_id == 2)
+				if (aa_rank == 1 && gender_id == 1)
 					title_name = "Barroness";
 				if (aa_rank == 2)
 					title_name = "Venerable";
@@ -1895,9 +1895,9 @@ namespace Zeal
 					title_name = "Elder";
 				break;
 			case Zeal::EqEnums::ClassTypes::Necromancer:
-				if (aa_rank == 1 && gender_id == 1)
+				if (aa_rank == 1 && gender_id == 0)
 					title_name = "Barron";
-				if (aa_rank == 1 && gender_id == 2)
+				if (aa_rank == 1 && gender_id == 1)
 					title_name = "Barroness";
 				if (aa_rank == 2)
 					title_name = "Sage";
@@ -1905,45 +1905,45 @@ namespace Zeal
 					title_name = "Lich";
 				break;
 			case Zeal::EqEnums::ClassTypes::Wizard:
-				if (aa_rank == 1 && gender_id == 1)
+				if (aa_rank == 1 && gender_id == 0)
 					title_name = "Barron";
-				if (aa_rank == 1 && gender_id == 2)
+				if (aa_rank == 1 && gender_id == 1)
 					title_name = "Barroness";
-				if (aa_rank == 2 && gender_id == 1)
+				if (aa_rank == 2 && gender_id == 0)
 					title_name = "Master";
-				if (aa_rank == 2 && gender_id == 2)
+				if (aa_rank == 2 && gender_id == 1)
 					title_name = "Mistress";
 				if (aa_rank == 3)
 					title_name = "Sage";
 				break;
 			case Zeal::EqEnums::ClassTypes::Magician:
-				if (aa_rank == 1 && gender_id == 1)
+				if (aa_rank == 1 && gender_id == 0)
 					title_name = "Barron";
-				if (aa_rank == 1 && gender_id == 2)
+				if (aa_rank == 1 && gender_id == 1)
 					title_name = "Barroness";
-				if (aa_rank == 2 && gender_id == 1)
+				if (aa_rank == 2 && gender_id == 0)
 					title_name = "Master";
-				if (aa_rank == 2 && gender_id == 2)
+				if (aa_rank == 2 && gender_id == 1)
 					title_name = "Mistress";
 				if (aa_rank == 3)
 					title_name = "Sage";
 				break;
 			case Zeal::EqEnums::ClassTypes::Enchanter:
-				if (aa_rank == 1 && gender_id == 1)
+				if (aa_rank == 1 && gender_id == 0)
 					title_name = "Barron";
-				if (aa_rank == 1 && gender_id == 2)
+				if (aa_rank == 1 && gender_id == 1)
 					title_name = "Barroness";
-				if (aa_rank == 2 && gender_id == 1)
+				if (aa_rank == 2 && gender_id == 0)
 					title_name = "Master";
-				if (aa_rank == 2 && gender_id == 2)
+				if (aa_rank == 2 && gender_id == 1)
 					title_name = "Mistress";
 				if (aa_rank == 3)
 					title_name = "Sage";
 				break;
 			case Zeal::EqEnums::ClassTypes::Beastlord:
-				if (aa_rank == 1 && gender_id == 1)
+				if (aa_rank == 1 && gender_id == 0)
 					title_name = "Barron";
-				if (aa_rank == 1 && gender_id == 2)
+				if (aa_rank == 1 && gender_id == 1)
 					title_name = "Barroness";
 				if (aa_rank == 2)
 					title_name = "Venerable";

--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -461,6 +461,8 @@ namespace Zeal
 		}
 		char* trim_name(char* name)
 		{
+			if (name == NULL)
+				return (char*)"";
 			return reinterpret_cast<char* (__thiscall*)(int CEverquest_ptr, char* spawnName)>(0x537D39)(*(int*)0x809478, name);
 		}
 		void send_message(UINT opcode, int* buffer, UINT size, int unknown)

--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -459,11 +459,14 @@ namespace Zeal
 		{
 			return reinterpret_cast<char*(__thiscall*)(int everquest, char* name)>(0x537e4b)(*(int*)0x809478, name);
 		}
+		char* trim_name(char* name)
+		{
+			return reinterpret_cast<char* (__thiscall*)(int CEverquest_ptr, char* spawnName)>(0x537D39)(*(int*)0x809478, name);
+		}
 		void send_message(UINT opcode, int* buffer, UINT size, int unknown)
 		{
 			reinterpret_cast<void(__cdecl*)(int* connection, UINT opcode, int* buffer, UINT size, int unknown)>(0x54e51a)((int*)0x7952fc, opcode, buffer, size, unknown);
 		}
-
 		bool is_view_actor_me()
 		{	
 			if (get_controlled() && get_controlled()->ActorInfo)
@@ -474,7 +477,12 @@ namespace Zeal
 			}
 			return false;
 		}
-
+		char* get_guildName_from_guildId(int guildId)
+		{
+			if (guildId == 0xFFFF)
+				return (char*)"";
+			return (Zeal::EqGame::guild_names->Guild[guildId].Name);
+		}
 		void print_group_leader()
 		{
 			const Zeal::EqStructures::GroupInfo* group_info = Zeal::EqGame::GroupInfo;
@@ -1765,6 +1773,188 @@ namespace Zeal
 				va_end(argptr);
 
 				EqGameInternal::CXStr_PrintString(str, buffer);
+		}
+
+		const char* title_name(BYTE class_id, int aa_rank, BYTE gender_id)
+		{
+			const char* title_name = "";
+			switch (class_id)
+			{
+			case Zeal::EqEnums::ClassTypes::Warrior:
+				if (aa_rank == 1 && gender_id == 1)
+					title_name = "Barron";
+				if (aa_rank == 1 && gender_id == 2)
+					title_name = "Barroness";
+				if (aa_rank == 2)
+					title_name = "Veteran";
+				if (aa_rank == 3)
+					title_name = "Marshall";	
+				break;
+			case Zeal::EqEnums::ClassTypes::Cleric:
+				if (aa_rank == 1 && gender_id == 1)
+					title_name = "Barron";
+				if (aa_rank == 1 && gender_id == 2)
+					title_name = "Barroness";
+				if (aa_rank == 2)
+					title_name = "Venerable";
+				if (aa_rank == 3)
+					title_name = "Exarch";
+				break;
+			case Zeal::EqEnums::ClassTypes::Paladin:
+				if (aa_rank == 1 && gender_id == 1)
+					title_name = "Barron";
+				if (aa_rank == 1 && gender_id == 2)
+					title_name = "Barroness";
+				if (aa_rank == 2 && gender_id == 1)
+					title_name = "Sir";
+				if (aa_rank == 2 && gender_id == 2)
+					title_name = "Lady";
+				if (aa_rank == 3 && gender_id == 1)
+					title_name = "Duke";
+				if (aa_rank == 3 && gender_id == 2)
+					title_name = "Duchess";
+				break;
+			case Zeal::EqEnums::ClassTypes::Ranger:
+				if (aa_rank == 1 && gender_id == 1)
+					title_name = "Barron";
+				if (aa_rank == 1 && gender_id == 2)
+					title_name = "Barroness";
+				if (aa_rank == 2)
+					title_name = "Veteran";
+				if (aa_rank == 3 && gender_id == 1)
+					title_name = "Hunter";
+				if (aa_rank == 3 && gender_id == 2)
+					title_name = "Huntress";
+				break;
+			case Zeal::EqEnums::ClassTypes::Shadowknight:
+				if (aa_rank == 1 && gender_id == 1)
+					title_name = "Barron";
+				if (aa_rank == 1 && gender_id == 2)
+					title_name = "Barroness";
+				if (aa_rank == 2 && gender_id == 1)
+					title_name = "Sir";
+				if (aa_rank == 2 && gender_id == 2)
+					title_name = "Lady";
+				if (aa_rank == 3 && gender_id == 1)
+					title_name = "Duke";
+				if (aa_rank == 3 && gender_id == 2)
+					title_name = "Duchess";
+				break;
+			case Zeal::EqEnums::ClassTypes::Druid:
+				if (aa_rank == 1 && gender_id == 1)
+					title_name = "Barron";
+				if (aa_rank == 1 && gender_id == 2)
+					title_name = "Barroness";
+				if (aa_rank == 2)
+					title_name = "Venerable";
+				if (aa_rank == 3)
+					title_name = "Elder";
+				break;
+			case Zeal::EqEnums::ClassTypes::Monk:
+				if (aa_rank == 1 && gender_id == 1)
+					title_name = "Barron";
+				if (aa_rank == 1 && gender_id == 2)
+					title_name = "Barroness";
+				if (aa_rank == 2 && gender_id == 1)
+					title_name = "Brother";
+				if (aa_rank == 2 && gender_id == 2)
+					title_name = "Sister";
+				if (aa_rank == 3)
+					title_name = "Sensei";
+				break;
+			case Zeal::EqEnums::ClassTypes::Bard:
+				if (aa_rank == 1 && gender_id == 1)
+					title_name = "Barron";
+				if (aa_rank == 1 && gender_id == 2)
+					title_name = "Barroness";
+				if (aa_rank == 2)
+					title_name = "Veteran";
+				if (aa_rank == 3 && gender_id == 1)
+					title_name = "Impresario";
+				if (aa_rank == 3 && gender_id == 2)
+					title_name = "Muse";
+				break;
+			case Zeal::EqEnums::ClassTypes::Rogue:
+				if (aa_rank == 1 && gender_id == 1)
+					title_name = "Barron";
+				if (aa_rank == 1 && gender_id == 2)
+					title_name = "Barroness";
+				if (aa_rank == 2)
+					title_name = "Veteran";
+				if (aa_rank == 3)
+					title_name = "Marauder";
+				break;
+			case Zeal::EqEnums::ClassTypes::Shaman:
+				if (aa_rank == 1 && gender_id == 1)
+					title_name = "Barron";
+				if (aa_rank == 1 && gender_id == 2)
+					title_name = "Barroness";
+				if (aa_rank == 2)
+					title_name = "Venerable";
+				if (aa_rank == 3)
+					title_name = "Elder";
+				break;
+			case Zeal::EqEnums::ClassTypes::Necromancer:
+				if (aa_rank == 1 && gender_id == 1)
+					title_name = "Barron";
+				if (aa_rank == 1 && gender_id == 2)
+					title_name = "Barroness";
+				if (aa_rank == 2)
+					title_name = "Sage";
+				if (aa_rank == 3)
+					title_name = "Lich";
+				break;
+			case Zeal::EqEnums::ClassTypes::Wizard:
+				if (aa_rank == 1 && gender_id == 1)
+					title_name = "Barron";
+				if (aa_rank == 1 && gender_id == 2)
+					title_name = "Barroness";
+				if (aa_rank == 2 && gender_id == 1)
+					title_name = "Master";
+				if (aa_rank == 2 && gender_id == 2)
+					title_name = "Mistress";
+				if (aa_rank == 3)
+					title_name = "Sage";
+				break;
+			case Zeal::EqEnums::ClassTypes::Magician:
+				if (aa_rank == 1 && gender_id == 1)
+					title_name = "Barron";
+				if (aa_rank == 1 && gender_id == 2)
+					title_name = "Barroness";
+				if (aa_rank == 2 && gender_id == 1)
+					title_name = "Master";
+				if (aa_rank == 2 && gender_id == 2)
+					title_name = "Mistress";
+				if (aa_rank == 3)
+					title_name = "Sage";
+				break;
+			case Zeal::EqEnums::ClassTypes::Enchanter:
+				if (aa_rank == 1 && gender_id == 1)
+					title_name = "Barron";
+				if (aa_rank == 1 && gender_id == 2)
+					title_name = "Barroness";
+				if (aa_rank == 2 && gender_id == 1)
+					title_name = "Master";
+				if (aa_rank == 2 && gender_id == 2)
+					title_name = "Mistress";
+				if (aa_rank == 3)
+					title_name = "Sage";
+				break;
+			case Zeal::EqEnums::ClassTypes::Beastlord:
+				if (aa_rank == 1 && gender_id == 1)
+					title_name = "Barron";
+				if (aa_rank == 1 && gender_id == 2)
+					title_name = "Barroness";
+				if (aa_rank == 2)
+					title_name = "Venerable";
+				if (aa_rank == 3)
+					title_name = "Elder";
+				break;
+			default:
+				title_name = "";
+				break;
+			}
+			return title_name;
 		}
 
 		std::string class_name(int class_id)

--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -1775,7 +1775,7 @@ namespace Zeal
 				EqGameInternal::CXStr_PrintString(str, buffer);
 		}
 
-		const char* title_name(BYTE class_id, int aa_rank, BYTE gender_id)
+		const char* get_aa_title_name(BYTE class_id, int aa_rank, BYTE gender_id)
 		{
 			const char* title_name = "";
 			switch (class_id)

--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -90,7 +90,7 @@ namespace Zeal
 			bool spellbook_window_open();
 		}
 		DWORD GetLevelCon(Zeal::EqStructures::Entity* ent);
-		const char* title_name(BYTE class_id, int aa_rank, BYTE gender_id);
+		const char* get_aa_title_name(BYTE class_id, int aa_rank, BYTE gender_id);
 		float CalcCombatRange(Zeal::EqStructures::Entity* entity1, Zeal::EqStructures::Entity* entity2);
 		float CalcZOffset(Zeal::EqStructures::Entity* ent);
 		float CalcBoundingRadius(Zeal::EqStructures::Entity* ent);

--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -90,6 +90,7 @@ namespace Zeal
 			bool spellbook_window_open();
 		}
 		DWORD GetLevelCon(Zeal::EqStructures::Entity* ent);
+		const char* title_name(BYTE class_id, int aa_rank, BYTE gender_id);
 		float CalcCombatRange(Zeal::EqStructures::Entity* entity1, Zeal::EqStructures::Entity* entity2);
 		float CalcZOffset(Zeal::EqStructures::Entity* ent);
 		float CalcBoundingRadius(Zeal::EqStructures::Entity* ent);
@@ -149,6 +150,8 @@ namespace Zeal
 		Zeal::EqStructures::Entity* get_entity_by_parent_id(short parent_id);
 		void send_message(UINT opcode, int* buffer, UINT size, int unknown);
 		char* strip_name(char* name);
+		char* trim_name(char* name);
+		char* get_guildName_from_guildId(int guildId);
 		char* get_string(UINT id);
 		//void set_camera_position(Vec3* pos);
 		int* get_display();

--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -344,21 +344,21 @@ void NamePlate::con_colors_set_enabled(bool _enabled)
 void NamePlate::self_set_enabled(bool _enabled)
 {
 	ZealService::get_instance()->ini->setValue<bool>("Zeal", "NameplateSelf", _enabled);
-	Zeal::EqGame::print_chat("Nameplate for Self is %s", _enabled ? "Disabled" : "Enabled");
+	Zeal::EqGame::print_chat("Hidden Nameplate for Self is %s", _enabled ? "Enabled" : "Disabled");
 	nameplateSelf = _enabled;
 }
 
 void NamePlate::x_set_enabled(bool _enabled)
 {
 	ZealService::get_instance()->ini->setValue<bool>("Zeal", "NameplateX", _enabled);
-	Zeal::EqGame::print_chat("Nameplate for Self set to X is %s", _enabled ? "Enabled" : "Disabled");
+	Zeal::EqGame::print_chat("Show Nameplate for Self set to X is %s", _enabled ? "Enabled" : "Disabled");
 	nameplateX = _enabled;
 }
 
 void NamePlate::raidpets_set_enabled(bool _enabled)
 {
 	ZealService::get_instance()->ini->setValue<bool>("Zeal", "NameplateRaidPets", _enabled);
-	Zeal::EqGame::print_chat("Nameplates for RaidPets are %s", _enabled ? "Disabled" : "Enabled");
+	Zeal::EqGame::print_chat("Hidden Nameplates for RaidPets are %s", _enabled ? "Disabled" : "Enabled");
 	nameplateRaidPets = _enabled;
 }
 
@@ -372,21 +372,21 @@ void NamePlate::charselect_set_enabled(bool _enabled)
 void NamePlate::target_color_set_enabled(bool _enabled)
 {
 	ZealService::get_instance()->ini->setValue<bool>("Zeal", "NameplateTargetColor", _enabled);
-	Zeal::EqGame::print_chat("Target Nameplate Color is %s", _enabled ? "Enabled" : "Disabled");
+	Zeal::EqGame::print_chat("Show Target Nameplate Color is %s", _enabled ? "Enabled" : "Disabled");
 	nameplateTargetColor = _enabled;
 }
 
 void NamePlate::target_marker_set_enabled(bool _enabled)
 {
 	ZealService::get_instance()->ini->setValue<bool>("Zeal", "NameplateTargetMarker", _enabled);
-	Zeal::EqGame::print_chat("Target Nameplate Marker is %s", _enabled ? "Enabled" : "Disabled");
+	Zeal::EqGame::print_chat("Show Target Nameplate Marker is %s", _enabled ? "Enabled" : "Disabled");
 	nameplateTargetMarker = _enabled;
 }
 
 void NamePlate::target_health_set_enabled(bool _enabled)
 {
 	ZealService::get_instance()->ini->setValue<bool>("Zeal", "NameplateTargetHealth", _enabled);
-	Zeal::EqGame::print_chat("Target Nameplate Health is %s", _enabled ? "Enabled" : "Disabled");
+	Zeal::EqGame::print_chat("Show Target Nameplate Health is %s", _enabled ? "Enabled" : "Disabled");
 	nameplateTargetHealth = _enabled;
 }
 

--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -193,6 +193,30 @@ void NamePlate::HandleState(void* this_ptr, void* not_used, Zeal::EqStructures::
 			}
 		}
 	}
+	if (nameplateRaidPets)
+	{
+		if (spawn->PetOwnerSpawnId == Zeal::EqGame::get_self()->SpawnId)
+		{
+			reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, spawn->ActorInfo->DagHeadPoint, fontTexture, (char*)"");
+			SetNameSpriteTint(this_ptr, not_used, spawn);
+			return;
+		}
+		for (int i = 0; i < Zeal::EqStructures::RaidInfo::kRaidMaxMembers; ++i) //Raid Member loop
+		{
+			const Zeal::EqStructures::RaidMember& member = raidMembers[i];
+			if ((member.GroupNumber == 0xFFFFFFFF - 1) || (strlen(member.Name) == 0) || (strcmp(member.Name, Zeal::EqGame::get_self()->Name) == 0))
+				continue;
+			Zeal::EqStructures::Entity* raidMember = ZealService::get_instance()->entity_manager->Get(member.Name);
+			if (!raidMember)
+				continue;
+			if (spawn->PetOwnerSpawnId == raidMember->SpawnId)
+			{
+				reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, spawn->ActorInfo->DagHeadPoint, fontTexture, (char*)"");
+				SetNameSpriteTint(this_ptr, not_used, spawn);
+				return;
+			}
+		}
+	}
 	if (spawn == Zeal::EqGame::get_target()) {
 		char targetNameplate[50];
 		strncpy_s(targetNameplate, sizeof(targetNameplate), spawn->ActorInfo->DagHeadPoint->StringSprite->Text, _TRUNCATE);
@@ -274,30 +298,6 @@ void NamePlate::HandleState(void* this_ptr, void* not_used, Zeal::EqStructures::
 			reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_target()->ActorInfo->DagHeadPoint, fontTexture, targetNameplate);
 			SetNameSpriteTint(this_ptr, not_used, Zeal::EqGame::get_target());
 			return;
-		}
-	}
-	if (nameplateRaidPets)
-	{
-		if (spawn->PetOwnerSpawnId == Zeal::EqGame::get_self()->SpawnId)
-		{
-			reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, spawn->ActorInfo->DagHeadPoint, fontTexture, (char*)"");
-			SetNameSpriteTint(this_ptr, not_used, spawn);
-			return;
-		}
-		for (int i = 0; i < Zeal::EqStructures::RaidInfo::kRaidMaxMembers; ++i) //Raid Member loop
-		{
-			const Zeal::EqStructures::RaidMember& member = raidMembers[i];
-			if ((member.GroupNumber == 0xFFFFFFFF - 1) || (strlen(member.Name) == 0) || (strcmp(member.Name, Zeal::EqGame::get_self()->Name) == 0))
-				continue;
-			Zeal::EqStructures::Entity* raidMember = ZealService::get_instance()->entity_manager->Get(member.Name);
-			if (!raidMember)
-				continue;
-			if (spawn->PetOwnerSpawnId == raidMember->SpawnId)
-			{
-				reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, spawn->ActorInfo->DagHeadPoint, fontTexture, (char*)"");
-				SetNameSpriteTint(this_ptr, not_used, spawn);
-				return;
-			}
 		}
 	}
 	if ((spawn->Type == Zeal::EqEnums::EntityTypes::NPCCorpse || spawn->Type == Zeal::EqEnums::EntityTypes::PlayerCorpse) && spawn->Race == 60) { //Skeleton Corpse - Nameplate fix

--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -41,9 +41,6 @@ void NamePlate::HandleTint(Zeal::EqStructures::Entity* spawn)
 			Zeal::EqStructures::Entity** groupmembers = reinterpret_cast<Zeal::EqStructures::Entity**>(Zeal::EqGame::GroupInfo->EntityList);
 			const Zeal::EqStructures::RaidMember* raidMembers = &(Zeal::EqGame::RaidInfo->MemberList[0]);
 
-			//if (spawn == Zeal::EqGame::get_target()) //Leave blinking indicator on target
-			//	return;
-
 			if (spawn->IsLinkDead == 1) { //LinkDead
 				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = LDcolor;
 				return;
@@ -125,29 +122,22 @@ void NamePlate::HandleTint(Zeal::EqStructures::Entity* spawn)
 				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = Adventurercolor;
 				return;
 			}
-
 		}
 		break;
 	case Zeal::EqEnums::EntityTypes::NPC: //NPC
 		if (nameplateconColors) {
-			//if (spawn == Zeal::EqGame::get_target()) //Leave blinking indicator on target
-			//	return;
 			if (spawn != Zeal::EqGame::get_self()) //All NPC entities
 				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = Zeal::EqGame::GetLevelCon(spawn); //Level Con Color for NPCs
 		}
 		break;
 	case Zeal::EqEnums::EntityTypes::NPCCorpse: //NPC Corpse
 		if (nameplateColors) {
-			//if (spawn == Zeal::EqGame::get_target()) //Leave blinking indicator on target
-			//	return;
 			spawn->ActorInfo->DagHeadPoint->StringSprite->Color = NpcCorpsecolor;
 			return;
 		}
 		break;
 	case Zeal::EqEnums::EntityTypes::PlayerCorpse: //Player Corpse
 		if (nameplateColors) {
-			//if (spawn == Zeal::EqGame::get_target()) //Leave blinking indicator on target
-			//	return;
 			spawn->ActorInfo->DagHeadPoint->StringSprite->Color = PlayersCorpsecolor;
 			return;
 		}
@@ -167,18 +157,6 @@ int __fastcall SetNameSpriteTint(void* this_ptr, void* not_used, Zeal::EqStructu
 		Zeal::EqGame::get_self()->ActorInfo->DagHeadPoint->StringSprite->Color = 0xFF00FF32; //Green indication Namecolors on at Character Select
 	return result;
 }
-
-//char* trim_name(char* spawnName)
-//{
-//	return reinterpret_cast<char* (__thiscall*)(int CEverquest_ptr, char* spawnName)>(0x537D39)(*(int*)0x809478, spawnName);
-//}
-
-//char* GetNameFromGuildId(int guildId)
-//{
-//	if (guildId == 0xFFFF)
-//		return (char*)"";
-//	return (Zeal::EqGame::guild_names->Guild[guildId].Name);
-//}
 
 void NamePlate::HandleState(void* this_ptr, void* not_used, Zeal::EqStructures::Entity* spawn)
 {
@@ -327,7 +305,6 @@ void NamePlate::HandleState(void* this_ptr, void* not_used, Zeal::EqStructures::
 		SetNameSpriteTint(this_ptr, not_used, spawn);
 		return;
 	}
-
 }
 
 int __fastcall SetNameSpriteState(void* this_ptr, void* not_used, Zeal::EqStructures::Entity* spawn, bool show)

--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -204,25 +204,25 @@ void NamePlate::HandleState(void* this_ptr, void* not_used, Zeal::EqStructures::
 		}
 		if (showName == 4 && spawn->Type == Zeal::EqEnums::EntityTypes::Player) { //2 lines on Nameplate, Guild on 2nd line, "AA_Title First_Name Last_Name \n <Guild>"
 			if (nameplateTargetMarker && nameplateTargetHealth && spawn->GuildId != 0xFFFF) {
-				_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, ">%s %s %s %i%%<\n<%s>", (char*)Zeal::EqGame::title_name(spawn->Class, spawn->AlternateAdvancementRank, spawn->Gender), Zeal::EqGame::trim_name(spawn->CharInfo->Name), Zeal::EqGame::trim_name(spawn->CharInfo->LastName), hpPercent, Zeal::EqGame::get_guildName_from_guildId(spawn->GuildId));
+				_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, ">%s %s %s %i%%<\n<%s>", (char*)Zeal::EqGame::get_aa_title_name(spawn->Class, spawn->AlternateAdvancementRank, spawn->Gender), Zeal::EqGame::trim_name(spawn->CharInfo->Name), Zeal::EqGame::trim_name(spawn->CharInfo->LastName), hpPercent, Zeal::EqGame::get_guildName_from_guildId(spawn->GuildId));
 				reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_target()->ActorInfo->DagHeadPoint, fontTexture, targetNameplate);
 				SetNameSpriteTint(this_ptr, not_used, Zeal::EqGame::get_target());
 				return;
 			}
 			if (nameplateTargetMarker && nameplateTargetHealth) {
-				_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, ">%s %s %s %i%%<", (char*)Zeal::EqGame::title_name(spawn->Class, spawn->AlternateAdvancementRank, spawn->Gender), Zeal::EqGame::trim_name(spawn->CharInfo->Name), Zeal::EqGame::trim_name(spawn->CharInfo->LastName), hpPercent);
+				_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, ">%s %s %s %i%%<", (char*)Zeal::EqGame::get_aa_title_name(spawn->Class, spawn->AlternateAdvancementRank, spawn->Gender), Zeal::EqGame::trim_name(spawn->CharInfo->Name), Zeal::EqGame::trim_name(spawn->CharInfo->LastName), hpPercent);
 				reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_target()->ActorInfo->DagHeadPoint, fontTexture, targetNameplate);
 				SetNameSpriteTint(this_ptr, not_used, Zeal::EqGame::get_target());
 				return;
 			}
 			if (nameplateTargetMarker) {
-				_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, ">%s %s %s<\n<%s>", (char*)Zeal::EqGame::title_name(spawn->Class, spawn->AlternateAdvancementRank, spawn->Gender), Zeal::EqGame::trim_name(spawn->CharInfo->Name), Zeal::EqGame::trim_name(spawn->CharInfo->LastName), Zeal::EqGame::get_guildName_from_guildId(spawn->GuildId));
+				_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, ">%s %s %s<\n<%s>", (char*)Zeal::EqGame::get_aa_title_name(spawn->Class, spawn->AlternateAdvancementRank, spawn->Gender), Zeal::EqGame::trim_name(spawn->CharInfo->Name), Zeal::EqGame::trim_name(spawn->CharInfo->LastName), Zeal::EqGame::get_guildName_from_guildId(spawn->GuildId));
 				reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_target()->ActorInfo->DagHeadPoint, fontTexture, targetNameplate);
 				SetNameSpriteTint(this_ptr, not_used, Zeal::EqGame::get_target());
 				return;
 			}
 			if (nameplateTargetHealth) {
-				_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, "%s %s %s %i%%\n<%s>", (char*)Zeal::EqGame::title_name(spawn->Class, spawn->AlternateAdvancementRank, spawn->Gender), Zeal::EqGame::trim_name(spawn->CharInfo->Name), Zeal::EqGame::trim_name(spawn->CharInfo->LastName), hpPercent, Zeal::EqGame::get_guildName_from_guildId(spawn->GuildId));
+				_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, "%s %s %s %i%%\n<%s>", (char*)Zeal::EqGame::get_aa_title_name(spawn->Class, spawn->AlternateAdvancementRank, spawn->Gender), Zeal::EqGame::trim_name(spawn->CharInfo->Name), Zeal::EqGame::trim_name(spawn->CharInfo->LastName), hpPercent, Zeal::EqGame::get_guildName_from_guildId(spawn->GuildId));
 				reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_target()->ActorInfo->DagHeadPoint, fontTexture, targetNameplate);
 				SetNameSpriteTint(this_ptr, not_used, Zeal::EqGame::get_target());
 				return;

--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -32,7 +32,7 @@ void NamePlate::HandleTint(Zeal::EqStructures::Entity* spawn)
 	if (spawn == Zeal::EqGame::get_target()) //Leave blinking indicator on target
 		return;
 	switch (spawn->Type) {
-	case 0: //Players
+	case Zeal::EqEnums::EntityTypes::Player: //Players
 		if (nameplateColors) 
 		{
 			uint8_t isInGroup = Zeal::EqGame::GroupInfo->is_in_group();
@@ -128,7 +128,7 @@ void NamePlate::HandleTint(Zeal::EqStructures::Entity* spawn)
 
 		}
 		break;
-	case 1: //NPC
+	case Zeal::EqEnums::EntityTypes::NPC: //NPC
 		if (nameplateconColors) {
 			//if (spawn == Zeal::EqGame::get_target()) //Leave blinking indicator on target
 			//	return;
@@ -136,7 +136,7 @@ void NamePlate::HandleTint(Zeal::EqStructures::Entity* spawn)
 				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = Zeal::EqGame::GetLevelCon(spawn); //Level Con Color for NPCs
 		}
 		break;
-	case 2: //NPC Corpse
+	case Zeal::EqEnums::EntityTypes::NPCCorpse: //NPC Corpse
 		if (nameplateColors) {
 			//if (spawn == Zeal::EqGame::get_target()) //Leave blinking indicator on target
 			//	return;
@@ -144,7 +144,7 @@ void NamePlate::HandleTint(Zeal::EqStructures::Entity* spawn)
 			return;
 		}
 		break;
-	case 3: //Player Corpse
+	case Zeal::EqEnums::EntityTypes::PlayerCorpse: //Player Corpse
 		if (nameplateColors) {
 			//if (spawn == Zeal::EqGame::get_target()) //Leave blinking indicator on target
 			//	return;
@@ -168,17 +168,17 @@ int __fastcall SetNameSpriteTint(void* this_ptr, void* not_used, Zeal::EqStructu
 	return result;
 }
 
-char* trim_name(char* spawnName)
-{
-	return reinterpret_cast<char* (__thiscall*)(int CEverquest_ptr, char* spawnName)>(0x537D39)(*(int*)0x809478, spawnName);
-}
+//char* trim_name(char* spawnName)
+//{
+//	return reinterpret_cast<char* (__thiscall*)(int CEverquest_ptr, char* spawnName)>(0x537D39)(*(int*)0x809478, spawnName);
+//}
 
-char* GetNameFromGuildId(int guildId)
-{
-	if (guildId == 0xFFFF)
-		return (char*)"";
-	return (Zeal::EqGame::guild_names->Guild[guildId].Name);
-}
+//char* GetNameFromGuildId(int guildId)
+//{
+//	if (guildId == 0xFFFF)
+//		return (char*)"";
+//	return (Zeal::EqGame::guild_names->Guild[guildId].Name);
+//}
 
 void NamePlate::HandleState(void* this_ptr, void* not_used, Zeal::EqStructures::Entity* spawn)
 {
@@ -192,7 +192,7 @@ void NamePlate::HandleState(void* this_ptr, void* not_used, Zeal::EqStructures::
 	uint8_t showPCNames = *(uint8_t*)0x63D6C8; //Options -> Display -> Show PC Names, 0 = off, 1 = on
 	uint8_t showNPCNames = *(uint8_t*)0x63D6CC; //Options -> Display -> Show NPC Names, 0 = off, 1 = on
 	if (spawn == Zeal::EqGame::get_target()) {
-		char targetNameplate[30];
+		char targetNameplate[50];
 		strncpy_s(targetNameplate, sizeof(targetNameplate), spawn->ActorInfo->DagHeadPoint->StringSprite->Text, _TRUNCATE);
 		int hpPercent = 0;
 		if (spawn->Type == Zeal::EqEnums::EntityTypes::Player) {
@@ -202,46 +202,73 @@ void NamePlate::HandleState(void* this_ptr, void* not_used, Zeal::EqStructures::
 		else {
 			hpPercent = spawn->HpCurrent;
 		}
-		if ((showName == 3 || showName == 4) && spawn->Type == 0) { //2 lines on Nameplate, Guild on 2nd line
+		if (showName == 4 && spawn->Type == Zeal::EqEnums::EntityTypes::Player) { //2 lines on Nameplate, Guild on 2nd line, "AA_Title First_Name Last_Name \n <Guild>"
 			if (nameplateTargetMarker && nameplateTargetHealth && spawn->GuildId != 0xFFFF) {
-				_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, ">%s %s %i%%<\n<%s>", trim_name(spawn->CharInfo->Name), trim_name(spawn->CharInfo->LastName), hpPercent, GetNameFromGuildId(spawn->GuildId));
+				_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, ">%s %s %s %i%%<\n<%s>", (char*)Zeal::EqGame::title_name(spawn->Class, spawn->AlternateAdvancementRank, spawn->Gender), Zeal::EqGame::trim_name(spawn->CharInfo->Name), Zeal::EqGame::trim_name(spawn->CharInfo->LastName), hpPercent, Zeal::EqGame::get_guildName_from_guildId(spawn->GuildId));
 				reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_target()->ActorInfo->DagHeadPoint, fontTexture, targetNameplate);
 				SetNameSpriteTint(this_ptr, not_used, Zeal::EqGame::get_target());
 				return;
 			}
 			if (nameplateTargetMarker && nameplateTargetHealth) {
-				_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, ">%s %s %i%%<", trim_name(spawn->CharInfo->Name), trim_name(spawn->CharInfo->LastName), hpPercent);
+				_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, ">%s %s %s %i%%<", (char*)Zeal::EqGame::title_name(spawn->Class, spawn->AlternateAdvancementRank, spawn->Gender), Zeal::EqGame::trim_name(spawn->CharInfo->Name), Zeal::EqGame::trim_name(spawn->CharInfo->LastName), hpPercent);
 				reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_target()->ActorInfo->DagHeadPoint, fontTexture, targetNameplate);
 				SetNameSpriteTint(this_ptr, not_used, Zeal::EqGame::get_target());
 				return;
 			}
 			if (nameplateTargetMarker) {
-				_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, ">%s %s<\n<%s>", trim_name(spawn->CharInfo->Name), trim_name(spawn->CharInfo->LastName), GetNameFromGuildId(spawn->GuildId));
+				_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, ">%s %s %s<\n<%s>", (char*)Zeal::EqGame::title_name(spawn->Class, spawn->AlternateAdvancementRank, spawn->Gender), Zeal::EqGame::trim_name(spawn->CharInfo->Name), Zeal::EqGame::trim_name(spawn->CharInfo->LastName), Zeal::EqGame::get_guildName_from_guildId(spawn->GuildId));
 				reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_target()->ActorInfo->DagHeadPoint, fontTexture, targetNameplate);
 				SetNameSpriteTint(this_ptr, not_used, Zeal::EqGame::get_target());
 				return;
 			}
 			if (nameplateTargetHealth) {
-				_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, "%s %s %i%%\n<%s>", trim_name(spawn->CharInfo->Name), trim_name(spawn->CharInfo->LastName), hpPercent, GetNameFromGuildId(spawn->GuildId));
+				_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, "%s %s %s %i%%\n<%s>", (char*)Zeal::EqGame::title_name(spawn->Class, spawn->AlternateAdvancementRank, spawn->Gender), Zeal::EqGame::trim_name(spawn->CharInfo->Name), Zeal::EqGame::trim_name(spawn->CharInfo->LastName), hpPercent, Zeal::EqGame::get_guildName_from_guildId(spawn->GuildId));
 				reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_target()->ActorInfo->DagHeadPoint, fontTexture, targetNameplate);
 				SetNameSpriteTint(this_ptr, not_used, Zeal::EqGame::get_target());
 				return;
 			}
 		}
+		if (showName == 3 && spawn->Type == Zeal::EqEnums::EntityTypes::Player) { //2 lines on Nameplate, Guild on 2nd line, "First_Name Last_Name \n <Guild>"
+			if (nameplateTargetMarker && nameplateTargetHealth && spawn->GuildId != 0xFFFF) {
+				_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, ">%s %s %i%%<\n<%s>", Zeal::EqGame::trim_name(spawn->CharInfo->Name), Zeal::EqGame::trim_name(spawn->CharInfo->LastName), hpPercent, Zeal::EqGame::get_guildName_from_guildId(spawn->GuildId));
+				reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_target()->ActorInfo->DagHeadPoint, fontTexture, targetNameplate);
+				SetNameSpriteTint(this_ptr, not_used, Zeal::EqGame::get_target());
+				return;
+			}
+			if (nameplateTargetMarker && nameplateTargetHealth) {
+				_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, ">%s %s %i%%<", Zeal::EqGame::trim_name(spawn->CharInfo->Name), Zeal::EqGame::trim_name(spawn->CharInfo->LastName), hpPercent);
+				reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_target()->ActorInfo->DagHeadPoint, fontTexture, targetNameplate);
+				SetNameSpriteTint(this_ptr, not_used, Zeal::EqGame::get_target());
+				return;
+			}
+			if (nameplateTargetMarker) {
+				_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, ">%s %s<\n<%s>", Zeal::EqGame::trim_name(spawn->CharInfo->Name), Zeal::EqGame::trim_name(spawn->CharInfo->LastName), Zeal::EqGame::get_guildName_from_guildId(spawn->GuildId));
+				reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_target()->ActorInfo->DagHeadPoint, fontTexture, targetNameplate);
+				SetNameSpriteTint(this_ptr, not_used, Zeal::EqGame::get_target());
+				return;
+			}
+			if (nameplateTargetHealth) {
+				_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, "%s %s %i%%\n<%s>", Zeal::EqGame::trim_name(spawn->CharInfo->Name), Zeal::EqGame::trim_name(spawn->CharInfo->LastName), hpPercent, Zeal::EqGame::get_guildName_from_guildId(spawn->GuildId));
+				reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_target()->ActorInfo->DagHeadPoint, fontTexture, targetNameplate);
+				SetNameSpriteTint(this_ptr, not_used, Zeal::EqGame::get_target());
+				return;
+			}
+		}
+		//Below accounts for /showname 1 and /showname 2 with only one line on Nameplate, no Guild line.  "First_Name Last_name"
 		if (nameplateTargetMarker && nameplateTargetHealth) {
-			_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, ">%s %i%%<", trim_name(targetNameplate), hpPercent);
+			_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, ">%s %i%%<", Zeal::EqGame::trim_name(targetNameplate), hpPercent);
 			reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_target()->ActorInfo->DagHeadPoint, fontTexture, targetNameplate);
 			SetNameSpriteTint(this_ptr, not_used, Zeal::EqGame::get_target());
 			return;
 		}
 		if (nameplateTargetMarker) {	
-			_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, ">%s<", trim_name(targetNameplate));
+			_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, ">%s<", Zeal::EqGame::trim_name(targetNameplate));
 			reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_target()->ActorInfo->DagHeadPoint, fontTexture, targetNameplate);
 			SetNameSpriteTint(this_ptr, not_used, Zeal::EqGame::get_target());
 			return;
 		}
 		if (nameplateTargetHealth) {
-			_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, "%s %i%%", trim_name(targetNameplate), hpPercent);
+			_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, "%s %i%%", Zeal::EqGame::trim_name(targetNameplate), hpPercent);
 			reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_target()->ActorInfo->DagHeadPoint, fontTexture, targetNameplate);
 			SetNameSpriteTint(this_ptr, not_used, Zeal::EqGame::get_target());
 			return;
@@ -296,8 +323,8 @@ void NamePlate::HandleState(void* this_ptr, void* not_used, Zeal::EqStructures::
 			}
 		}
 	}
-	if ((spawn->Type == 2 || spawn->Type == 3) && spawn->Race == 60) { //Skeleton Corpse - Nameplate fix
-		reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, spawn->ActorInfo->DagHeadPoint, fontTexture, trim_name(spawn->Name));
+	if ((spawn->Type == Zeal::EqEnums::EntityTypes::NPCCorpse || spawn->Type == Zeal::EqEnums::EntityTypes::PlayerCorpse) && spawn->Race == 60) { //Skeleton Corpse - Nameplate fix
+		reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, spawn->ActorInfo->DagHeadPoint, fontTexture, Zeal::EqGame::trim_name(spawn->Name));
 		SetNameSpriteTint(this_ptr, not_used, spawn);
 		return;
 	}

--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -358,7 +358,7 @@ void NamePlate::x_set_enabled(bool _enabled)
 void NamePlate::raidpets_set_enabled(bool _enabled)
 {
 	ZealService::get_instance()->ini->setValue<bool>("Zeal", "NameplateRaidPets", _enabled);
-	Zeal::EqGame::print_chat("Hidden Nameplates for RaidPets are %s", _enabled ? "Disabled" : "Enabled");
+	Zeal::EqGame::print_chat("Hidden Nameplates for RaidPets are %s", _enabled ? "Enabled" : "Disabled");
 	nameplateRaidPets = _enabled;
 }
 

--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -41,9 +41,6 @@ void NamePlate::HandleTint(Zeal::EqStructures::Entity* spawn)
 			Zeal::EqStructures::Entity** groupmembers = reinterpret_cast<Zeal::EqStructures::Entity**>(Zeal::EqGame::GroupInfo->EntityList);
 			const Zeal::EqStructures::RaidMember* raidMembers = &(Zeal::EqGame::RaidInfo->MemberList[0]);
 
-			//if (spawn == Zeal::EqGame::get_target()) //Leave blinking indicator on target
-			//	return;
-
 			if (spawn->IsLinkDead == 1) { //LinkDead
 				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = LDcolor;
 				return;
@@ -130,24 +127,18 @@ void NamePlate::HandleTint(Zeal::EqStructures::Entity* spawn)
 		break;
 	case Zeal::EqEnums::EntityTypes::NPC: //NPC
 		if (nameplateconColors) {
-			//if (spawn == Zeal::EqGame::get_target()) //Leave blinking indicator on target
-			//	return;
 			if (spawn != Zeal::EqGame::get_self()) //All NPC entities
 				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = Zeal::EqGame::GetLevelCon(spawn); //Level Con Color for NPCs
 		}
 		break;
 	case Zeal::EqEnums::EntityTypes::NPCCorpse: //NPC Corpse
 		if (nameplateColors) {
-			//if (spawn == Zeal::EqGame::get_target()) //Leave blinking indicator on target
-			//	return;
 			spawn->ActorInfo->DagHeadPoint->StringSprite->Color = NpcCorpsecolor;
 			return;
 		}
 		break;
 	case Zeal::EqEnums::EntityTypes::PlayerCorpse: //Player Corpse
 		if (nameplateColors) {
-			//if (spawn == Zeal::EqGame::get_target()) //Leave blinking indicator on target
-			//	return;
 			spawn->ActorInfo->DagHeadPoint->StringSprite->Color = PlayersCorpsecolor;
 			return;
 		}
@@ -167,18 +158,6 @@ int __fastcall SetNameSpriteTint(void* this_ptr, void* not_used, Zeal::EqStructu
 		Zeal::EqGame::get_self()->ActorInfo->DagHeadPoint->StringSprite->Color = 0xFF00FF32; //Green indication Namecolors on at Character Select
 	return result;
 }
-
-//char* trim_name(char* spawnName)
-//{
-//	return reinterpret_cast<char* (__thiscall*)(int CEverquest_ptr, char* spawnName)>(0x537D39)(*(int*)0x809478, spawnName);
-//}
-
-//char* GetNameFromGuildId(int guildId)
-//{
-//	if (guildId == 0xFFFF)
-//		return (char*)"";
-//	return (Zeal::EqGame::guild_names->Guild[guildId].Name);
-//}
 
 void NamePlate::HandleState(void* this_ptr, void* not_used, Zeal::EqStructures::Entity* spawn)
 {

--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -41,6 +41,9 @@ void NamePlate::HandleTint(Zeal::EqStructures::Entity* spawn)
 			Zeal::EqStructures::Entity** groupmembers = reinterpret_cast<Zeal::EqStructures::Entity**>(Zeal::EqGame::GroupInfo->EntityList);
 			const Zeal::EqStructures::RaidMember* raidMembers = &(Zeal::EqGame::RaidInfo->MemberList[0]);
 
+			//if (spawn == Zeal::EqGame::get_target()) //Leave blinking indicator on target
+			//	return;
+
 			if (spawn->IsLinkDead == 1) { //LinkDead
 				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = LDcolor;
 				return;
@@ -122,22 +125,29 @@ void NamePlate::HandleTint(Zeal::EqStructures::Entity* spawn)
 				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = Adventurercolor;
 				return;
 			}
+
 		}
 		break;
 	case Zeal::EqEnums::EntityTypes::NPC: //NPC
 		if (nameplateconColors) {
+			//if (spawn == Zeal::EqGame::get_target()) //Leave blinking indicator on target
+			//	return;
 			if (spawn != Zeal::EqGame::get_self()) //All NPC entities
 				spawn->ActorInfo->DagHeadPoint->StringSprite->Color = Zeal::EqGame::GetLevelCon(spawn); //Level Con Color for NPCs
 		}
 		break;
 	case Zeal::EqEnums::EntityTypes::NPCCorpse: //NPC Corpse
 		if (nameplateColors) {
+			//if (spawn == Zeal::EqGame::get_target()) //Leave blinking indicator on target
+			//	return;
 			spawn->ActorInfo->DagHeadPoint->StringSprite->Color = NpcCorpsecolor;
 			return;
 		}
 		break;
 	case Zeal::EqEnums::EntityTypes::PlayerCorpse: //Player Corpse
 		if (nameplateColors) {
+			//if (spawn == Zeal::EqGame::get_target()) //Leave blinking indicator on target
+			//	return;
 			spawn->ActorInfo->DagHeadPoint->StringSprite->Color = PlayersCorpsecolor;
 			return;
 		}
@@ -157,6 +167,18 @@ int __fastcall SetNameSpriteTint(void* this_ptr, void* not_used, Zeal::EqStructu
 		Zeal::EqGame::get_self()->ActorInfo->DagHeadPoint->StringSprite->Color = 0xFF00FF32; //Green indication Namecolors on at Character Select
 	return result;
 }
+
+//char* trim_name(char* spawnName)
+//{
+//	return reinterpret_cast<char* (__thiscall*)(int CEverquest_ptr, char* spawnName)>(0x537D39)(*(int*)0x809478, spawnName);
+//}
+
+//char* GetNameFromGuildId(int guildId)
+//{
+//	if (guildId == 0xFFFF)
+//		return (char*)"";
+//	return (Zeal::EqGame::guild_names->Guild[guildId].Name);
+//}
 
 void NamePlate::HandleState(void* this_ptr, void* not_used, Zeal::EqStructures::Entity* spawn)
 {
@@ -281,20 +303,29 @@ void NamePlate::HandleState(void* this_ptr, void* not_used, Zeal::EqStructures::
 			}
 		}
 		//Below accounts for /showname 1 and /showname 2 with only one line on Nameplate, no Guild line.  "First_Name Last_name"
-		if (nameplateTargetMarker && nameplateTargetHealth) {
-			_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, ">%s %i%%<", Zeal::EqGame::trim_name(targetNameplate), hpPercent);
+		if (nameplateTargetMarker && nameplateTargetHealth && (spawn->Type == Zeal::EqEnums::EntityTypes::Player || spawn->Type == Zeal::EqEnums::EntityTypes::NPC)) {
+			if (spawn->Race == 60 && spawn->StandingState == Zeal::EqEnums::Stance::Feigned) //Prevents broken string bug on Skeleton Nameplate
+				_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, ">%s %i%%<", Zeal::EqGame::trim_name(targetNameplate), hpPercent);
+			else
+				_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, ">%s %i%%<", Zeal::EqGame::trim_name(targetNameplate), hpPercent);
 			reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_target()->ActorInfo->DagHeadPoint, fontTexture, targetNameplate);
 			SetNameSpriteTint(this_ptr, not_used, Zeal::EqGame::get_target());
 			return;
 		}
-		if (nameplateTargetMarker) {	
-			_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, ">%s<", Zeal::EqGame::trim_name(targetNameplate));
+		if (nameplateTargetMarker && (spawn->Type == Zeal::EqEnums::EntityTypes::Player || spawn->Type == Zeal::EqEnums::EntityTypes::NPC)) {
+			if (spawn->Race == 60 && spawn->StandingState == Zeal::EqEnums::Stance::Standing) //Prevents broken string bug on Skeleton Nameplate
+				_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, ">%s<", Zeal::EqGame::trim_name(targetNameplate));
+			else
+				_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, ">%s<", Zeal::EqGame::trim_name(targetNameplate));
 			reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_target()->ActorInfo->DagHeadPoint, fontTexture, targetNameplate);
 			SetNameSpriteTint(this_ptr, not_used, Zeal::EqGame::get_target());
 			return;
 		}
-		if (nameplateTargetHealth) {
-			_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, "%s %i%%", Zeal::EqGame::trim_name(targetNameplate), hpPercent);
+		if (nameplateTargetHealth && (spawn->Type == Zeal::EqEnums::EntityTypes::Player || spawn->Type == Zeal::EqEnums::EntityTypes::NPC)) {
+			if (spawn->Race == 60 && spawn->StandingState == Zeal::EqEnums::Stance::Standing) //Prevents broken string bug on Skeleton Nameplate
+				_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, "%s %i%%", Zeal::EqGame::trim_name(targetNameplate), hpPercent);
+			else
+				_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, "%s %i%%", Zeal::EqGame::trim_name(targetNameplate), hpPercent);
 			reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_target()->ActorInfo->DagHeadPoint, fontTexture, targetNameplate);
 			SetNameSpriteTint(this_ptr, not_used, Zeal::EqGame::get_target());
 			return;
@@ -305,6 +336,7 @@ void NamePlate::HandleState(void* this_ptr, void* not_used, Zeal::EqStructures::
 		SetNameSpriteTint(this_ptr, not_used, spawn);
 		return;
 	}
+
 }
 
 int __fastcall SetNameSpriteState(void* this_ptr, void* not_used, Zeal::EqStructures::Entity* spawn, bool show)

--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -191,6 +191,30 @@ void NamePlate::HandleState(void* this_ptr, void* not_used, Zeal::EqStructures::
 	uint16_t showName = *(uint16_t*)0x7D01E4; // /showname command, 1 = first names, 2 = first/last names, 3 = first/last/guild names, 4 = everything
 	uint8_t showPCNames = *(uint8_t*)0x63D6C8; //Options -> Display -> Show PC Names, 0 = off, 1 = on
 	uint8_t showNPCNames = *(uint8_t*)0x63D6CC; //Options -> Display -> Show NPC Names, 0 = off, 1 = on
+	if (spawn == Zeal::EqGame::get_self())
+	{
+		if (nameplateSelf)
+		{
+			reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_self()->ActorInfo->DagHeadPoint, fontTexture, (char*)"");
+			SetNameSpriteTint(this_ptr, not_used, Zeal::EqGame::get_self());
+			return;
+		}
+		if (nameplateX)
+		{
+			if (spawn->IsHidden == 0) //Visible
+			{
+				reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_self()->ActorInfo->DagHeadPoint, fontTexture, (char*)"X");
+				SetNameSpriteTint(this_ptr, not_used, Zeal::EqGame::get_self());
+				return;
+			}
+			if (spawn->IsHidden == 1) //Invisible
+			{
+				reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_self()->ActorInfo->DagHeadPoint, fontTexture, (char*)"(X)");
+				SetNameSpriteTint(this_ptr, not_used, Zeal::EqGame::get_self());
+				return;
+			}
+		}
+	}
 	if (spawn == Zeal::EqGame::get_target()) {
 		char targetNameplate[50];
 		strncpy_s(targetNameplate, sizeof(targetNameplate), spawn->ActorInfo->DagHeadPoint->StringSprite->Text, _TRUNCATE);
@@ -202,7 +226,7 @@ void NamePlate::HandleState(void* this_ptr, void* not_used, Zeal::EqStructures::
 		else {
 			hpPercent = spawn->HpCurrent;
 		}
-		if (showName == 4 && spawn->Type == Zeal::EqEnums::EntityTypes::Player) { //2 lines on Nameplate, Guild on 2nd line, "AA_Title First_Name Last_Name \n <Guild>"
+		if (showName == 4 && spawn->Type == Zeal::EqEnums::EntityTypes::Player && spawn->AlternateAdvancementRank > 0) { //2 lines on Nameplate, Guild on 2nd line, "AA_Title First_Name Last_Name \n <Guild>"
 			if (nameplateTargetMarker && nameplateTargetHealth && spawn->GuildId != 0xFFFF) {
 				_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, ">%s %s %s %i%%<\n<%s>", (char*)Zeal::EqGame::get_aa_title_name(spawn->Class, spawn->AlternateAdvancementRank, spawn->Gender), Zeal::EqGame::trim_name(spawn->CharInfo->Name), Zeal::EqGame::trim_name(spawn->CharInfo->LastName), hpPercent, Zeal::EqGame::get_guildName_from_guildId(spawn->GuildId));
 				reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_target()->ActorInfo->DagHeadPoint, fontTexture, targetNameplate);
@@ -228,7 +252,7 @@ void NamePlate::HandleState(void* this_ptr, void* not_used, Zeal::EqStructures::
 				return;
 			}
 		}
-		if (showName == 3 && spawn->Type == Zeal::EqEnums::EntityTypes::Player) { //2 lines on Nameplate, Guild on 2nd line, "First_Name Last_Name \n <Guild>"
+		if ((showName == 3 && spawn->Type == Zeal::EqEnums::EntityTypes::Player) || (showName == 4 && spawn->Type == Zeal::EqEnums::EntityTypes::Player && spawn->AlternateAdvancementRank == 0)) { //2 lines on Nameplate, Guild on 2nd line, "First_Name Last_Name \n <Guild>"
 			if (nameplateTargetMarker && nameplateTargetHealth && spawn->GuildId != 0xFFFF) {
 				_snprintf_s(targetNameplate, sizeof(targetNameplate), _TRUNCATE, ">%s %s %i%%<\n<%s>", Zeal::EqGame::trim_name(spawn->CharInfo->Name), Zeal::EqGame::trim_name(spawn->CharInfo->LastName), hpPercent, Zeal::EqGame::get_guildName_from_guildId(spawn->GuildId));
 				reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_target()->ActorInfo->DagHeadPoint, fontTexture, targetNameplate);
@@ -272,31 +296,6 @@ void NamePlate::HandleState(void* this_ptr, void* not_used, Zeal::EqStructures::
 			reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_target()->ActorInfo->DagHeadPoint, fontTexture, targetNameplate);
 			SetNameSpriteTint(this_ptr, not_used, Zeal::EqGame::get_target());
 			return;
-		}
-	}
-
-	if (spawn == Zeal::EqGame::get_self())
-	{
-		if (nameplateSelf)
-		{
-			reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_self()->ActorInfo->DagHeadPoint, fontTexture, (char*)"");
-			SetNameSpriteTint(this_ptr, not_used, Zeal::EqGame::get_self());
-			return;
-		}
-		if (nameplateX) 
-		{
-			if (spawn->IsHidden == 0) //Visible
-			{
-				reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_self()->ActorInfo->DagHeadPoint, fontTexture, (char*)"X");
-				SetNameSpriteTint(this_ptr, not_used, Zeal::EqGame::get_self());
-				return;
-			}
-			if (spawn->IsHidden == 1) //Invisible
-			{
-				reinterpret_cast<int(__thiscall*)(void* this_ptr, Zeal::EqStructures::EQDAGINFO * dag, int fontTexture, char* text)>(0x4B0AA8)(this_ptr, Zeal::EqGame::get_self()->ActorInfo->DagHeadPoint, fontTexture, (char*)"(X)");
-				SetNameSpriteTint(this_ptr, not_used, Zeal::EqGame::get_self());
-				return;
-			}
 		}
 	}
 	if (nameplateRaidPets)


### PR DESCRIPTION
This update includes AA Rank Titles in Nameplate logic. This won't matter for regular users until Luclin.  Those with GM access to AA rank prior to Luclin may benefit in the meantime.  This change is to account for all future Nameplate possibilities all the way through PoP timeline that I can think of currently.  Will revisit if other scenarios come up that haven't been considered.

Moved three functions get_aa_title_name, trim_name, and get_guildName_from_guildId  out of Nameplate function to EqFunctions.cpp for universal usage.  now access thru  Zeal::EqGame::(function)


