### PR TITLE
Restore partial spellset support (0.6.2-beta1)

### DIFF
--- a/Zeal/Zeal.h
+++ b/Zeal/Zeal.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "framework.h"
-#define ZEAL_VERSION "0.6.2-beta0"
+#define ZEAL_VERSION "0.6.2-beta1"
 #ifndef ZEAL_BUILD_VERSION  // Set by github actions
 #define ZEAL_BUILD_VERSION "UNOFFICIAL"  // Local build
 #endif

--- a/Zeal/spellsets.cpp
+++ b/Zeal/spellsets.cpp
@@ -65,8 +65,7 @@ void SpellSets::load(const std::string& name)
     {
       short spell_id = ini->getValue<WORD>(name, std::to_string(gem_index));
       if (spell_id == -1) { // Empty slot when saved.
-          Zeal::EqGame::Spells::Forget(gem_index);
-          continue;  // Leave it empty.
+          continue;  // Leave it unchanged.
       }
 
       if (spell_id < 1 || spell_id >= EQ_NUM_SPELLS || !spell_manager->Spells[spell_id])


### PR DESCRIPTION
- Removed the newly added logic that forgot spell gems that were empty in the spell set. This fixed potential reload collisions but prevents modular spellset reloads. Can fix collisions in a future round.