### PR TITLE
Add ZealService reset() for RightClickToEquip

### DIFF
--- a/Zeal/Zeal.cpp
+++ b/Zeal/Zeal.cpp
@@ -257,6 +257,7 @@ ZealService::~ZealService()
 	item_displays.reset();
 	spell_sets.reset();
 	eqstr_hook.reset();
+	equip_item_hook.reset();
 	raid_hook.reset();
 	binds_hook.reset();
 	labels_hook.reset();


### PR DESCRIPTION
I think I just overlooked this, unless there's a reason I shouldn't add the cleanup.