### PR TITLE
Consolidate zeal settings into a zeal.ini

### DIFF
--- a/Zeal/IO_ini.h
+++ b/Zeal/IO_ini.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <iostream>
 #include <fstream>
+#include <filesystem>
 #include <string>
 #include <map>
 #include <stdexcept>
@@ -16,7 +17,19 @@ class IO_ini {
 private:
     std::string filename;
 public:
-    IO_ini(const std::string& filename) : filename(filename) {   };
+    IO_ini(const std::string& filename, bool import_check = false) : filename(filename) {
+        static constexpr char kClientFilename[] = ".\\eqclient.ini";
+        if (import_check  && filename != std::string(kClientFilename) && !std::filesystem::exists(filename)) {
+            static constexpr int kMaxSectionSize = 32767;  // Maximum size for a section read.
+            auto buffer = std::make_unique<char[]>(kMaxSectionSize);
+            std::vector<std::string> sections = { "Zeal", "ZealColors" };
+            for (const auto& section : sections) {
+                int size = GetPrivateProfileSectionA(section.c_str(), buffer.get(), kMaxSectionSize, kClientFilename);
+                if (size)
+                    WritePrivateProfileSectionA(section.c_str(), buffer.get(), filename.c_str());
+            }
+        }
+    };
 
     void set(std::string path)
     {

--- a/Zeal/Zeal.cpp
+++ b/Zeal/Zeal.cpp
@@ -1,5 +1,6 @@
 #include "Zeal.h"
 #include "EqAddresses.h"
+#include "ZealSettings.h"
 #include <filesystem>
 #include <Windows.h>
 
@@ -17,7 +18,7 @@ ZealService::ZealService()
 	crash_handler = std::make_shared<CrashHandler>();
 	hooks = std::make_shared<HookWrapper>();
 	//hooks->Add("SetUnhandledExceptionFilter", (int)SetUnhandledExceptionFilter, SetUnhandledExceptionFilter_Hook, hook_type_detour);
-	ini = std::make_shared<IO_ini>(".\\eqclient.ini"); //other functions rely on this hook
+	ini = std::make_shared<IO_ini>(ZealSetting<bool>::kIniFilename, true); //other functions rely on this hook
 	dx = std::make_shared<directx>();
 //initialize the hooked function classes
 	commands_hook = std::make_shared<ChatCommands>(this); //other classes below rely on this class on initialize

--- a/Zeal/ZealSettings.h
+++ b/Zeal/ZealSettings.h
@@ -5,6 +5,7 @@
 #include <Windows.h>
 #include <memory>
 #include "callbacks.h"
+#include "EqFunctions.h"
 //#include "Zeal.h"
 class IO_ini;
 class ZealService;
@@ -12,18 +13,13 @@ template <typename T>
 class ZealSetting
 {
 public:
+	static constexpr char kIniFilename[] = ".\\zeal.ini";
+
 	void set(T val, bool store = true) { 
 		if (store && section.length() && key.length())
 		{
-			std::string ini_name = ".\\eqclient.ini";
-			if (per_character)
-				ini_name = ZealService::get_instance()->ui->GetUIIni();
-			if (ini_name.length())
-			{
-				IO_ini ini(ini_name);
-				ini.setValue<T>(section, key, val);
-			}
-
+			IO_ini ini(kIniFilename);
+			ini.setValue<T>(get_section_name(), key, val);
 		}
 		value = val; 
 		if (set_callback)
@@ -34,6 +30,14 @@ public:
 		set(!value, store);
 	}
 	T get() { return value; }
+	std::string get_section_name() const {
+		if (!per_character)
+			return section;
+
+		Zeal::EqStructures::EQCHARINFO* c = Zeal::EqGame::get_char_info();
+		std::string suffix = (c) ? std::string(c->Name) : "Unknown";
+		return section + "_" + suffix;
+	}
 	/*
 	*   save_per_character if true saves in player names ini rather than eqclient
 	*	read and write ini as well as a callback with new value
@@ -95,15 +99,10 @@ private:
 	{
 		if (section.length() && key.length())
 		{
-			std::string ini_name = ".\\eqclient.ini";
-			if (per_character)
-				ini_name = ZealService::get_instance()->ui->GetUIIni();
-			if (ini_name.length())
-			{
-				IO_ini ini(ini_name);
-				if (ini.exists(section, key))
-					value = ini.getValue<T>(section, key);
-			}
+			IO_ini ini(kIniFilename);
+			std::string section_name = get_section_name();
+			if (ini.exists(section_name, key))
+				value = ini.getValue<T>(section_name, key);
 		}
 	}
 };


### PR DESCRIPTION
- io_ini now directed to a zeal.ini file
- Added simple migration that will attempt to copy old values from eqclient.ini if the zeal.ini does not exist (the per character settings are not migrated)