### PR TITLE
Fix StringSprite crash (skellies)

### DIFF
--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -249,9 +249,6 @@ std::string generateTargetNameplateString(const std::string& nameplateString) {
 	}
 	else //Target NPC Nameplate	
 	{  
-		if ((target->Race == 60 || target->Race == 29) && target->StandingState != Zeal::EqEnums::Stance::Standing)//Needed to play nice with Skeleton/Gargoyle Nameplate fix code below
-			ossShowNameLogic << Zeal::EqGame::trim_name(target->Name); //Prevents broken string bug on Skeleton/Gargoyle Nameplate
-		else
 			ossShowNameLogic << nameplateString; //All other NPC Nameplate
 	}
 
@@ -340,19 +337,23 @@ void NamePlate::HandleState(void* this_ptr, void* not_used, Zeal::EqStructures::
 			}
 		}
 	}
+	bool valid_string_sprite = (spawn->ActorInfo->DagHeadPoint->StringSprite->Unknown0000 == 0x51);
 	if (spawn == target && (nameplateTargetMarker || nameplateTargetHealth)) { //Target Marker and Target Health
-		std::string targetNameplate = spawn->ActorInfo->DagHeadPoint->StringSprite->Text;
+		std::string targetNameplate = valid_string_sprite ?
+			spawn->ActorInfo->DagHeadPoint->StringSprite->Text : Zeal::EqGame::trim_name(spawn->Name);
 		ChangeDagStringSprite(target->ActorInfo->DagHeadPoint, fontTexture, generateTargetNameplateString(targetNameplate).c_str());
 		return;
 	}
-	if (spawn->Race == 60 || spawn->Race == 29) { //Skeleton Feigned and Gargoyle Sitting at spawn point Nameplate fix and Skeleton Corpse Nameplate fix
-		if ((spawn->Type == Zeal::EqEnums::EntityTypes::NPC && spawn->StandingState != Zeal::EqEnums::Stance::Standing) || spawn->StandingState == Zeal::EqEnums::Stance::Dead)
-		{
-			std::string skeletonName = Zeal::EqGame::trim_name(spawn->Name);
-			ChangeDagStringSprite(spawn->ActorInfo->DagHeadPoint, fontTexture, skeletonName.c_str());
-			SetNameSpriteTint(this_ptr, not_used, spawn);
-			return;
-		}
+
+	// Handle cases of hidden, invalid nameplates that we want to show (targeted or corpses).
+	if (!valid_string_sprite &&
+		(spawn == target || spawn->Type == Zeal::EqEnums::EntityTypes::NPCCorpse ||
+			spawn->Type == Zeal::EqEnums::EntityTypes::PlayerCorpse)) 
+	{
+		std::string spawnName = Zeal::EqGame::trim_name(spawn->Name);
+		ChangeDagStringSprite(spawn->ActorInfo->DagHeadPoint, fontTexture, spawnName.c_str());
+		SetNameSpriteTint(this_ptr, not_used, spawn);
+		return;
 	}
 }
 


### PR DESCRIPTION
- Use the magic "valid flag" in the nameplate StringSprite Unknown0000 field to protect against using bad Text pointers
- Also use that field to generalize the display of nameplates for the current target and corpses (not just skeletons or gargs)