### PR TITLE
Add Succor label to all zones using zone data

### DIFF
--- a/Zeal/EqAddresses.h
+++ b/Zeal/EqAddresses.h
@@ -27,6 +27,7 @@ namespace Zeal
 		// The client maintains a 5000 entry spawn_id to entity (EQPlayer) LUT for faster access to the linked list.
 		static constexpr int kEntityIdArraySize = 5000;
 		static EqStructures::Entity** EntityIdArray = (Zeal::EqStructures::Entity**)0x0078c47c;  // EQP_IDArray
+		static EqStructures::EQZONEINFO* ZoneInfo = (EqStructures::EQZONEINFO*)0x00798784;
 		//static EqStructures::SPELLMGR* SpellsMgr = (EqStructures::SPELLMGR*)0x805CB0;
 		
 		//static DWORD* ptr_LocalPC = (DWORD*)0x7F94E8;

--- a/Zeal/EqStructures.h
+++ b/Zeal/EqStructures.h
@@ -539,6 +539,44 @@ namespace Zeal
 			/* 0x0008 */ WORD Unknown0008;
 			/* 0x000A */
 		};
+		struct EQZONEINFO
+		{
+			/* 0x0000 */ CHAR PlayerName[0x40];
+			/* 0x0040 */ CHAR ShortName[0x20];
+			/* 0x0060 */ CHAR LongName[0x80];
+			/* 0x00E0 */ BYTE Unknown00E0[150];
+			/* 0x0176 */ BYTE Type;
+			/* 0x0177 */ BYTE FogColorRed[4];    // Set to 0x0c if 0184 and 0194 set to 0.
+			/* 0x017B */ BYTE FogColorGreen[4];  // Set to 0x0c if 0184 and 0194 set to 0.
+			/* 0x017F */ BYTE FogColorBlue[4];   // Set to 0x0c if 0184 and 0194 set to 0.
+			/* 0x0183 */ BYTE Unknown0183;
+			/* 0x0184 */ FLOAT Unknown0184;  // Set to 500.0 if 0184 and 0194 set to 0.
+			/* 0x0188 */ FLOAT Unknown0188;
+			/* 0x018C */ FLOAT Unknown018C;
+			/* 0x0190 */ FLOAT Unknown0190;
+			/* 0x0194 */ FLOAT Unknown0194;  // Set to 600.0 if 0184 and 0194 set to 0.
+			/* 0x0198 */ FLOAT Unknown0198;
+			/* 0x019C */ FLOAT Unknown019C;
+			/* 0x01A0 */ FLOAT Unknown01A0;
+			/* 0x01A4 */ FLOAT Gravity;
+			/* 0x01A8 */ BYTE Unknown01A8;
+			/* 0x01A9 */ BYTE Unknown01A9;
+			/* 0x01AA */ BYTE Unknown01AA;
+			/* 0x01AB */ BYTE Unknown01AB;
+			/* 0x01AC */ BYTE Unknown01AC;
+			/* 0x01AD */ BYTE Unknown01AD[45];
+			/* 0x01DA */ BYTE SkyType;
+			/* 0x01DB */ BYTE Unknown01DB[9];
+			/* 0x01E4 */ FLOAT ExperienceMultiplier;
+			/* 0x01E8 */ FLOAT SafeCoordsY; // CDisplay::MoveLocalPlayerToSafeCoords
+			/* 0x01EC */ FLOAT SafeCoordsX;
+			/* 0x01F0 */ FLOAT SafeCoordsZ;
+			/* 0x01F4 */ FLOAT Unknown01F4;
+			/* 0x01F8 */ FLOAT Unknown01F8;
+			/* 0x01FC */ FLOAT MinClip; // draw distance (minimum Far Clip Plane), set to max(50, value).
+			/* 0x0200 */ FLOAT MaxClip; // draw distance (maximum Far Clip Plane), set to 4*(0x0194) if < 51 or 4*0x01fc
+			/* ...... */
+		};
 		struct EQCHARINFO
 		{
 			float encum_factor()

--- a/Zeal/zone_map.h
+++ b/Zeal/zone_map.h
@@ -222,6 +222,7 @@ private:
 	Vec3 transform_world_to_model(const Vec3& world) const;
 	Vec3 transform_screen_to_model(float x, float y, float z = 1.f) const;
 	D3DCOLOR get_background_color() const;
+	void update_succor_label();
 
 	const ZoneMapData* get_zone_map(int zone_id);
 	void add_map_data_from_internal(const ZoneMapData& internal_map, CustomMapData& map_data);
@@ -286,6 +287,7 @@ private:
 	bool mouse_drag_enabled = false;
 
 	std::vector<const ZoneMapLabel*> labels_list;  // List of pointers to visible map labels.
+	ZoneMapLabel succor_label;  // Auto-generated succor label for safe coordinates.
 	int line_count = 0;  // # of primitives in line buffer.
 	int grid_line_count;  // # of primitives at end of line buffer.
 	IDirect3DVertexBuffer8* line_vertex_buffer = nullptr;

--- a/Zeal/zone_map_src/README.md
+++ b/Zeal/zone_map_src/README.md
@@ -20,6 +20,7 @@ Support scripts and data files for producing the auto-generated zone_map_data.h 
   `python extract_zone_id_lut.csv`
 
 ## Generation of the zone_map_data.h and zone_map_data.cpp files
+* Note: "Succor" points of interest are filtered out and handled automatically in the code
 * Execute the script below from the zone_map_src directory and it by default uses the checked in
   input files and writes the output to the Zeal source directory (at ../)
   `python maps_to_cpp.py`

--- a/Zeal/zone_map_src/maps_to_cpp.py
+++ b/Zeal/zone_map_src/maps_to_cpp.py
@@ -244,7 +244,8 @@ def export_single_zone_data(zone_name: str, zone_data: dict, fp):
     fp.write('};\n')
     fp.write(f'static const ZoneMapLabel {zone_name}_labels[] = {{')
     for label in zone_data['labels']:
-        fp.write(format_label(label) + ',')
+        if label[6] != "Succor" and label[6] != "succor":  # Succor is automatically added.
+            fp.write(format_label(label) + ',')
     fp.write('};\n')
     fp.write(f'static const ZoneMapLevel {zone_name}_levels[] = {{')
     sorted_level_ids = sorted(zone_data['levels'].keys())


### PR DESCRIPTION
- A fair number of Brewall map data files lacked the Succor label, so switch over to always add the Succor label using the EQZONEINFO data and filter it out from the map data