### PR TITLE
Improve melody consistency (0.6.2-beta2)

### DIFF
--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -6,6 +6,11 @@ namespace Zeal
 {
 	namespace EqGame
 	{
+		int GetSpellCastingTime()  // GetSpellCastingTime() in eqmac.
+		{
+			return reinterpret_cast<int(__cdecl*)(void)>(0x00435f28)();
+		}
+
 		DWORD GetLevelCon(Zeal::EqStructures::Entity* ent) {
 			if (!ent || !Zeal::EqGame::get_self())
 				return 0;

--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -112,6 +112,7 @@ namespace Zeal
 		{
 			bool spellbook_window_open();
 		}
+		int GetSpellCastingTime();  // Used by CCastingWnd. Returns -1 if done otherwise in units of 0.1% of time left.
 		DWORD GetLevelCon(Zeal::EqStructures::Entity* ent);
 		const char* get_aa_title_name(BYTE class_id, int aa_rank, BYTE gender_id);
 		float CalcCombatRange(Zeal::EqStructures::Entity* entity1, Zeal::EqStructures::Entity* entity2);

--- a/Zeal/EqStructures.h
+++ b/Zeal/EqStructures.h
@@ -472,7 +472,13 @@ namespace Zeal
 			/* 0x00B4 */ FLOAT Unknown00B4;
 			/* 0x00B8 */ FLOAT Unknown00B8;
 			/* 0x00BC */ FLOAT MovementSpeedModifier; // how much slower/faster you move
-			/* 0x00C0 */ BYTE Unknown00C0[196];
+			/* 0x00C0 */ BYTE Unknown00C0[0xc];
+			/* 0x00CC */ DWORD CastingTimeout;  // Set in CastSpell as current time + casting time.
+			/* 0x00D0 */ BYTE Unknown00D0[0x8];
+			/* 0x00D8 */ DWORD RecastTimeout[EQ_NUM_SPELL_GEMS]; // Set in the OP_MemorizeSpell handler.
+			/* 0x00F8 */ BYTE Unknown00F8[0x68];
+			/* 0x0160 */ DWORD FizzleTimeout;   // Set in the OP_MemorizeSpell handler.
+			/* 0x0164 */ BYTE Unknown0164[0x20];
 			/* 0x0184 */ DWORD Animation;
 			/* 0x0188 */ BYTE Unknown0188[16];
 			/* 0x0198 */ int Unsure_Strafe_Calc;
@@ -488,8 +494,8 @@ namespace Zeal
 			/* 0x0270 */ BYTE Unknown0270[4];
 			/* 0x0274 */ BYTE Unknown0274[4];
 			/* 0x0278 */ BYTE Unknown0278[4];
-			/* 0x027C */ WORD CastingSpellId;
-			/* 0x027E */ BYTE CastingSpellGemNumber; // 255 = Bard Singing
+			/* 0x027C */ WORD CastingSpellId;  // Set in StartCasting. Set to -1 (kInvalidSpell) in stop.
+			/* 0x027E */ BYTE CastingSpellGemNumber; // StartCasting:Gem #, OP_MemorizeSpell handler: 0xff. Stop: 0x0.
 			/* 0x027F */ BYTE Unknown027F;
 			/* 0x0280 */ BYTE Unknown0280[4];
 			/* 0x0284 */ struct _EQMODELINFO* ModelInfo;
@@ -503,7 +509,9 @@ namespace Zeal
 			/* 0x0320 */ BYTE MovementType; // 0 = None, 4 = Walking, 6 = Running, 7 = Swimming
 			/* 0x0321 */ BYTE Unknown0321[12];
 			/* 0x032D */ BYTE IsMovingTimer; // 0 = Moving, 1-6 = Recently Stopped Moving, 200 = Not Moving
-			/* 0x032E */ BYTE Unknown032E[266];
+			/* 0x032E */ BYTE Unknown032E[0xf6];
+			/* 0x0424 */ DWORD CastingSpellCastTime;  // Set in StartCasting. Used in GetSpellCastingTime().
+			/* 0x0428 */ BYTE Unknown0428[0x10];
 			/* 0x0438 */ DWORD IsLookingForGroup;
 			/* 0x043C */ DWORD IsTrader;
 			/* ...... */

--- a/Zeal/Zeal.h
+++ b/Zeal/Zeal.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "framework.h"
-#define ZEAL_VERSION "0.6.2-beta1"
+#define ZEAL_VERSION "0.6.2-beta2"
 #ifndef ZEAL_BUILD_VERSION  // Set by github actions
 #define ZEAL_BUILD_VERSION "UNOFFICIAL"  // Local build
 #endif

--- a/Zeal/melody.h
+++ b/Zeal/melody.h
@@ -9,6 +9,7 @@ public:
 	bool start(const std::vector<int>& new_songs); //returns true if no errors
 	void end(bool do_print=false);
 	void handle_stop_cast_callback(BYTE reason, WORD spell_id);
+	void handle_deactivate_ui();
 	bool use_item(int item_index); // asks Melody to handle /useitem command. Returns true if melody handled the command.
 	Melody(class ZealService* pHookWrapper, class IO_ini* ini);
 	~Melody();
@@ -21,4 +22,5 @@ private:
 	WORD casting_melody_spell_id = kInvalidSpellId; // Current melody song being cast. Is only a valid id while cast window is visible (actively casting).
 	int use_item_index = -1; // The pending use_item() to try.
 	ULONGLONG use_item_timeout = 0; // The max timestamp until the pending use_item() gives up.
+	ULONGLONG enter_zone_time = 0; // Timestamp of the most recent enter zone callback.
 };


### PR DESCRIPTION
- Modified the start of next song timing to rely on a positive confirmation from the server that the current song has completed casted rather than relying on an empirically determined 150 ms wait time after the client's casting window has dropped
  - Should improve melody performance for those with high latency connections and reduce the mysterious dropping of songs for everyone
  - Also removed an unneed stop song packet from client to server
  - Should reduce collisions to improve consistency (feet move faster followed immediately by you slow down)
- Removed the "Your song ends" log spam for melody song transitions
- Made melodyd behavior across zoning more consistent.
  - Pauses melody at zone exit and rewinds an interrupted song
  - Restarts melody two seconds after zoning when things are stable with the interrupted song. A user can restart a melody sooner.