### PR TITLE
Add Pet Damage Color Filters

### DIFF
--- a/Zeal/callbacks.cpp
+++ b/Zeal/callbacks.cpp
@@ -67,7 +67,7 @@ void CallbackManager::AddCommand(std::function<bool(UINT, BOOL)> callback_functi
 	cmd_functions[type].push_back(callback_function);
 }
 
-void CallbackManager::AddOutputText(std::function<void(Zeal::EqUI::ChatWnd*& wnd, std::string& msg, short channel)> callback_function)
+void CallbackManager::AddOutputText(std::function<void(Zeal::EqUI::ChatWnd*& wnd, std::string& msg, short& channel)> callback_function)
 {
 	output_text_functions.push_back(callback_function);
 }
@@ -139,7 +139,7 @@ void CallbackManager::invoke_player(Zeal::EqStructures::Entity* ent, callback_ty
 	for (auto& fn : player_spawn_functions[cb])
 		fn(ent);
 }
-void CallbackManager::invoke_outputtext(Zeal::EqUI::ChatWnd*& wnd, std::string& msg, short channel)
+void CallbackManager::invoke_outputtext(Zeal::EqUI::ChatWnd*& wnd, std::string& msg, short& channel)
 {
 	for (auto& fn : output_text_functions)
 		fn(wnd, msg, channel);
@@ -230,17 +230,18 @@ void __fastcall OutputText(Zeal::EqUI::ChatWnd* wnd, int u, Zeal::EqUI::CXSTR ms
 	//int multiByteSize = WideCharToMultiByte(CP_UTF8, 0, (wchar_t*)msg.Data->Text, -1, NULL, 0, NULL, NULL);
 	//std::string msg_data(multiByteSize, '\0');
 	//WideCharToMultiByte(CP_UTF8, 0, (wchar_t*)msg.Data->Text, -1, msg_data.data(), multiByteSize, NULL, NULL);
+	short new_channel = channel;
 	if (msg.Data)
 	{
 		std::string msg_data = msg.CastToCharPtr();
-		zeal->callbacks->invoke_outputtext(wnd, msg_data, channel); //msg_data is by-ref so we can now edit it in the callbacks
+		zeal->callbacks->invoke_outputtext(wnd, msg_data, new_channel); //msg_data is by-ref so we can now edit it in the callbacks
 		if (!wnd)
 			wnd = Zeal::EqGame::Windows->ChatManager->ChatWindows[0];
 
 		msg.FreeRep();
 		msg = Zeal::EqUI::CXSTR(msg_data);
 	}
-	zeal->hooks->hook_map["AddOutputText"]->original(OutputText)(wnd, u, msg, channel); //msg is freed in this function so no need to free it after
+	zeal->hooks->hook_map["AddOutputText"]->original(OutputText)(wnd, u, msg, new_channel); //msg is freed in this function so no need to free it after
 }
 
 ///*000*/	UINT16	target;

--- a/Zeal/callbacks.h
+++ b/Zeal/callbacks.h
@@ -39,14 +39,14 @@ public:
 	void AddCommand(std::function<bool(UINT, BOOL)> callback_function, callback_type fn = callback_type::ExecuteCmd);
 	void AddDelayed(std::function<void()> callback_function, int ms);
 	void AddEntity(std::function<void(struct Zeal::EqStructures::Entity*)> callback_function, callback_type cb);
-	void AddOutputText(std::function<void(struct Zeal::EqUI::ChatWnd*& wnd, std::string& msg, short channel)> callback_function);
+	void AddOutputText(std::function<void(struct Zeal::EqUI::ChatWnd*& wnd, std::string& msg, short& channel)> callback_function);
 	void AddReportSuccessfulHit(std::function<void(struct Zeal::EqStructures::Entity* source, struct Zeal::EqStructures::Entity* target, WORD type, short spell_id, short damage, int heal, char output_text)> callback_function);
 	void invoke_ReportSuccessfulHit(struct Zeal::Packets::Damage_Struct* dmg, int heal, char output_text);
 	void invoke_player(struct Zeal::EqStructures::Entity* ent, callback_type cb);
 	void invoke_generic(callback_type fn);
 	bool invoke_packet(callback_type fn, UINT opcode, char* buffer, UINT len);
 	bool invoke_command(callback_type fn, UINT opcode, bool state);
-	void invoke_outputtext(struct Zeal::EqUI::ChatWnd*& wnd, std::string& msg, short channel);
+	void invoke_outputtext(struct Zeal::EqUI::ChatWnd*& wnd, std::string& msg, short& channel);
 	void invoke_delayed();
 	CallbackManager(class ZealService* zeal);
 	~CallbackManager();
@@ -57,7 +57,7 @@ private:
 	std::unordered_map<callback_type, std::vector<std::function<bool(UINT, char*, UINT)>>> packet_functions;
 	std::unordered_map<callback_type, std::vector<std::function<bool(UINT, BOOL)>>> cmd_functions;
 	std::unordered_map<callback_type, std::vector<std::function<void(struct Zeal::EqStructures::Entity*)>>> player_spawn_functions;
-	std::vector<std::function<void(struct Zeal::EqUI::ChatWnd*& wnd,std::string& msg, short channel)>> output_text_functions;
+	std::vector<std::function<void(struct Zeal::EqUI::ChatWnd*& wnd,std::string& msg, short& channel)>> output_text_functions;
 	std::vector<std::function<void(struct Zeal::EqStructures::Entity* source, struct Zeal::EqStructures::Entity* victim, WORD type, short spell_id, short damage, int heal, char output_text)>> ReportSuccessfulHit_functions;
 };
 

--- a/Zeal/chat.cpp
+++ b/Zeal/chat.cpp
@@ -92,8 +92,25 @@ UINT32  __fastcall GetRGBAFromIndex(int t, int u, USHORT index)
 {
     ui_options* options = ZealService::get_instance()->ui->options.get();
     chat* c = ZealService::get_instance()->chat_hook.get();
-    if ((index == 4 || index == 0x10) && c->UseBlueCon.get())
-        return options->GetColor(14); //index = 325; No longer need to change index with new Zeal Color button
+
+    switch (index)
+    {
+        case 4:
+        case 0x10:
+            if (c->UseBlueCon.get())
+            {
+                return options->GetColor(14);
+            }
+            break;
+        case CHANNEL_MYPETDMG:
+            return options->GetColor(19);
+        case CHANNEL_OTHERPETDMG:
+            return options->GetColor(20);
+        case CHANNEL_MYPETSAY:
+            return options->GetColor(21);
+        case CHANNEL_OTHERPETSAY:
+            return options->GetColor(22);
+    }
     return ZealService::get_instance()->hooks->hook_map["GetRGBAFromIndex"]->original(GetRGBAFromIndex)(t, u, index);
 }
 

--- a/Zeal/chatfilter.h
+++ b/Zeal/chatfilter.h
@@ -4,18 +4,23 @@
 #include "EqUI.h"
 #include <functional>
 
+#define CHANNEL_MYPETDMG 1000
+#define CHANNEL_OTHERPETDMG 1001
+#define CHANNEL_MYPETSAY 1002
+#define CHANNEL_OTHERPETSAY 1003
+
 struct CustomFilter {
 	std::string name; //String name - Appears in the Menu
 	int channelMap;   //Extended Channel Map ID - Zeal developer set
 	Zeal::EqUI::ChatWnd* windowHandle; //Window Handle - Maintains the currently filtered Chat Window handle
-	std::function<bool(short, std::string)> isHandled;
+	std::function<bool(short&, std::string)> isHandled;
     // Default Constructor
     CustomFilter()
         : name(""), channelMap(0), windowHandle(nullptr), isHandled(nullptr) {
         // Optionally, add default lambda for isHandled
     }
 
-    CustomFilter(const std::string& name, int channelMap, std::function<bool(short, std::string)> isHandled)
+    CustomFilter(const std::string& name, int channelMap, std::function<bool(short&, std::string)> isHandled)
         : name(name), channelMap(channelMap), isHandled(isHandled) {
     }
 
@@ -37,7 +42,7 @@ class chatfilter
   public:
 	chatfilter(class ZealService* pHookWrapper, class IO_ini* ini);
 	std::vector<CustomFilter> Extended_ChannelMaps;
-	void AddOutputText(Zeal::EqUI::ChatWnd*& wnd, std::string msg, short channel);
+	void AddOutputText(Zeal::EqUI::ChatWnd*& wnd, std::string msg, short& channel);
 	void LoadSettings(Zeal::EqUI::CChatManager* cm);
 	bool isExtendedCM(int channelMap, int applyOffset = 0);
 	bool isStandardCM(int channelMap, int applyOffset = 0);

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -180,6 +180,26 @@ void ui_options::LoadColors()
 		if (color_buttons.count(18))
 			color_buttons[18]->TextColor.ARGB = D3DCOLOR_ARGB(0xff, 0xff, 0x80, 0xff); //Target Pink Default
 	}
+	if (!ini->exists("ZealColors", "Color19")) //My Pet Damage
+	{
+		if (color_buttons.count(19))
+			color_buttons[19]->TextColor.ARGB = D3DCOLOR_ARGB(0xff, 0xf0, 0xf0, 0xf0); //Default White
+	}
+	if (!ini->exists("ZealColors", "Color20")) //Other Pet Damage
+	{
+		if (color_buttons.count(20))
+			color_buttons[20]->TextColor.ARGB = D3DCOLOR_ARGB(0xff, 0xf0, 0xf0, 0xf0); //Default White
+	}
+	if (!ini->exists("ZealColors", "Color21")) //My Pet Say
+	{
+		if (color_buttons.count(19))
+			color_buttons[21]->TextColor.ARGB = D3DCOLOR_ARGB(0xff, 0xf0, 0xf0, 0xf0); //Default White
+	}
+	if (!ini->exists("ZealColors", "Color22")) //Other Pet Say
+	{
+		if (color_buttons.count(20))
+			color_buttons[22]->TextColor.ARGB = D3DCOLOR_ARGB(0xff, 0xf0, 0xf0, 0xf0); //Default White
+	}
 
 	for (auto& [index, btn] : color_buttons)
 	{

--- a/Zeal/uifiles/zeal/EQUI_OptionsWindow.xml
+++ b/Zeal/uifiles/zeal/EQUI_OptionsWindow.xml
@@ -2679,7 +2679,7 @@
     <Style_HScroll>false</Style_HScroll>
     <Style_Transparent>false</Style_Transparent>
     <Style_Checkbox>false</Style_Checkbox>
-    <Text>17 - My Pet Say</Text>
+    <Text>17 - Unused at this time</Text>
     <TextColor>
       <R>255</R>
       <G>255</G>
@@ -2737,7 +2737,7 @@
     <Style_HScroll>false</Style_HScroll>
     <Style_Transparent>false</Style_Transparent>
     <Style_Checkbox>false</Style_Checkbox>
-    <Text>19 - Other Pet Say</Text>
+    <Text>19 - Unused at this time</Text>
     <TextColor>
       <R>255</R>
       <G>255</G>

--- a/Zeal/uifiles/zeal/EQUI_Tab_Colors.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_Colors.xml
@@ -655,6 +655,174 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
+
+	<Label item="Section_ChatColors">
+		<ScreenID>Section_ChatColors</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>136</X>
+			<Y>347</Y>
+		</Location>
+		<Size>
+			<CX>160</CX>
+			<CY>16</CY>
+		</Size>
+		<Text>Extended Chat Colors</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<NoWrap>true</NoWrap>
+		<AlignCenter>false</AlignCenter>
+		<AlignRight>false</AlignRight>
+	</Label>
+
+	<Button item="Zeal_BtnDividerCC">
+		<ScreenID>Zeal_BtnDividerCC</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>0</X>
+			<Y>360</Y>
+		</Location>
+		<Size>
+			<CX>380</CX>
+			<CY>2</CY>
+		</Size>
+		<Style_VScroll>false</Style_VScroll>
+		<Style_HScroll>false</Style_HScroll>
+		<Style_Transparent>false</Style_Transparent>
+		<Style_Checkbox>false</Style_Checkbox>
+		<Text>-</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<ButtonDrawTemplate>
+			<Normal>A_BtnNormal</Normal>
+			<Pressed>A_BtnPressed</Pressed>
+			<Flyby>A_BtnFlyby</Flyby>
+			<Disabled>A_BtnDisabled</Disabled>
+			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+		</ButtonDrawTemplate>
+	</Button>
+  <Button item="Zeal_Color19">
+    <ScreenID>Zeal_Color19</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>370</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>20 - My Pet Damage</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_Color20">
+    <ScreenID>Zeal_Color20</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>200</X>
+      <Y>370</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>21 - Other Pet Damage</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+	<Button item="Zeal_Color21">
+		<ScreenID>Zeal_Color21</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>10</X>
+			<Y>392</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>20</CY>
+		</Size>
+		<Style_VScroll>false</Style_VScroll>
+		<Style_HScroll>false</Style_HScroll>
+		<Style_Transparent>false</Style_Transparent>
+		<Style_Checkbox>false</Style_Checkbox>
+		<Text>22 - My Pet Say</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<ButtonDrawTemplate>
+			<Normal>A_BtnNormal</Normal>
+			<Pressed>A_BtnPressed</Pressed>
+			<Flyby>A_BtnFlyby</Flyby>
+			<Disabled>A_BtnDisabled</Disabled>
+			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+		</ButtonDrawTemplate>
+	</Button>
+	<Button item="Zeal_Color22">
+		<ScreenID>Zeal_Color22</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>200</X>
+			<Y>392</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>20</CY>
+		</Size>
+		<Style_VScroll>false</Style_VScroll>
+		<Style_HScroll>false</Style_HScroll>
+		<Style_Transparent>false</Style_Transparent>
+		<Style_Checkbox>false</Style_Checkbox>
+		<Text>23 - Other Pet Say</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<ButtonDrawTemplate>
+			<Normal>A_BtnNormal</Normal>
+			<Pressed>A_BtnPressed</Pressed>
+			<Flyby>A_BtnFlyby</Flyby>
+			<Disabled>A_BtnDisabled</Disabled>
+			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+		</ButtonDrawTemplate>
+	</Button>
   <Page item="Tab_Colors">
 	<ScreenID>Tab_Colors</ScreenID>
 	 <RelativePosition>true</RelativePosition>
@@ -695,10 +863,15 @@
 	<Pieces>Zeal_Color17</Pieces>
 	<Pieces>Section_Nameplate</Pieces>
 	<Pieces>Section_NameplateNPC</Pieces>
+	<Pieces>Section_ChatColors</Pieces>
 	<Pieces>Zeal_BtnDivider</Pieces>
 	<Pieces>Zeal_BtnDividerNPC</Pieces>
+	<Pieces>Zeal_BtnDividerCC</Pieces>
 	<Pieces>Zeal_Color18</Pieces>
-
+	<Pieces>Zeal_Color19</Pieces>
+	<Pieces>Zeal_Color20</Pieces>
+	<Pieces>Zeal_Color21</Pieces>
+	<Pieces>Zeal_Color22</Pieces>
     <Location>
       <X>0</X>
       <Y>22</Y>


### PR DESCRIPTION
- Change AddOutputText callbacks to pass channel by reference, so it can be modified during callbacks
- Add code to GetRGBA to convert new "color_index" to colors
- Add "color_index" to Pet Say/Damage for your pet + all other pets
- Add GUI elements for configuring colors to Zeal Colors Tab
- Rename elements in normal options window back to original

Just a note here, while "My Pet Damage" has an entity available to it, that can accurately determine which pet is actually your pet, "My Pet Say" is only available with a 'string'. This may cause false messages as "my pet" when two or more characters are charming pets with the same name in the same proximity.