### PR TITLE
Update map z-level autofade

### DIFF
--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -342,6 +342,7 @@ void ui_options::InitMap()
 	if (!wnd)
 		return;
 	ui->AddCheckboxCallback(wnd, "Zeal_Map", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->zone_map->set_enabled(wnd->Checked, true); });
+	ui->AddCheckboxCallback(wnd, "Zeal_MapAutoFadeEnable", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->zone_map->set_default_to_zlevel_autofade(wnd->Checked, true); });
 	ui->AddCheckboxCallback(wnd, "Zeal_MapInteractiveEnable", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->zone_map->set_interactive_enable(wnd->Checked, true); });
 	ui->AddCheckboxCallback(wnd, "Zeal_MapExternalWindow", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->zone_map->set_external_enable(wnd->Checked, true); });
 	ui->AddCheckboxCallback(wnd, "Zeal_MapShowRaid", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->zone_map->set_show_raid(wnd->Checked); });
@@ -554,6 +555,8 @@ void ui_options::UpdateOptionsTargetRing()
 	ui->SetLabelValue("Zeal_TargetRingRotation_Value", "%.2f", ZealService::get_instance()->target_ring->rotation_speed.get());
 	ui->SetLabelValue("Zeal_TargetRingSize_Value", "%.2f", ZealService::get_instance()->target_ring->outer_size.get());
 	ui->SetLabelValue("Zeal_TargetRingTransparency_Value", "%.2f", ZealService::get_instance()->target_ring->transparency.get());
+	ui->SetComboValue("Zeal_TargetRingTexture_Combobox",
+		FindComboIndex("Zeal_TargetRingTexture_Combobox", ZealService::get_instance()->target_ring->texture_name.get()));
 }
 
 void ui_options::UpdateOptionsNameplate()
@@ -589,8 +592,9 @@ void ui_options::UpdateOptionsMap()
 {
 	if (!wnd)
 		return;
-
+	
 	ui->SetChecked("Zeal_Map", ZealService::get_instance()->zone_map->is_enabled());
+	ui->SetChecked("Zeal_MapAutoFadeEnable", ZealService::get_instance()->zone_map->is_default_zlevel_autofade());
 	ui->SetChecked("Zeal_MapInteractiveEnable", ZealService::get_instance()->zone_map->is_interactive_enabled());
 	ui->SetChecked("Zeal_MapExternalWindow", ZealService::get_instance()->zone_map->is_external_enabled());
 	ui->SetChecked("Zeal_MapShowRaid", ZealService::get_instance()->zone_map->is_show_raid_enabled());

--- a/Zeal/uifiles/zeal/EQUI_Tab_Map.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_Map.xml
@@ -189,13 +189,44 @@
     <AlignCenter>false</AlignCenter>
     <AlignRight>true</AlignRight>
   </Label>
+  <!-- Zeal Map AutoFade Enable-->
+  <Button item="Zeal_MapAutoFadeEnable">
+    <ScreenID>Zeal_MapAutoFadeEnable</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>184</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Defaults to z-level autofade mode</TooltipReference>
+    <Text>Default to Z Autofade</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
   <!-- Zeal Map Alignment Combobox -->
   <Label item="Zeal_MapAlignment_Label">
     <ScreenID>Zeal_MapAlignment_Label</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>184</Y>
+      <Y>214</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -216,7 +247,7 @@
     <DrawTemplate>WDT_Inner</DrawTemplate>
     <Location>
       <X>10</X>
-      <Y>204</Y>
+      <Y>234</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -240,7 +271,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>239</Y>
+      <Y>269</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -261,7 +292,7 @@
     <DrawTemplate>WDT_Inner</DrawTemplate>
     <Location>
       <X>10</X>
-      <Y>259</Y>
+      <Y>289</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -286,7 +317,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>294</Y>
+      <Y>324</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -307,7 +338,7 @@
     <DrawTemplate>WDT_Inner</DrawTemplate>
     <Location>
       <X>10</X>
-      <Y>314</Y>
+      <Y>344</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -332,7 +363,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>349</Y>
+      <Y>379</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -363,7 +394,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>379</Y>
+      <Y>409</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -384,7 +415,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>399</Y>
+      <Y>429</Y>
     </Location>
     <Size>
       <CX>100</CX>
@@ -397,7 +428,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>110</X>
-      <Y>399</Y>
+      <Y>429</Y>
     </Location>
     <Size>
       <CX>40</CX>
@@ -419,7 +450,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>422</Y>
+      <Y>452</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -450,7 +481,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>452</Y>
+      <Y>482</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -471,7 +502,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>472</Y>
+      <Y>502</Y>
     </Location>
     <Size>
       <CX>100</CX>
@@ -484,7 +515,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>110</X>
-      <Y>472</Y>
+      <Y>502</Y>
     </Location>
     <Size>
       <CX>40</CX>
@@ -952,6 +983,7 @@
     <Pieces>Zeal_MapFadedZLevelAlpha_Label</Pieces>
     <Pieces>Zeal_MapFadedZLevelAlpha_Slider</Pieces>
     <Pieces>Zeal_MapFadedZLevelAlpha_Value</Pieces>
+    <Pieces>Zeal_MapAutoFadeEnable</Pieces>
     <Pieces>Zeal_MapNamesLength_Label</Pieces>
     <Pieces>Zeal_MapNamesLength_Slider</Pieces>
     <Pieces>Zeal_MapNamesLength_Value</Pieces>

--- a/Zeal/zone_map.cpp
+++ b/Zeal/zone_map.cpp
@@ -1482,11 +1482,15 @@ int ZoneMap::get_zlevel_scale() const {
         return zlevel_height_scale_override;
 
     switch (zone_id) {
+        case 71:    // airplane
+            return 50;
         case 103:   // chardok
         case 1103:  // chardok_instanced
         case 108:   // veeshan
         case 1108:  // veeshan_instanced
             return 30;
+        case 76:    // hateplane
+        case 1076:  // hate_instanced
         case 121:   // crystal
         case 89:    // sebilis
         case 1089:  // sebilis_instanced
@@ -1496,7 +1500,8 @@ int ZoneMap::get_zlevel_scale() const {
         case 63:    // unrest
             return 6;
         default:
-            return kDefaultZLevelHeightScale;
+            // Effectively disable for open outdoor zones (type 1).
+            return (Zeal::EqGame::ZoneInfo->TimeType == 1) ? 2000 :  kDefaultZLevelHeightScale;
     }
 }
 

--- a/Zeal/zone_map.h
+++ b/Zeal/zone_map.h
@@ -43,6 +43,7 @@ public:
 	void set_enabled(bool enable, bool update_default = false);
 	void set_external_enable(bool enabled, bool update_default = false);
 	void set_interactive_enable(bool enable, bool update_default = true);
+	void set_default_to_zlevel_autofade(bool enable_autofade, bool update_default = true);
 	bool set_show_group_mode(int new_mode, bool update_default = true);
 	void set_show_raid(bool enable, bool update_default = true);
 	void set_show_all_names_override(bool flag);  // Override to enable showing group and raid names.
@@ -67,6 +68,7 @@ public:
 	bool is_show_grid_enabled() const { return map_show_grid; }
 	bool is_show_all_names_override() const { return map_show_all_names_override;}
 	bool is_interactive_enabled() const { return map_interactive_enabled; }
+	bool is_default_zlevel_autofade() const { return default_to_zlevel_autofade; }
 	int get_show_group_mode() const { return map_show_group_mode; }
 	int get_map_zoom_default_index() const { return map_zoom_default_index; }
 	int get_name_length() const { return map_name_length; }
@@ -133,6 +135,7 @@ private:
 	static constexpr int kInvalidPositionValue = 0x7fff;
 	static constexpr int kDefaultGridPitch = 1000;
 	static constexpr int kDefaultNameLength = 5;
+	static constexpr int kDefaultZLevelHeightScale = 10;
 	static constexpr float kDefaultBackgroundAlpha = 0.5f;
 	static constexpr float kDefaultFadedZLevelAlpha = 0.2f;
 	static constexpr float kDefaultPositionSize = 0.01f;
@@ -219,6 +222,7 @@ private:
 	D3DCOLOR get_background_color() const;
 	D3DCOLOR render_get_line_color_and_opacity(const ZoneMapLine& line, int position_z, int level_id) const;
 	void update_succor_label();
+	int get_zlevel_scale() const;
 	bool is_zlevel_change() const;
 
 	const ZoneMapData* get_zone_map(int zone_id);
@@ -240,6 +244,7 @@ private:
 	bool reenable_on_zone = false;  // Flag to re-enable after a zone transition completes.
 	bool external_enabled = false;  // External map window enable and sizes.
 	bool map_interactive_enabled = false;  // Supports some mouse/cursor operations.
+	bool default_to_zlevel_autofade = false;  // Start in auto-fade mode.
 	bool map_show_grid = false;
 	int map_grid_pitch = kDefaultGridPitch;  // Pitch when grid is visible.
 	int map_ring_radius = 0;
@@ -276,6 +281,8 @@ private:
 	float clip_min_y = 0;
 	int clip_max_z = 0;
 	int clip_min_z = 0;
+	int zlevel_height_scale = kDefaultZLevelHeightScale;  // Vertical height for z-level visibility.
+	int zlevel_height_scale_override = 0;  // Zero disables the override.
 	int zlevel_position_z = kInvalidPositionValue;
 	float position_size = kDefaultPositionSize;
 	float marker_size = kDefaultMarkerSize;


### PR DESCRIPTION
- Follow Tarik's recommendations to change the default z-level autofade height to 10 from 15 and add some zone dependent values
- Add a command line override for the autofade height: /map level autoz <height>
- Add a 'default to z autofade' checkbox to the map options tab (also increases visibility of feature)