### PR TITLE
Add /map show_zone command to explore other zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,15 @@ button click. The external window also supports a middle mouse button click to d
 
 * Key bind: "Toggle Map Interactive Mode" - toggles internal overlay between transparent and interactive
 
+#### Show zone mode
+Zone maps other than the player's current location can be explored using the show_zone command. The
+target zone is specified using the zone's short name (like /who all). Interactive mode, levels, grid,
+labels, and poi search all work for the selected zone.
+
+* Command examples
+  - `/map show_zone gukbottom` shows the zone map for the Ruins of Old Guk
+  - `/map show_zone` exits show_zone mode
+
 #### Map grid
 A simple background grid aligned at a selectable pitch is available. The x == 0 and y == 0 axes
 are colored orange.
@@ -536,7 +545,7 @@ in the options tab and instead use the key bind to situationally toggle it on an
 * Zeal checkbox to enable raid member visibility
 * Zeal slider to adjust name length
 * Key bind: "Toggle Map Show Raid" - Toggles visibility of raid members
-* Key bind: "Flash Map Member Names" - Displays names of group and raid members while held (if visible)
+* Key bind: "Flash Map Member Names" - Toggles (previously flashed) names of group and raid members
 * Command examples:
   - `/map show_group` toggles the group member markers on and off
   - `/map show_group labels_off` disables group member labels

--- a/Zeal/zone_map.h
+++ b/Zeal/zone_map.h
@@ -166,6 +166,7 @@ private:
 	void parse_map_data_mode(const std::vector<std::string>& args);
 	void parse_show_group(const std::vector<std::string>& args);
 	void parse_show_raid(const std::vector<std::string>& args);
+	void parse_show_zone(const std::vector<std::string>& args);
 	void parse_grid(const std::vector<std::string>& args);
 	void parse_ring(const std::vector<std::string>& args);
 	void parse_font(const std::vector<std::string>& args);
@@ -175,6 +176,7 @@ private:
 	void clear_markers(bool erase_list = true);
 	bool set_map_rect(float top, float left, float bottom, float right, bool update_default = false);
 	bool set_level(int level);  // Set to 0 to show all levels.
+	bool set_show_zone_id(const std::string& zone_name);
 	void update_ui_options();
 
 	void load_ini(class IO_ini* ini);
@@ -184,6 +186,7 @@ private:
 	void callback_zone();
 	void callback_render();
 	void callback_dx_reset();
+	void reset_zone_state();
 
 	// The following methods execute as part of callback_render().
 	void render_release_resources(bool release_font = true);
@@ -231,6 +234,7 @@ private:
 	bool is_zlevel_change() const;
 
 	const ZoneMapData* get_zone_map(int zone_id);
+	int find_zone_id(const std::string& zone_name) const;
 	void add_map_data_from_internal(const ZoneMapData& internal_map, CustomMapData& map_data);
 	bool add_map_data_from_file(const std::string& filename, CustomMapData& map_data);
 	void assemble_zone_map(const char* zone_name, CustomMapData& map_data);
@@ -261,6 +265,7 @@ private:
 	ShowGroupMode::e map_show_group_mode = ShowGroupMode::kOff;
 	MapDataMode::e map_data_mode = MapDataMode::kInternal;
 	int zone_id = kInvalidZoneId;
+	int show_zone_id = kInvalidZoneId;  // Override to show zone indepent of current location.
 	std::vector<Marker> markers_list;
 	bool always_align_to_center = false;
 	int map_level_index = 0;


### PR DESCRIPTION
- The new /map show_zone <short_name> will show the map data from a zone the player is not currently in.  Use a blank <short_name> to reset back to normal map mode.