### PR TITLE
Minor namedpipe cleanups

### DIFF
--- a/Zeal/named_pipe.h
+++ b/Zeal/named_pipe.h
@@ -2,6 +2,7 @@
 #include "json.hpp"
 #include <Windows.h>
 #include <string>
+#include <mutex>
 #include <thread>
 enum struct pipe_data_type
 {
@@ -43,10 +44,15 @@ public:
 	void update_delay(unsigned new_delay);
 	bool is_connected() const { return pipe_handles.size() != 0; }
 private:
+	void add_new_pipe_handle(const HANDLE& handle);
+	void update_pipe_handles();
+
 	int pipe_delay=500;
 	bool end_thread = false;
 	std::string name = "\\\\.\\pipe\\zeal_";
 	std::vector<HANDLE> pipe_handles;
+	std::vector<HANDLE> pipe_handle_queue;  // Mutex protected transfer queue.
 	std::thread pipe_thread;
+	std::mutex pipe_handle_mutex;
 };
 

--- a/Zeal/named_pipe.h
+++ b/Zeal/named_pipe.h
@@ -16,19 +16,17 @@ enum struct pipe_data_type
 struct pipe_data
 {
 	pipe_data_type type;
-	UINT data_len;
 	std::string data;
 	std::string character;
 	pipe_data(pipe_data_type _type, std::string _data);
-	pipe_data() : data{ "" }, character{ "" } {};
+	pipe_data() : type(pipe_data_type::custom), data{ "" }, character{ "" } {};
 	nlohmann::json serialize() const
 	{
-		return nlohmann::json{ {"type", type}, {"data_len", data_len}, {"data", data}, {"character", character} };
+		return nlohmann::json{ {"type", type}, {"data_len", data.length()}, {"data", data}, {"character", character}};
 	}
 	void deserialize(nlohmann::json json_obj)
 	{
 		type = json_obj["type"];
-		data_len = json_obj["data_len"];
 		data = json_obj["data"];
 	}
 };
@@ -43,6 +41,7 @@ public:
 	void write(const char* format, ...);
 	void main_loop();
 	void update_delay(unsigned new_delay);
+	bool is_connected() const { return pipe_handles.size() != 0; }
 private:
 	int pipe_delay=500;
 	bool end_thread = false;


### PR DESCRIPTION
- Minimized the amount of processing performed if not connected to any pipes (the log and chat hooks were doing some unnecessary work)
- Added handling to throw up an error messagebox in the unlikely failure of a CreateEvent
- Minor cleanup of pipe_data struct (constructor init, remove redundant data member)