### PR TITLE
Add tab completion to /t and /consent

### DIFF
--- a/Zeal/EntityManager.cpp
+++ b/Zeal/EntityManager.cpp
@@ -52,6 +52,20 @@ Zeal::EqStructures::Entity* EntityManager::Get(WORD id) const
 	return entity;
 }
 
+std::vector<std::string> EntityManager::GetPlayerPartialMatches(const std::string& start_of_name) const
+{
+	std::vector<std::string> result;
+	Zeal::EqStructures::Entity* current_ent = Zeal::EqGame::get_entity_list();
+	while (current_ent != nullptr)
+	{
+		if (current_ent->Type == Zeal::EqEnums::Player &&
+			_strnicmp(current_ent->Name, start_of_name.c_str(), start_of_name.length()) == 0)
+			result.push_back(current_ent->Name);
+		current_ent = current_ent->Next;
+	}
+	return result;
+}
+
 // Local Dump() helper that confirms there isn't a mismatch of a hashmap key/value pair.
 static bool is_valid_entity(const std::string& name, struct Zeal::EqStructures::Entity* entity) {
 	if (!entity)

--- a/Zeal/EntityManager.h
+++ b/Zeal/EntityManager.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <unordered_map>
 #include <string>
+#include <vector>
 
 class EntityManager
 {
@@ -14,6 +15,7 @@ public:
 	void Remove(struct Zeal::EqStructures::Entity*);
 	Zeal::EqStructures::Entity* Get(std::string name) const;  // Returns nullptr if not found.
 	Zeal::EqStructures::Entity* Get(WORD id) const;  // Note: Equivalent to EqGame::get_entity_by_id()
+	std::vector<std::string> GetPlayerPartialMatches(const std::string& start_of_name) const;
 	void Dump() const;
 
 private:


### PR DESCRIPTION
- Hitting the tab key when using /t or /consent commands with the start of a name will search the client tell list and all player entities in the zone for a match. If a single match, completes the name. If multiple matches, lists them.