### PR TITLE
Switch to using client's EQP_IDArray as ID LUT

### DIFF
--- a/Zeal/EntityManager.cpp
+++ b/Zeal/EntityManager.cpp
@@ -5,15 +5,18 @@
 
 void EntityManager::Add(struct Zeal::EqStructures::Entity* ent)
 {
-	entity_map[ent->Name] = ent;
-	entity_id_map[ent->SpawnId] = ent;
-
-	Zeal::EqStructures::Entity* self = Get(0);
-	if (self && self->SpawnId != 0)
-	{
-		entity_id_map[self->SpawnId] = self;
-		entity_id_map.erase(0);
-	}
+	// Perform simple validity checks before adding an entity.
+	// Notes:
+	// - The client StartNetworkGame method contructs a placeholder for _LocalPlayer
+	// with EQPlayer::EQPlayer(nullptr,0,1,1,"load") and a zero id that is later deconstructed
+	// - Entering a zone constructs a new Self EQPlayer that starts with a zero spawn_id.
+	// - The server likes to reuse npc names (a_bat039) shortly after they die even while the
+	// previous corpse is still there. This will overwrite the map with the new entity, so
+	// the entity manager map's count will be reduced relative to the IDArray count.
+	if (!ent)
+		return;
+	if (ent->SpawnId == 0 || ent == Zeal::EqGame::get_entity_by_id(ent->SpawnId))
+		entity_map[ent->Name] = ent;
 }
 
 void EntityManager::Remove(struct Zeal::EqStructures::Entity* ent)
@@ -24,43 +27,71 @@ void EntityManager::Remove(struct Zeal::EqStructures::Entity* ent)
 	for (auto it = entity_map.begin(); it != entity_map.end(); ++it)
 	{
 		if (it->second == ent) {
-			entity_id_map.erase(it->second->SpawnId);
 			entity_map.erase(it);  // Ignoring updated iterator.
 			return;
 		}
 	}
 }
 
-Zeal::EqStructures::Entity* EntityManager::Get(std::string  name) const {
+Zeal::EqStructures::Entity* EntityManager::Get(std::string name) const {
 	if (!Zeal::EqGame::is_in_game())
 		return nullptr;
 	auto it = entity_map.find(name);
-	return (it == entity_map.end()) ? nullptr : it->second;
+	if (it != entity_map.end()) {
+		// Only return a hit if the manager is in sync with the client EQP_IDArray.
+		auto* entity = it->second;
+		if (entity && entity == Zeal::EqGame::get_entity_by_id(entity->SpawnId))
+			return entity;
+	}
+	return nullptr;
 }
+
 Zeal::EqStructures::Entity* EntityManager::Get(WORD id) const
 {
-	if (!Zeal::EqGame::is_in_game())
-		return nullptr;
-	auto it = entity_id_map.find(id);
-	return (it == entity_id_map.end()) ? nullptr : it->second;
+	auto* entity = Zeal::EqGame::get_entity_by_id(id);
+	return entity;
 }
 
 // Local Dump() helper that confirms there isn't a mismatch of a hashmap key/value pair.
 static bool is_valid_entity(const std::string& name, struct Zeal::EqStructures::Entity* entity) {
-	Zeal::EqStructures::Entity* current = Zeal::EqGame::get_entity_list();
+	if (!entity)
+		return false;
+	auto* client_entity = Zeal::EqGame::get_entity_by_id(entity->SpawnId);  // Returns nullptr if fails.
+	if (client_entity != entity) {
+		Zeal::EqGame::print_chat("MISMATCH: client[%i] entity does not match for name: %s", entity->SpawnId, name.c_str());
+		return false;
+	} else if (name != client_entity->Name) {
+		if (strcmp(Zeal::EqGame::trim_name(name.c_str()), Zeal::EqGame::trim_name(client_entity->Name)) == 0)
+			Zeal::EqGame::print_chat("NAME_CHANGED[%i]: manager: %s, client: %s", entity->SpawnId, name.c_str(), client_entity->Name);
+		else
+			Zeal::EqGame::print_chat("BADNAME[%i]: manager: %s, client: %s", entity->SpawnId, name.c_str(), client_entity->Name);
+		return false;
+	}
+	return true;
+}
 
+// Local dump helper that reports any missing entries in the table.
+static int report_missing_entities() {
+	Zeal::EqStructures::Entity* current = Zeal::EqGame::get_entity_list();
+	auto entity_manager = ZealService::get_instance()->entity_manager.get();  // Short-term ptr.
+
+	int missing_corpse_count = 0;
+	int missing_count = 0;
 	while (current != nullptr) {
-		if (current == entity) {
-			if (name != current->Name) {
-				Zeal::EqGame::print_chat("MISMATCH: entity name: %s, manager name: %s", current->Name, name.c_str());
-				return false;
+		if (!entity_manager->Get(current->Name)) {
+			if (current->Type == Zeal::EqEnums::NPCCorpse)
+				++missing_corpse_count;
+			else {
+				++missing_count;
+				Zeal::EqGame::print_chat("MISSING: entity[%i]: %s", current->SpawnId, current->Name);
 			}
-			return true;
 		}
 		current = current->Next;
 	}
+	if (missing_corpse_count)
+		Zeal::EqGame::print_chat("Missing corpse count: %i", missing_corpse_count);
 
-	return false;
+	return missing_count;
 }
 
 // Local Dump() helper that just counts up the number of EQ game entities.
@@ -76,18 +107,18 @@ static int get_num_game_entities() {
 
 void EntityManager::Dump() const {
 
-	Zeal::EqGame::print_chat("Num EQ entities: %i, Num in manager: %i, Num in spawn_id: %i",
-		get_num_game_entities(), entity_map.size(), entity_id_map.size());
+	Zeal::EqGame::print_chat("Num EQ entities: %i, Num in manager: %i",
+			get_num_game_entities(), entity_map.size());
 
 	for (const auto& [key, value] : entity_map)
 	{
 		// First do an integrity check to make sure the entity address is valid.
-		if (!is_valid_entity(key, value))
-			Zeal::EqGame::print_chat("INVALID: name: %s, entity: 0x%08x",
-				key.c_str(), reinterpret_cast<uint32_t>(value));
-		else if (value->Type == Zeal::EqEnums::EntityTypes::Player)
-			Zeal::EqGame::print_chat("name: %s, entity: 0x%08x", key.c_str(), reinterpret_cast<uint32_t>(value));
+		if (is_valid_entity(key, value) && (value->Type == Zeal::EqEnums::EntityTypes::Player))
+			Zeal::EqGame::print_chat("[%i]: name: %s, entity: 0x%08x", value->SpawnId,
+									key.c_str(), reinterpret_cast<uint32_t>(value));
 	}
+
+	report_missing_entities();
 }
 
 EntityManager::EntityManager(class ZealService* zeal, class IO_ini* ini)

--- a/Zeal/EntityManager.h
+++ b/Zeal/EntityManager.h
@@ -13,11 +13,10 @@ public:
 	void Add(struct Zeal::EqStructures::Entity*);
 	void Remove(struct Zeal::EqStructures::Entity*);
 	Zeal::EqStructures::Entity* Get(std::string name) const;  // Returns nullptr if not found.
-	Zeal::EqStructures::Entity* Get(WORD id) const;
+	Zeal::EqStructures::Entity* Get(WORD id) const;  // Note: Equivalent to EqGame::get_entity_by_id()
 	void Dump() const;
 
 private:
 	std::unordered_map<std::string, struct Zeal::EqStructures::Entity*> entity_map;
-	std::unordered_map<WORD, struct Zeal::EqStructures::Entity*> entity_id_map;
 };
 

--- a/Zeal/EqAddresses.h
+++ b/Zeal/EqAddresses.h
@@ -23,7 +23,10 @@ namespace Zeal
 		static EqStructures::KeyboardModifiers* KeyMods = (EqStructures::KeyboardModifiers*)0x799738;
 		static EqUI::pInstWindows* Windows = (EqUI::pInstWindows*)0x63D5CC;
 		static EqUI::CXWndManager* WndManager = (EqUI::CXWndManager*)0x809DB4;
-		static EqStructures::Entity* PetArray = (Zeal::EqStructures::Entity*)0x78c47c;
+
+		// The client maintains a 5000 entry spawn_id to entity (EQPlayer) LUT for faster access to the linked list.
+		static constexpr int kEntityIdArraySize = 5000;
+		static EqStructures::Entity** EntityIdArray = (Zeal::EqStructures::Entity**)0x0078c47c;  // EQP_IDArray
 		//static EqStructures::SPELLMGR* SpellsMgr = (EqStructures::SPELLMGR*)0x805CB0;
 		
 		//static DWORD* ptr_LocalPC = (DWORD*)0x7F94E8;

--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -1713,16 +1713,9 @@ namespace Zeal
 
 		Zeal::EqStructures::Entity* get_entity_by_id(short id)
 		{
-			if (id == get_controlled()->SpawnId)
-				return get_controlled();
-			Zeal::EqStructures::Entity* current_ent = get_entity_list();
-			while (current_ent->Next)
-			{
-				if (current_ent->SpawnId == id)
-					return current_ent;
-				current_ent = current_ent->Next;
-			}
-			return 0;
+			if ((id < 0) || (id >= kEntityIdArraySize))
+				return nullptr;
+			return EntityIdArray[id];
 		}
 		Zeal::EqStructures::Entity* get_entity_by_parent_id(short parent_id)
 		{

--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -79,6 +79,7 @@ namespace Zeal
 			static mem::function<int __cdecl()> MessageEvent = 0x52437F;
 			static mem::function<int __fastcall(int, int)> ProcessControls = 0x53F337;
 			static mem::function<int __cdecl(Zeal::EqStructures::Entity*, const char*)> ReplyTarget = 0x4ff62d;
+			static mem::function<Zeal::EqStructures::Entity* __cdecl(const char* name)> GetPlayerFromName = 0x005081db;  // Entity list traversal with name stricmp.
 		}
 		namespace Spells //some wrappers for simplifying
 		{
@@ -149,7 +150,7 @@ namespace Zeal
 		Zeal::EqStructures::SPELLMGR* get_spell_mgr();
 		Zeal::EqStructures::Entity* get_controlled();
 		Zeal::EqStructures::CameraInfo* get_camera();
-		Zeal::EqStructures::Entity* get_entity_by_id(short id);
+		Zeal::EqStructures::Entity* get_entity_by_id(short id);  // Returns nullptr if invalid id.
 		Zeal::EqStructures::Entity* get_entity_by_parent_id(short parent_id);
 		void send_message(UINT opcode, int* buffer, UINT size, int unknown);
 		char* trim_name(char* name);

--- a/Zeal/EqStructures.h
+++ b/Zeal/EqStructures.h
@@ -436,7 +436,7 @@ namespace Zeal
 			/* 0x0060 */ DWORD UnknownTimer3;
 			/* 0x0064 */ DWORD UnknownTimer4;
 			/* 0x0068 */ DWORD AttackTimer;
-			/* 0x006C */ DWORD Unknown006C;
+			/* 0x006C */ DWORD DeathTimer;
 			/* 0x0070 */ DWORD Unknown0070;
 			/* 0x0074 */ DWORD UnknownTimer5;
 			/* 0x0078 */ DWORD UnknownTimer6;

--- a/Zeal/SpellCategories.h
+++ b/Zeal/SpellCategories.h
@@ -10,6 +10,7 @@ struct SpellCat
 	SpellCat(int cat, int subcat, std::string name = "") : Category(cat), SubCategory(subcat), NewName(name) {};
 };
 
+// Note: This function uses 141300 bytes of stack (assumed to be once during static initialization).
 SpellCat getSpellCategoryAndSubcategory(int spellID) {
     static const std::unordered_map<int, SpellCat> combinedMap = {
     {3, { 125, 64 } }, // Summon Corpse,

--- a/Zeal/commands.cpp
+++ b/Zeal/commands.cpp
@@ -357,6 +357,11 @@ ChatCommands::ChatCommands(ZealService* zeal)
 				Zeal::EqGame::print_chat(ss.str());
 				return true;
 			}
+			if (args.size() == 2 && args[1] == "check")  // Report state and do basic debug integrity checks.
+			{
+				ZealService::get_instance()->entity_manager.get()->Dump();
+				return true;
+			}
 			if (args.size() > 1 && Zeal::String::compare_insensitive(args[1], "help"))
 			{
 				print_commands();


### PR DESCRIPTION
- Switched the get_entity_by_id() to use the IDArray instead of performing a traversal of the entity list
- Switched EntityManager's Get by ID to use get_entity_by_id
- Added a sanity check to the EntityManaget.Get(name) to ensure the entity matches the client's IDArray