### PR TITLE
Cleanup compiler warnings

### DIFF
--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -114,7 +114,6 @@ namespace Zeal
 		void SetMusicSelection(int number, bool enabled);
 		bool is_new_ui();
 		HWND get_game_window();
-		bool is_in_char_select();
 		bool show_context_menu();
 		bool game_wants_input(); //returns true if the game wants text input so it doesn't run binds
 		void CXStr_PrintString(Zeal::EqUI::CXSTR* str, const char* format, ...);

--- a/Zeal/FindPattern.cpp
+++ b/Zeal/FindPattern.cpp
@@ -1,4 +1,7 @@
 #include "FindPattern.h"
+
+typedef const unsigned char* LPCBYTE;  // Not defined in WIN32_LEAN_AND_MEAN.
+
 namespace Zeal
 {
 	namespace Memory

--- a/Zeal/IO_ini.h
+++ b/Zeal/IO_ini.h
@@ -1,11 +1,15 @@
 #pragma once
-#include <iostream>
-#include <fstream>
+#include <Windows.h>
 #include <filesystem>
+#include <iostream>
+#include <sstream>
 #include <string>
-#include <map>
-#include <stdexcept>
-#include "EqFunctions.h"
+
+// Declare a single function from EqFunctions.h to avoid pulling in many headers.
+namespace Zeal::EqGame {
+    void print_chat(const char* format, ...);
+}
+
 class IO_ini {
 private:
     std::string filename;

--- a/Zeal/Zeal.vcxproj
+++ b/Zeal/Zeal.vcxproj
@@ -101,7 +101,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;ZEAL_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;NDEBUG;ZEAL_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(zeal_build_version)'!=''">ZEAL_BUILD_VERSION="$(zeal_build_version)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
@@ -194,6 +194,7 @@
     <ClInclude Include="cycle_target.h" />
     <ClInclude Include="EqAddresses.h" />
     <ClInclude Include="EqFunctions.h" />
+    <ClInclude Include="EqPackets.h" />    
     <ClInclude Include="eqstr.h" />
     <ClInclude Include="EqStructures.h" />
     <ClInclude Include="EqUI.h" />
@@ -234,7 +235,6 @@
     <ClCompile Include="default_spritefont.cpp" />
     <ClCompile Include="directx.cpp" />
     <ClCompile Include="EntityManager.cpp" />
-    <ClCompile Include="EqPackets.h" />
     <ClCompile Include="floating_damage.cpp" />
     <ClCompile Include="ui_group.cpp" />
     <ClCompile Include="ui_inputdialog.cpp" />

--- a/Zeal/Zeal.vcxproj.filters
+++ b/Zeal/Zeal.vcxproj.filters
@@ -51,9 +51,6 @@
     <ClInclude Include="framework.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="pch.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="memory.h">
       <Filter>Header Files\memory</Filter>
     </ClInclude>
@@ -243,6 +240,12 @@
     <ClInclude Include="ZealSettings.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="json.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EqPackets.h">
+      <Filter>Header Files\everquest</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
@@ -344,9 +347,6 @@
     <ClCompile Include="autofire.cpp">
       <Filter>Source Files\hooks</Filter>
     </ClCompile>
-    <ClCompile Include="EqPackets.h">
-      <Filter>Header Files\everquest</Filter>
-    </ClCompile>
     <ClCompile Include="ui_raid.cpp">
       <Filter>Source Files\ui</Filter>
     </ClCompile>
@@ -415,9 +415,6 @@
     </ClCompile>
     <ClCompile Include="ui_inputdialog.cpp">
       <Filter>Source Files\ui</Filter>
-    </ClCompile>
-    <ClCompile Include="ZealSettings.cpp">
-      <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Zeal/ZealSettings.h
+++ b/Zeal/ZealSettings.h
@@ -1,13 +1,10 @@
 #pragma once
-#define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
 #include <string>
 #include <functional>
 #include <Windows.h>
-#include <memory>
 #include "callbacks.h"
-#include "EqFunctions.h"
 #include "io_ini.h"
-//#include "Zeal.h"
+#include "EqFunctions.h"
 
 class ZealService;
 template <typename T>

--- a/Zeal/framework.h
+++ b/Zeal/framework.h
@@ -1,5 +1,4 @@
 #pragma once
-#define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
 // Windows Header Files
 #include <windows.h>
 #include "hook_wrapper.h"

--- a/Zeal/hook_wrapper.cpp
+++ b/Zeal/hook_wrapper.cpp
@@ -1,4 +1,5 @@
 #include "hook_wrapper.h"
+typedef BYTE byte;	// unsigned char
 
 namespace Zeal
 {

--- a/Zeal/spellsets.h
+++ b/Zeal/spellsets.h
@@ -3,6 +3,7 @@
 #include "hook_wrapper.h"
 #include "memory.h"
 #include "IO_ini.h"
+#include "EqFunctions.h"
 
 struct menudata
 {
@@ -46,7 +47,7 @@ private:
 	Stance original_stance;
 	void CleanUI();
 	void callback_main();
-	void callback_characterselect();
+	//void callback_characterselect();
 };
 
 


### PR DESCRIPTION
- Add WIN32_LEAN_AND_MEAN to project definitions so it is consistent across all files (and fix missing defines)
- Strip io_ini.h includes to the minimal set to simplify the include looping
- Fix a few project file categories (compile -> include)