### PR TITLE
Add ClickThruSelf and ClickThruMyPet feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Zeal custom code is entirely open source and the releases are built directly
 from the repo using github actions, providing full transparency on the contents.
 
 ### Features
-- Camera motion improvements (major improvements to third person view)
+- Camera motion improvements (major improvements to third person view, click thru self/pet options)
 - Additional key binds (tab targeting, strafe, pet)
 - Additional commands (melody, useitem, autoinventory)
 - Additional ui support (new gauges, bag control, looting, spellsets, targetrings, nameplates)
@@ -252,13 +252,19 @@ ___
   - **Description:** toggles nameplate choices shown at character selection screen on and off (on/off)
 
 - `/nameplatetargetcolor`
-  - **Description:** toggles target nameplate color on and off (on/off)
+  - **Description:** toggles target nameplate color (on/off)
  
 - `/nameplatetargetmarker`
-  - **Description:** toggles target nameplate marker on and off (on/off)
+  - **Description:** toggles target nameplate marker (on/off)
  
 - `/nameplatetargethealth`
-  - **Description:** toggles target nameplate health on and off (on/off)
+  - **Description:** toggles target nameplate health (on/off)
+
+- `/clickthruself`
+  - **Description:** toggles ability to click through self (on/off)
+
+- `/clickthrumypet`
+  - **Description:** toggles ability to click through my pet (on/off)
 ___
 ### Binds
 - Cycle through nearest NPCs
@@ -290,10 +296,12 @@ ___
 - Toggle nameplate for self on/off
 - Toggle nameplate for self as X on/off
 - Toggle nameplate for raid pets and your pet on/off
-- Toggle nameplate choices that are shown at character selection screen on and off
-- Toggle target nameplate color on and off
-- Toggle target nameplate marker on and off
-- Toggle target nameplate health on and off
+- Toggle nameplate choices that are shown at character selection screen on/off
+- Toggle target nameplate color on/off
+- Toggle target nameplate marker on/off
+- Toggle target nameplate health on/off
+- Toggle ability to click through self on/off
+- Toggle ability to click through my pet on/off
 ___
 ### UI
 - **Gauge EqType's**
@@ -355,8 +363,8 @@ Build in `Release` `x86` (32bit) mode using Microsoft Visual Studio 2022 (free C
 ### Nameplate Options
 #### Setup and configuration
 Zeal 5.0 and later includes options for players to adjust Player Nameplates and NPC Nameplates in game.
-In addition, Skeletons now show a Nameplate. (Client Skeleton Nameplate Bug Fix)
-Necromancers will now have an easier time finding their corpses.
+Skeletons and Gargoyles now show a Nameplate at their spawn points. (Client Skeleton/Gargoyle Nameplate Bug Fix)
+In addition, Necromancers will now have an easier time finding their corpses.
 
 The nameplate is controlled through three interfaces:
 * Dedicated Zeal options window tab (requires `zeal\uifiles`, see Installation notes above)

--- a/Zeal/binds.cpp
+++ b/Zeal/binds.cpp
@@ -332,6 +332,14 @@ void Binds::add_binds()
 			 ZealService::get_instance()->zone_map->set_interactive_enable(
 				!ZealService::get_instance()->zone_map->is_interactive_enabled(), false);
 		});
+	add_bind(243, "Toggle Click Through Self", "ToggleClickThroughSelf", key_category::Camera, [this](int key_down) {
+		if (key_down && !Zeal::EqGame::EqGameInternal::UI_ChatInputCheck())
+			ZealService::get_instance()->camera_mods->click_thru_self_toggle();
+		});
+	add_bind(244, "Toggle Click Through My Pet", "ToggleClickThroughMyPet", key_category::Camera, [this](int key_down) {
+		if (key_down && !Zeal::EqGame::EqGameInternal::UI_ChatInputCheck())
+			ZealService::get_instance()->camera_mods->click_thru_my_pet_toggle();
+		});
 	add_bind(255, "Auto Inventory", "AutoInventory", key_category::Commands | key_category::Macros, [](int key_down)
 	{
 		if (key_down)

--- a/Zeal/camera_mods.h
+++ b/Zeal/camera_mods.h
@@ -26,7 +26,8 @@ public:
 	ZealSetting<float> user_sensitivity_y_3rd = { 0.1f, "Zeal", "MouseSensitivityY3rd", false };
 	ZealSetting<float> fov = { 45.f, "Zeal", "Fov", false, [this](float val) { Zeal::EqStructures::CameraInfo* ci = Zeal::EqGame::get_camera();	if (ci) ci->FieldOfView = val; } };
 	ZealSetting<int> pan_delay = { 0, "Zeal", "PanDelay", false };
-
+	ZealSetting<bool> ClickThruSelf = { false, "Zeal", "ClickThruSelf", false, [this](bool val) { click_thru_self_toggle(); }, true };
+	ZealSetting<bool> ClickThruMyPet = { false, "Zeal", "ClickThruMyPet", false, [this](bool val) { click_thru_my_pet_toggle(); }, true };
 
 	const float max_zoom_out = 100;
 	const float zoom_speed = 5.f;
@@ -38,6 +39,8 @@ public:
 	float zeal_cam_yaw;
 	float current_zoom = 0.f;
 	float desired_zoom = 0.f;
+	float selfBoundingRadiusStored;
+	float myPetBoundingRadiusStored;
 	void set_smoothing(bool val);
 	void callback_main();
 	void callback_render();
@@ -51,6 +54,8 @@ public:
 	void handle_camera_motion_binds(int cmd, bool is_down);
 	void handle_cycle_camera_views(int cmd, bool is_down);
 	void proc_rmousedown(int x, int y);
+	void click_thru_self_toggle();
+	void click_thru_my_pet_toggle();
 	CameraMods(class ZealService* pHookWrapper, class IO_ini* ini);
 	~CameraMods();
 private:

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -326,6 +326,8 @@ void ui_options::InitCamera()
 	}
 	ui->AddCheckboxCallback(wnd, "Zeal_Cam_TurnLocked", [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->camera_mods->cam_lock.set(wnd->Checked); } );
 	ui->AddCheckboxCallback(wnd, "Zeal_UseOldSens", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->camera_mods->use_old_sens.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_ClickThruSelf", [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->camera_mods->ClickThruSelf.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_ClickThruMyPet", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->camera_mods->ClickThruMyPet.set(wnd->Checked); });
 	ui->AddSliderCallback(wnd, "Zeal_PanDelaySlider", [this](Zeal::EqUI::SliderWnd* wnd, int value) {
 		ZealService::get_instance()->camera_mods->pan_delay.set(value * 4);
 		ui->SetLabelValue("Zeal_PanDelayValueLabel", "%d ms", ZealService::get_instance()->camera_mods->pan_delay);
@@ -578,6 +580,8 @@ void ui_options::UpdateOptionsCamera()
 	ui->SetLabelValue("Zeal_PanDelayValueLabel", "%d ms", ZealService::get_instance()->camera_mods->pan_delay.get());
 	ui->SetChecked("Zeal_Cam", ZealService::get_instance()->camera_mods->enabled.get());
 	ui->SetChecked("Zeal_UseOldSens", ZealService::get_instance()->camera_mods->use_old_sens.get());
+	ui->SetChecked("Zeal_ClickThruSelf", ZealService::get_instance()->camera_mods->ClickThruSelf.get());
+	ui->SetChecked("Zeal_ClickThruMyPet", ZealService::get_instance()->camera_mods->ClickThruMyPet.get());
 }
 void ui_options::UpdateOptionsTargetRing()
 {

--- a/Zeal/uifiles/zeal/EQUI_Tab_Cam.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_Cam.xml
@@ -505,6 +505,66 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
+   <Button item="Zeal_ClickThruSelf">
+    <ScreenID>Zeal_ClickThruSelf</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>102</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Toggle ability to Click Through Self</TooltipReference>
+    <Text>Click Thru Self</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+   <Button item="Zeal_ClickThruMyPet">
+    <ScreenID>Zeal_ClickThruMyPet</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>124</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Toggle ability to Click Through My Pet</TooltipReference>
+    <Text>Click Thru My Pet</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
   <Page item="Tab_Camera">
     <ScreenID>Tab_Camera</ScreenID>
     <RelativePosition>true</RelativePosition>
@@ -547,6 +607,8 @@
     <Pieces>Zeal_FovLabel</Pieces>
     <Pieces>Zeal_FovLabel_</Pieces>
 	<Pieces>Zeal_Cam_TurnLocked</Pieces>
+	<Pieces>Zeal_ClickThruSelf</Pieces>
+	<Pieces>Zeal_ClickThruMyPet</Pieces>
     <Location>
       <X>0</X>
       <Y>22</Y>


### PR DESCRIPTION
-Add ClickThruSelf and ClickThruMyPet feature

When this feature is on, the player can click through either their self or their pet depending on

This is 95% done.  Binds work.  Commands work.  

Need a hand with connecting the new XML buttons because using the new ZealSetting bool variables are new compared to the old method.