### PR TITLE
Adds trim_name call to target nameplate (deal with rare crash)

### DIFF
--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -341,7 +341,7 @@ void NamePlate::HandleState(void* this_ptr, void* not_used, Zeal::EqStructures::
 		}
 	}
 	if (spawn == target && (nameplateTargetMarker || nameplateTargetHealth)) { //Target Marker and Target Health
-		std::string targetNameplate = spawn->ActorInfo->DagHeadPoint->StringSprite->Text;
+		std::string targetNameplate = Zeal::EqGame::trim_name(spawn->ActorInfo->DagHeadPoint->StringSprite->Text);
 		ChangeDagStringSprite(target->ActorInfo->DagHeadPoint, fontTexture, generateTargetNameplateString(targetNameplate).c_str());
 		return;
 	}


### PR DESCRIPTION
Temporarily fixes rare hard-to-reproduce crash involved in target nameplate (skeleton text issue) by calling trim_name extra time and relying on trim_name null pointer protection