### PR TITLE
Fix item display of non-haste (worn) effects

### DIFF
--- a/Zeal/item_display.cpp
+++ b/Zeal/item_display.cpp
@@ -123,7 +123,7 @@ void UpdateSetItemText(Zeal::EqUI::ItemDisplayWnd* wnd, Zeal::EqStructures::_EQI
 				s = std::string("Combat ") + s.substr(0, end) + " (Required level: "
 					+ std::to_string(item->Common.CastingLevel) + ")";
 			}
-			else if (item->Common.IsStackableEx == 2 && s.find(" (Worn)") != std::string::npos)
+			else if (item->Common.IsStackableEx == 2 && s.find("Effect: Haste (Worn)") != std::string::npos)
 			{
 				s = std::string("Effect: Haste: +") + std::to_string(item->Common.CastingLevel + 1) + "%";
 			}


### PR DESCRIPTION
- Restored some filtering so items with (worn) effects aren't all treated as haste effects