### PR TITLE
Add map z level fade and fix map data parsing bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ ___
   - **Description:** changes your field of view with a value between 45 and 90.
 
 - `/lead`
-  - **Description:** prints out your current group leader.
+  - **Arguments:** none, `open` (reports raid groups with open slots), `all` (lists all raid groups)
+  - **Description:** prints out your current group leader (and raid leader if in raid).
 
 - `/melody`
   - **Arguments:** `song gem #'s (maximum of 5)`
@@ -179,6 +180,16 @@ ___
 - `/autobank`
   - **Aliases:** `/autoba`, `/ab`
   - **Description:** Drops whatever is on your cursor into your bank. [requires you to be at a banker] (not fully functional atm)
+
+- `/corpsedrag`
+  - **Aliases:** `/drag`
+  - **Arguments:** none, `nearest` (auto-targets nearest corpse for dragging)
+  - **Description:** Attempts to corpse drag your current target. Use `/corpsedrag nearest` to auto-target.
+
+- `/corpsedrop`
+  - **Aliases:** `/drop`
+  - **Arguments:** none, `all` (drops all corpses)
+  - **Description:** Stop dragging your currently targeted corpse. To drop all use `/corpsedrop all`.
 
 - `/target`
   - **Aliases:** `/cleartarget`
@@ -270,8 +281,9 @@ ___
 - Toggle through map backgrounds
 - Toggle through map label modes
 - Toggle up or down through visible map levels
-- Toggle map visibility of raid members
+- Toggle map visibility of raid members and member names
 - Toggle map visibility of grid lines
+- Toggle map interactive mode (internal overlay)
 - Press to display group and raid member labels
 - Toggle nameplate colors for players on/off
 - Toggle nameplate con colors for npcs on/off
@@ -398,7 +410,7 @@ modifications (see README.md in zone_map_src). As a result there are some out of
 #### Setup and configuration
 Zeal 4.0 and later includes an integrated in-game map that contains the map data for
 all zones through Planes of Power. The map is drawn into the game's DirectX viewport
-as part of the rendering sequence and is currently not 'clickable'.
+as part of the rendering sequence and is by default not 'clickable' (see interactive mode below).
 
 The map is controlled through three interfaces:
 * Dedicated Zeal options window tab (requires `zeal\uifiles`, see Installation notes above)
@@ -451,11 +463,11 @@ clear (0), dark (1), light (2), or tan (3).  Additionally, it supports alpha tra
   - `/map background 1` sets the background to dark with no change to alpha
   - `/map background 2 40` sets the background to light with 40% alpha
 
-#### External map window (Beta)
+#### External map window
 The map has simple support for opening an external window outside of the EQ client window.
 This window can be dragged with the title bar and positioned as desired, but it is only resizable
 using the height and width Zeal map options sliders. The top and left sliders are ignored
-in external window mode. It does not accept any inputs and the map content is controlled
+in external window mode. See interactive mode for mouse inputs. The map content is controlled
 with the normal map key binds. Also note that if external window mode is set in options,
 the map will not automatically open when the game starts. Use the map enable to open and
 close the window (recommend using the keybind 'm').

--- a/README.md
+++ b/README.md
@@ -535,9 +535,14 @@ in the options tab and instead use the key bind to situationally toggle it on an
 
 #### Showing map levels
 The map supports showing different levels based on the Brewall map color standards. Not all of
-the zones are properly colored, but it does work well in some of the 3-D overlapping zones.
+the zones are properly colored, but it does work well in some of the 3-D overlapping zones. It
+also supports a simplified auto z-level mode that shows map data within a z-level range of the
+player as fully opaque and further data at a faded alpha transparency level. The auto-mode
+is selectable using the toggle map level keybinds (see below).
 
+* Zeal slider to adjust the faded z-level alpha transparency value
 * Key bind: "Toggle Map Level Up", "Toggle Map Level Down" - toggles up or down the visible level
+  - The default index of 0 shows all levels and -1 = auto z-level.
 * Command examples:
   - `/map level` shows the current zone's map data level info
   - `/map level 0` shows default of all levels

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -393,6 +393,9 @@ void ui_options::InitMap()
 	ui->AddSliderCallback(wnd, "Zeal_MapBackgroundAlpha_Slider", [this](Zeal::EqUI::SliderWnd* wnd, int value) {
 		ZealService::get_instance()->zone_map->set_background_alpha(value);
 		});
+	ui->AddSliderCallback(wnd, "Zeal_MapFadedZLevelAlpha_Slider", [this](Zeal::EqUI::SliderWnd* wnd, int value) {
+		ZealService::get_instance()->zone_map->set_faded_zlevel_alpha(value);
+		});
 	ui->AddSliderCallback(wnd, "Zeal_MapNamesLength_Slider", [this](Zeal::EqUI::SliderWnd* wnd, int value) {
 		ZealService::get_instance()->zone_map->set_name_length(value * ZoneMap::kMaxNameLength / 100);
 		});
@@ -407,6 +410,7 @@ void ui_options::InitMap()
 	ui->AddLabel(wnd, "Zeal_MapPositionSize_Value");
 	ui->AddLabel(wnd, "Zeal_MapMarkerSize_Value");
 	ui->AddLabel(wnd, "Zeal_MapBackgroundAlpha_Value");
+	ui->AddLabel(wnd, "Zeal_MapFadedZLevelAlpha_Value");
 	ui->AddLabel(wnd, "Zeal_MapNamesLength_Value");
 	ui->AddLabel(wnd, "Zeal_MapGridPitch_Value");
 }
@@ -629,6 +633,7 @@ void ui_options::UpdateOptionsMap()
 	ui->SetSliderValue("Zeal_MapPositionSize_Slider", ZealService::get_instance()->zone_map->get_position_size());
 	ui->SetSliderValue("Zeal_MapMarkerSize_Slider", ZealService::get_instance()->zone_map->get_marker_size());
 	ui->SetSliderValue("Zeal_MapBackgroundAlpha_Slider", ZealService::get_instance()->zone_map->get_background_alpha());
+	ui->SetSliderValue("Zeal_MapFadedZLevelAlpha_Slider", ZealService::get_instance()->zone_map->get_faded_zlevel_alpha());
 	ui->SetSliderValue("Zeal_MapNamesLength_Slider", ZealService::get_instance()->zone_map->get_name_length() * 100 / ZoneMap::kMaxNameLength);
 	ui->SetSliderValue("Zeal_MapGridPitch_Slider", ZealService::get_instance()->zone_map->get_grid_pitch() * 100 / ZoneMap::kMaxGridPitch);
 	ui->SetLabelValue("Zeal_MapZoom_Value", "%i%%", ZealService::get_instance()->zone_map->get_zoom());
@@ -639,6 +644,7 @@ void ui_options::UpdateOptionsMap()
 	ui->SetLabelValue("Zeal_MapPositionSize_Value", "%i%%", ZealService::get_instance()->zone_map->get_position_size());
 	ui->SetLabelValue("Zeal_MapMarkerSize_Value", "%i%%", ZealService::get_instance()->zone_map->get_marker_size());
 	ui->SetLabelValue("Zeal_MapBackgroundAlpha_Value", "%i%%", ZealService::get_instance()->zone_map->get_background_alpha());
+	ui->SetLabelValue("Zeal_MapFadedZLevelAlpha_Value", "%i%%", ZealService::get_instance()->zone_map->get_faded_zlevel_alpha());
 	ui->SetLabelValue("Zeal_MapNamesLength_Value", "%i", ZealService::get_instance()->zone_map->get_name_length());
 	ui->SetLabelValue("Zeal_MapGridPitch_Value", "%i", ZealService::get_instance()->zone_map->get_grid_pitch());
 }

--- a/Zeal/uifiles/zeal/EQUI_Tab_Map.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_Map.xml
@@ -133,13 +133,69 @@
     <AlignCenter>false</AlignCenter>
     <AlignRight>true</AlignRight>
   </Label>
+  <!-- Zeal Map Faded ZLevel Alpha -->
+  <Label item="Zeal_MapFadedZLevelAlpha_Label">
+    <ScreenID>Zeal_MapFadedZLevelAlpha_Label</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>142</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>14</CY>
+    </Size>
+    <Text>Faded Z-level alpha</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
+  <Slider item="Zeal_MapFadedZLevelAlpha_Slider">
+    <ScreenID>Zeal_MapFadedZLevelAlpha_Slider</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>162</Y>
+    </Location>
+    <Size>
+      <CX>100</CX>
+      <CY>16</CY>
+    </Size>
+    <SliderArt>SDT_DefSlider</SliderArt>
+  </Slider>
+  <Label item="Zeal_MapFadedZLevelAlpha_Value">
+    <ScreenID>Zeal_MapFadedZLevelAlpha_Value</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>110</X>
+      <Y>162</Y>
+    </Location>
+    <Size>
+      <CX>40</CX>
+      <CY>16</CY>
+    </Size>
+    <Text>0</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>true</AlignRight>
+  </Label>
   <!-- Zeal Map Alignment Combobox -->
   <Label item="Zeal_MapAlignment_Label">
     <ScreenID>Zeal_MapAlignment_Label</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>142</Y>
+      <Y>184</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -160,7 +216,7 @@
     <DrawTemplate>WDT_Inner</DrawTemplate>
     <Location>
       <X>10</X>
-      <Y>162</Y>
+      <Y>204</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -184,7 +240,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>197</Y>
+      <Y>239</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -205,7 +261,7 @@
     <DrawTemplate>WDT_Inner</DrawTemplate>
     <Location>
       <X>10</X>
-      <Y>217</Y>
+      <Y>259</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -230,7 +286,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>252</Y>
+      <Y>294</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -251,7 +307,7 @@
     <DrawTemplate>WDT_Inner</DrawTemplate>
     <Location>
       <X>10</X>
-      <Y>272</Y>
+      <Y>314</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -276,7 +332,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>307</Y>
+      <Y>349</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -307,7 +363,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>337</Y>
+      <Y>379</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -328,7 +384,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>357</Y>
+      <Y>399</Y>
     </Location>
     <Size>
       <CX>100</CX>
@@ -341,7 +397,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>110</X>
-      <Y>357</Y>
+      <Y>399</Y>
     </Location>
     <Size>
       <CX>40</CX>
@@ -363,7 +419,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>380</Y>
+      <Y>422</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -394,7 +450,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>410</Y>
+      <Y>452</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -415,7 +471,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>430</Y>
+      <Y>472</Y>
     </Location>
     <Size>
       <CX>100</CX>
@@ -428,7 +484,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>110</X>
-      <Y>430</Y>
+      <Y>472</Y>
     </Location>
     <Size>
       <CX>40</CX>
@@ -450,7 +506,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>455</Y>
+      <Y>497</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -1029,6 +1085,9 @@
     <Pieces>Zeal_MapBackgroundAlpha_Label</Pieces>
     <Pieces>Zeal_MapBackgroundAlpha_Slider</Pieces>
     <Pieces>Zeal_MapBackgroundAlpha_Value</Pieces>
+    <Pieces>Zeal_MapFadedZLevelAlpha_Label</Pieces>
+    <Pieces>Zeal_MapFadedZLevelAlpha_Slider</Pieces>
+    <Pieces>Zeal_MapFadedZLevelAlpha_Value</Pieces>
     <Pieces>Zeal_MapNamesLength_Label</Pieces>
     <Pieces>Zeal_MapNamesLength_Slider</Pieces>
     <Pieces>Zeal_MapNamesLength_Value</Pieces>

--- a/Zeal/zone_map.h
+++ b/Zeal/zone_map.h
@@ -53,6 +53,7 @@ public:
 	bool set_map_data_mode(int new_mode, bool update_default = true);
 	bool set_background(int new_state, bool update_default = true); // [clear, dark, light, tan]
 	bool set_background_alpha(int percent, bool update_default = true);
+	bool set_faded_zlevel_alpha(int percent, bool update_default = true);
 	bool set_alignment(int new_state, bool update_default = true); // [left, center, right]
 	bool set_labels_mode(int new_mode, bool update_default = true);  // [off, summary, all]
 	bool set_map_top(int top_percent, bool update_default = true, bool preserve_height = true);
@@ -77,6 +78,7 @@ public:
 	int get_map_data_mode() const { return static_cast<int>(map_data_mode); }
 	int get_background() const { return static_cast<int>(map_background_state); }
 	int get_background_alpha() const { return static_cast<int>(map_background_alpha * 100 + 0.5f); }
+	int get_faded_zlevel_alpha() const { return static_cast<int>(map_faded_zlevel_alpha * 100 + 0.5f); }
 	int get_alignment() const { return static_cast<int>(map_alignment_state); }
 	int get_labels_mode() const { return static_cast<int>(map_labels_mode); }
 	int get_map_top() const { return static_cast<int>(map_rect_top * 100 + 0.5f); }
@@ -136,9 +138,11 @@ private:
 
 	static constexpr int kInvalidZoneId = 0;
 	static constexpr int kInvalidScreenValue = 0x7fff;  // EQ game sets mouse abs to this when not focused.
+	static constexpr int kInvalidPositionValue = 0x7fff;
 	static constexpr int kDefaultGridPitch = 1000;
 	static constexpr int kDefaultNameLength = 5;
 	static constexpr float kDefaultBackgroundAlpha = 0.5f;
+	static constexpr float kDefaultFadedZLevelAlpha = 0.2f;
 	static constexpr float kDefaultRectTop = 0.1f;
 	static constexpr float kDefaultRectLeft = 0.1f;
 	static constexpr float kDefaultRectBottom = 0.4f;
@@ -222,7 +226,9 @@ private:
 	Vec3 transform_world_to_model(const Vec3& world) const;
 	Vec3 transform_screen_to_model(float x, float y, float z = 1.f) const;
 	D3DCOLOR get_background_color() const;
+	D3DCOLOR render_get_line_color_and_opacity(const ZoneMapLine& line, int position_z, int level_id) const;
 	void update_succor_label();
+	bool is_zlevel_change() const;
 
 	const ZoneMapData* get_zone_map(int zone_id);
 	void add_map_data_from_internal(const ZoneMapData& internal_map, CustomMapData& map_data);
@@ -249,6 +255,7 @@ private:
 	bool map_show_all_names_override = false;  // Overrides modes to show names of all visible members.
 	BackgroundType::e map_background_state = BackgroundType::kClear;
 	float map_background_alpha = kDefaultBackgroundAlpha;
+	float map_faded_zlevel_alpha = kDefaultFadedZLevelAlpha;
 	AlignmentType::e map_alignment_state = AlignmentType::kFirst;
 	LabelsMode::e map_labels_mode = LabelsMode::kOff;
 	ShowGroupMode::e map_show_group_mode = ShowGroupMode::kOff;
@@ -256,7 +263,6 @@ private:
 	int zone_id = kInvalidZoneId;
 	std::vector<Marker> markers_list;
 	bool always_align_to_center = false;
-	int map_level_zone_id = kInvalidZoneId;
 	int map_level_index = 0;
 	int dynamic_labels_zone_id = kInvalidZoneId;
 	std::vector<DynamicLabel> dynamic_labels_list;  // Optional temporary labels.
@@ -278,6 +284,7 @@ private:
 	float clip_min_y = 0;
 	int clip_max_z = 0;
 	int clip_min_z = 0;
+	int zlevel_position_z = kInvalidPositionValue;
 	float position_size = kDefaultPositionSize;
 	float marker_size = kDefaultMarkerSize;
 	bool cursor_hidden = false;

--- a/Zeal/zone_map_src/maps_to_cpp.py
+++ b/Zeal/zone_map_src/maps_to_cpp.py
@@ -99,8 +99,10 @@ def parse_file(file: str) -> dict:
                     float(splits[3]), float(splits[4]), float(splits[5]),
                     int(splits[6]), int(splits[7]), int(splits[8]),))
         elif input_line[0] == 'P':
-            result['labels'].append((float(splits[0]), float(splits[1]), float(splits[2]), 
-                       int(splits[3]), int(splits[4]), int(splits[5]), splits[7].strip(),))
+            text_label = splits[7].strip()
+            if text_label not in ['Succor', 'succor']:  # Added automatically by map code.
+                result['labels'].append((float(splits[0]), float(splits[1]), float(splits[2]),
+                           int(splits[3]), int(splits[4]), int(splits[5]), text_label,))
         elif input_line.strip():
             print(f'Invalid line: {input_line}')
           
@@ -244,8 +246,7 @@ def export_single_zone_data(zone_name: str, zone_data: dict, fp):
     fp.write('};\n')
     fp.write(f'static const ZoneMapLabel {zone_name}_labels[] = {{')
     for label in zone_data['labels']:
-        if label[6] != "Succor" and label[6] != "succor":  # Succor is automatically added.
-            fp.write(format_label(label) + ',')
+        fp.write(format_label(label) + ',')
     fp.write('};\n')
     fp.write(f'static const ZoneMapLevel {zone_name}_levels[] = {{')
     sorted_level_ids = sorted(zone_data['levels'].keys())


### PR DESCRIPTION
Add map z-level fading and auto z-level mode
- Added Faded Z-level alpha slider in options to control the
  faded transparency of map lines out of the target z-level
  (previously they were invisible, ie, alpha = 0)
- Added a simple auto z-level that shows the map lines within
  a z-level range of the current position and auto-updates as
  the player moves.  This was added as index [-1] in the toggle
  level sequence and is adjacent to the default show all index
  [0] set at zone in.