### PR TITLE
Refactor nameplate code, eliminate target delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,32 +245,10 @@ ___
   - **Arguments:** `oldui`
   - **Description:** Re-opens the alarm window, if oldui is specified it allows for an alarm on it.
 
-- `/nameplatecolors`
-  - **Description:** toggles nameplate colors for players
+- `/nameplate`
+  - **Arguments:** `colors`, `concolors`, `targetcolor`, `charselect`, `hideself`, `x`, `hideraidpets`, `targetmarker`, `targethealth`, `inlineguild`
+  - **Description:** toggles nameplate modes for adjusting colors (tints) and text
 
-- `/nameplateconcolors`
-  - **Description:** toggles nameplate con colors for npcs
-
-- `/nameplatehideself`
-  - **Description:** toggles nameplate for self (on/off)
-
-- `/nameplatex`
-  - **Description:** toggles nameplate for self as X (on/off)
-
-- `/nameplatehideraidpets`
-  - **Description:** toggles nameplate for raid pets and your pet (on/off)
- 
-- `/nameplatecharselect`
-  - **Description:** toggles nameplate choices shown at character selection screen on and off (on/off)
-
-- `/nameplatetargetcolor`
-  - **Description:** toggles target nameplate color on and off (on/off)
- 
-- `/nameplatetargetmarker`
-  - **Description:** toggles target nameplate marker on and off (on/off)
- 
-- `/nameplatetargethealth`
-  - **Description:** toggles target nameplate health on and off (on/off)
 ___
 ### Binds
 - Cycle through nearest NPCs
@@ -373,18 +351,20 @@ Necromancers will now have an easier time finding their corpses.
 The nameplate is controlled through three interfaces:
 * Dedicated Zeal options window tab (requires `zeal\uifiles`, see Installation notes above)
 * Key binds for nameplate options (configure in EQ Options->Keyboard->Target)
-* The five /nameplate commands listed below
+* The /nameplate commands described below
 
 #### Enabling Disabling Nameplate Options
-* The `/nameplatecolors` command - Toggles Nameplate Colors for Players on and off
-* The `/nameplateconcolors` command - Toggles Nameplate Con Colors for NPCs on and off
-* The `/nameplatehideself` command - Toggles Player Nameplate on and off
-* The `/nameplatex` command - Toggles Player Nameplate as X on and off
-* The `/nameplatehideraidpets` command - Toggles NPC Raid Pets Nameplate on and off
-* The `/nameplatecharselect` command - Toggles Nameplate Choices Shown at Character Selection Screen on and off
-* The `/nameplatetargetcolor` command - Toggles Target Nameplate Color on and off
-* The `/nameplatetargetmarker` command - Toggles Target Nameplate Marker on and off
-* The `/nameplatetargethealth` command - Toggles Target Nameplate Health on and off
+* The `/nameplate colors` command - Toggles Nameplate Colors for Players on and off
+* The `/nameplate concolors` command - Toggles Nameplate Con Colors for NPCs on and off
+* The `/nameplate hideself` command - Toggles Player Nameplate on and off
+* The `/nameplate x` command - Toggles Player Nameplate as X on and off
+* The `/nameplate hideraidpets` command - Toggles NPC Raid Pets Nameplate on and off
+* The `/nameplate charselect` command - Toggles Nameplate Choices Shown at Character Selection Screen on and off
+* The `/nameplate targetcolor` command - Toggles Target Nameplate Color on and off
+* The `/nameplate targetmarker` command - Toggles Target Nameplate Marker on and off
+* The `/nameplate targethealth` command - Toggles Target Nameplate Health on and off
+* The `/nameplate targethealth` command - Toggles Target Nameplate Health on and off
+* The `/nameplate inlineguild` command - Toggles guild name appearing inline or on a separate line
 
 #### Changing the Color of Nameplates
 Zeal allows players to change the colors of the Nameplates of Players and NPCs in game.

--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -183,14 +183,18 @@ namespace Zeal
 		// re-used, so the result should be consumed immediately (copy to std::string or compare immediately).
 		const char* trim_name(const char* name);  // Cleans but leaves suffixes. Use for name's corpse123 => name's corpse.
 		const char* strip_name(const char* name);  // Strips numbers and any text past an apostrophe ('s corpse).
-		char* get_guildName_from_guildId(int guildId);
 		char* get_string(UINT id);
 		//void set_camera_position(Vec3* pos);
 		int* get_display();
 		float heading_to_yaw(float heading);
 		bool is_mouse_hovering_window();
+		int get_showname(); // Holds value of /showname command.
 		std::string class_name_short(int class_id);
 		std::string class_name(int class_id);
+		std::string get_full_zone_name(int zone_id);  // EQWorldData::GetFullZoneName()
+		std::string get_class_desc(int class_id);  // CEverQuest::GetClassDesc()
+		std::string get_title_desc(int class_id, int aa_rank, int gender);  // CEverQuest::GetTitleDesc()
+		std::string get_player_guild_name(short guild_id); // GetPlayerGuildName()
 		bool is_game_ui_window_hovered();
 		bool is_targetable(Zeal::EqStructures::Entity* ent);
 		bool is_in_game();
@@ -201,6 +205,7 @@ namespace Zeal
 		std::vector<Zeal::EqStructures::RaidMember*> get_raid_list();
 		DWORD get_raid_group_number();
 		int get_raid_group_count(DWORD group_number);
+		bool is_raid_pet(const Zeal::EqStructures::Entity& entity);
 		std::string get_raid_group_leader(DWORD group_number);
 		void print_group_leader();
 		void print_raid_leaders(bool show_all_groups = false, bool show_open_groups = false);

--- a/Zeal/EqPackets.h
+++ b/Zeal/EqPackets.h
@@ -12,6 +12,7 @@ namespace Zeal
             PrintNonMeleeDamage = 0x4236,
             CorpseDrag = 0x4114,
             CorpseDrop = 0x1337,
+            TargetMouse = 0x4162,
             RequestTrade = 0x40D1
         };
         struct TradeRequest_Struct {
@@ -52,6 +53,11 @@ namespace Zeal
             /*016*/	UINT8   is_PC;
             /*017*/	UINT8   unknown015[3];
             /*020*/
+        };
+        struct ClientTarget_Struct
+        {
+            /*000*/	UINT16	new_target; // Target spawn ID.
+            /*002*/
         };
     }
 }

--- a/Zeal/EqStructures.h
+++ b/Zeal/EqStructures.h
@@ -402,7 +402,8 @@ namespace Zeal
 		} EQARGBCOLOR;
 		typedef struct _EQSTRINGSPRITE
 		{
-			/* 0x0000 */ DWORD Unknown0000;
+			static constexpr int kMagicValidValue = 0x51;  // Magic value that means valid.
+			/* 0x0000 */ DWORD MagicValue;  // Set to kMagicValidValue in valid StringSprites.
 			/* 0x0004 */ DWORD Unknown0004;
 			/* 0x0008 */ DWORD Unknown0008;
 			/* 0x000C */ DWORD Unknown000C;
@@ -709,7 +710,7 @@ namespace Zeal
 			/* 0x0F10 */ FLOAT ZoneBirthZ;
 			/* 0x0F14 */ BYTE Unknown0F14[1080];
 			/* 0x134C */ WORD Deity;
-			/* 0x134E */ WORD GuildId;
+			/* 0x134E */ short GuildId;
 			/* 0x1350 */ BYTE Unknown1350[8];
 			/* 0x1358 */ BYTE Unknown1358;
 			/* 0x1359 */ BYTE Unknown1359;
@@ -775,7 +776,7 @@ namespace Zeal
 			/* 0x0096 */ WORD PetOwnerSpawnId; // spawn id of the owner of this pet spawn
 			/* 0x0098 */ DWORD HpMax;
 			/* 0x009C */ DWORD HpCurrent;
-			/* 0x00A0 */ WORD GuildId;
+			/* 0x00A0 */ short GuildId;  // -1 is unguilded
 			/* 0x00A2 */ BYTE Unknown00A2[6];
 			/* 0x00A8 */ BYTE Type; // EQ_SPAWN_TYPE_x
 			/* 0x00A9 */ BYTE Class; // EQ_CLASS_x

--- a/Zeal/EqUI.h
+++ b/Zeal/EqUI.h
@@ -412,7 +412,8 @@ namespace Zeal
 		};
 		struct CharSelect : EQWND
 		{
-			/*0x134*/	BYTE    Unk[0x3C];  // 0x134 looks like an activated flag (set to 0 in Deactivate callbacks.)
+			/*0x134*/	BYTE    Activated;   // Set to 1 when activated and 0 in Deactivate().
+			/*0x135*/	BYTE    Unknown0x135[0x3B];
 			/*0x170*/   BYTE    Rotate;
 			/*0x171*/   BYTE    Explore;
 		};

--- a/Zeal/ZealSettings.h
+++ b/Zeal/ZealSettings.h
@@ -27,7 +27,7 @@ public:
 	{
 		set(!value, store);
 	}
-	T get() { return value; }
+	T get() const { return value; }
 	std::string get_section_name() const {
 		if (!per_character)
 			return section;

--- a/Zeal/binds.cpp
+++ b/Zeal/binds.cpp
@@ -298,11 +298,11 @@ void Binds::add_binds()
 		});
 	add_bind(235, "Toggle Nameplate Colors", "ToggleNameplateColors", key_category::Target, [this](int key_down) {
 		if (key_down && !Zeal::EqGame::EqGameInternal::UI_ChatInputCheck())
-			ZealService::get_instance()->nameplate->colors_set_enabled(!ZealService::get_instance()->nameplate->colors_is_enabled());
+			ZealService::get_instance()->nameplate->setting_colors.toggle(false);
 		});
 	add_bind(236, "Toggle Nameplate Con Colors", "ToggleNameplateConColors", key_category::Target, [this](int key_down) {
 		if (key_down && !Zeal::EqGame::EqGameInternal::UI_ChatInputCheck())
-			ZealService::get_instance()->nameplate->con_colors_set_enabled(!ZealService::get_instance()->nameplate->con_colors_is_enabled());
+			ZealService::get_instance()->nameplate->setting_con_colors.toggle(false);
 		});
 	add_bind(237, "Toggle Map Member Names", "FlashMapMemberNames", key_category::UI, [this](int key_down) {
 		// Left the short name as "Flash" to stay consistent with previous keybinds.
@@ -313,15 +313,15 @@ void Binds::add_binds()
 		});
 	add_bind(238, "Toggle Nameplate Self", "ToggleNameplateSelf", key_category::Target, [this](int key_down) {
 		if (key_down && !Zeal::EqGame::EqGameInternal::UI_ChatInputCheck())
-			ZealService::get_instance()->nameplate->hide_self_set_enabled(!ZealService::get_instance()->nameplate->hide_self_is_enabled());
+			ZealService::get_instance()->nameplate->setting_hide_self.toggle(false);
 		});
 	add_bind(239, "Toggle Nameplate Self as X", "ToggleNameplateX", key_category::Target, [this](int key_down) {
 		if (key_down && !Zeal::EqGame::EqGameInternal::UI_ChatInputCheck())
-			ZealService::get_instance()->nameplate->x_set_enabled(!ZealService::get_instance()->nameplate->x_is_enabled());
+			ZealService::get_instance()->nameplate->setting_x.toggle(false);
 		});
 	add_bind(240, "Toggle Nameplate Raid Pets", "ToggleNameplateRaidPets", key_category::Target, [this](int key_down) {
 		if (key_down && !Zeal::EqGame::EqGameInternal::UI_ChatInputCheck())
-			ZealService::get_instance()->nameplate->hide_raidpets_set_enabled(!ZealService::get_instance()->nameplate->hide_raidpets_is_enabled());
+			ZealService::get_instance()->nameplate->setting_hide_raid_pets.toggle(false);
 		});
 	add_bind(241, "Toggle Map Grid Lines", "ToggleMapGridLines", key_category::UI, [this](int key_down) {
 		if (key_down && !Zeal::EqGame::EqGameInternal::UI_ChatInputCheck()) 

--- a/Zeal/bitmap_font.h
+++ b/Zeal/bitmap_font.h
@@ -15,7 +15,7 @@
 class BitmapFont
 {
 public:
-    static constexpr char kFontDirectoryPath[] = "uifiles/zeal/fonts";
+    static constexpr char kFontDirectoryPath[] = "./uifiles/zeal/fonts";
     static constexpr char kFontFileExtension[] = ".spritefont";
     static constexpr char kDefaultFontName[] = "default";
 

--- a/Zeal/commands.cpp
+++ b/Zeal/commands.cpp
@@ -373,7 +373,7 @@ ChatCommands::ChatCommands(ZealService* zeal)
 						original.c_str(), trimmed.c_str(), stripped.c_str(), trimmed == stripped ? "true" : "false");
 					if (target->ActorInfo && target->ActorInfo->DagHeadPoint && target->ActorInfo->DagHeadPoint->StringSprite) {
 						auto& sprite = *target->ActorInfo->DagHeadPoint->StringSprite;
-						if (sprite.Unknown0000 == 0x51)
+						if (sprite.MagicValue == sprite.kMagicValidValue)
 							Zeal::EqGame::print_chat("Sprite: %s, len: %i", sprite.Text, sprite.TextLength);
 					}
 				}

--- a/Zeal/nameplate.h
+++ b/Zeal/nameplate.h
@@ -3,41 +3,58 @@
 #include "memory.h"
 #include <stdint.h>
 #include "EqStructures.h"
+#include "ZealSettings.h"
 
 class NamePlate
 {
 public:
-	bool nameplateColors = false;
-	bool nameplateconColors = false;
-	bool nameplateHideSelf = false;
-	bool nameplateX = false;
-	bool nameplateHideRaidPets = false;
-	bool nameplateCharSelect = false;
-	bool nameplateTargetColor = false;
-	bool nameplateTargetMarker = false;
-	bool nameplateTargetHealth = false;
+	// The positive color indices must be kept in sync with the color options.
+	enum class ColorIndex : int
+	{
+		UseConsider = -2,	// Special internal signal to use consider level.
+		UseClient = -1,		// Internal signal to use the client default color.
+		AFK = 0,
+		LFG = 1,
+		LD = 2,
+		MyGuild= 3,
+		Raid = 4,
+		Group = 5,
+		PVP = 6,
+		Role = 7,
+		OtherGuild = 8,
+		Adventurer = 9,
+		NpcCorpse = 10,
+		PlayerCorpse = 11,
+		Target = 18,
+	};
 
-	bool colors_is_enabled() const { return nameplateColors; }
-	bool con_colors_is_enabled() const { return nameplateconColors; }
-	bool hide_self_is_enabled() const { return nameplateHideSelf; }
-	bool x_is_enabled() const { return nameplateX; }
-	bool hide_raidpets_is_enabled() const { return nameplateHideRaidPets; }
-	bool charselect_is_enabled() const { return nameplateCharSelect; }
-	bool target_color_is_enabled() const { return nameplateTargetColor; }
-	bool target_marker_is_enabled() const { return nameplateTargetMarker; }
-	bool target_health_is_enabled() const { return nameplateTargetHealth; }
-	void colors_set_enabled(bool enabled);	
-	void con_colors_set_enabled(bool enabled);
-	void hide_self_set_enabled(bool enabled);
-	void x_set_enabled(bool enabled);
-	void hide_raidpets_set_enabled(bool enabled);
-	void charselect_set_enabled(bool enabled);
-	void target_color_set_enabled(bool enabled);
-	void target_marker_set_enabled(bool enabled);
-	void target_health_set_enabled(bool enabled);
-	void HandleState(void* this_ptr, void* not_used, Zeal::EqStructures::Entity* spawn);
-	void HandleTint(Zeal::EqStructures::Entity* spawn);
 	NamePlate(class ZealService* zeal, class IO_ini* ini);
 	~NamePlate();
+
+	// Tint (color) settings.
+	ZealSetting<bool> setting_colors = { false, "Zeal", "NameplateColors", false };
+	ZealSetting<bool> setting_con_colors = { false, "Zeal", "NameplateConColors", false };
+	ZealSetting<bool> setting_target_color = { false, "Zeal", "NameplateTargetColor", false };
+	ZealSetting<bool> setting_char_select = { false, "Zeal", "NameplateCharSelect", false };
+
+	// Text settings.
+	ZealSetting<bool> setting_hide_self = { false, "Zeal", "NameplateHideSelf", false };
+	ZealSetting<bool> setting_x = { false, "Zeal", "NameplateX", false };
+	ZealSetting<bool> setting_hide_raid_pets = { false, "Zeal", "NameplateHideRaidPets", false };
+	ZealSetting<bool> setting_target_marker = { false, "Zeal", "NameplateTargetMarker", false };
+	ZealSetting<bool> setting_target_health = { false, "Zeal", "NameplateTargetHealth", false };
+	ZealSetting<bool> setting_inline_guild = { false, "Zeal", "NameplateInlineGuild", false };
+
+	// Internal use only (public for use by callbacks).
+	__declspec(noinline) bool handle_SetNameSpriteTint(Zeal::EqStructures::Entity* entity);
+	bool handle_SetNameSpriteState(void* this_display, Zeal::EqStructures::Entity* entity, int show);
+
 private:
+	void parse_args(const std::vector<std::string>& args);
+	ColorIndex get_color_index(const Zeal::EqStructures::Entity& entity);
+	ColorIndex get_player_color_index(const Zeal::EqStructures::Entity& entity) const;
+	ColorIndex get_pet_color_index(const Zeal::EqStructures::Entity& entity) const;
+	std::string generate_nameplate_text(const Zeal::EqStructures::Entity& entity, int show) const;
+	std::string generate_target_postamble(const Zeal::EqStructures::Entity& entity) const;
+	bool is_nameplate_hidden_by_race(const Zeal::EqStructures::Entity& entity) const;
 };

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -468,15 +468,16 @@ void ui_options::InitNameplate()
 {
 	if (!wnd)
 		return;
-	ui->AddCheckboxCallback(wnd, "Zeal_NameplateColors", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->colors_set_enabled(wnd->Checked); });
-	ui->AddCheckboxCallback(wnd, "Zeal_NameplateConColors", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->con_colors_set_enabled(wnd->Checked); });
-	ui->AddCheckboxCallback(wnd, "Zeal_NameplateHideSelf", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->hide_self_set_enabled(wnd->Checked); });
-	ui->AddCheckboxCallback(wnd, "Zeal_NameplateX", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->x_set_enabled(wnd->Checked); });
-	ui->AddCheckboxCallback(wnd, "Zeal_NameplateHideRaidPets", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->hide_raidpets_set_enabled(wnd->Checked); });
-	ui->AddCheckboxCallback(wnd, "Zeal_NameplateCharSelect", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->charselect_set_enabled(wnd->Checked); });
-	ui->AddCheckboxCallback(wnd, "Zeal_NameplateTargetColor", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->target_color_set_enabled(wnd->Checked); });
-	ui->AddCheckboxCallback(wnd, "Zeal_NameplateTargetMarker", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->target_marker_set_enabled(wnd->Checked); });
-	ui->AddCheckboxCallback(wnd, "Zeal_NameplateTargetHealth", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->target_health_set_enabled(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_NameplateColors", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->setting_colors.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_NameplateConColors", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->setting_con_colors.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_NameplateHideSelf", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->setting_hide_self.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_NameplateX", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->setting_x.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_NameplateHideRaidPets", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->setting_hide_raid_pets.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_NameplateCharSelect", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->setting_char_select.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_NameplateInlineGuild", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->setting_inline_guild.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_NameplateTargetColor", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->setting_target_color.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_NameplateTargetMarker", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->setting_target_marker.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_NameplateTargetHealth", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->setting_target_health.set(wnd->Checked); });
 }
 
 void ui_options::UpdateOptions()
@@ -564,15 +565,16 @@ void ui_options::UpdateOptionsNameplate()
 	if (!wnd)
 		return;
 
-	ui->SetChecked("Zeal_NameplateColors", ZealService::get_instance()->nameplate->nameplateColors);
-	ui->SetChecked("Zeal_NameplateConColors", ZealService::get_instance()->nameplate->nameplateconColors);
-	ui->SetChecked("Zeal_NameplateHideSelf", ZealService::get_instance()->nameplate->nameplateHideSelf);
-	ui->SetChecked("Zeal_NameplateX", ZealService::get_instance()->nameplate->nameplateX);
-	ui->SetChecked("Zeal_NameplateHideRaidpets", ZealService::get_instance()->nameplate->nameplateHideRaidPets);
-	ui->SetChecked("Zeal_NameplateCharSelect", ZealService::get_instance()->nameplate->nameplateCharSelect);
-	ui->SetChecked("Zeal_NameplateTargetColor", ZealService::get_instance()->nameplate->nameplateTargetColor);
-	ui->SetChecked("Zeal_NameplateTargetMarker", ZealService::get_instance()->nameplate->nameplateTargetMarker);
-	ui->SetChecked("Zeal_NameplateTargetHealth", ZealService::get_instance()->nameplate->nameplateTargetHealth);
+	ui->SetChecked("Zeal_NameplateColors", ZealService::get_instance()->nameplate->setting_colors.get());
+	ui->SetChecked("Zeal_NameplateConColors", ZealService::get_instance()->nameplate->setting_con_colors.get());
+	ui->SetChecked("Zeal_NameplateHideSelf", ZealService::get_instance()->nameplate->setting_hide_self.get());
+	ui->SetChecked("Zeal_NameplateX", ZealService::get_instance()->nameplate->setting_x.get());
+	ui->SetChecked("Zeal_NameplateHideRaidPets", ZealService::get_instance()->nameplate->setting_hide_raid_pets.get());
+	ui->SetChecked("Zeal_NameplateCharSelect", ZealService::get_instance()->nameplate->setting_char_select.get());
+	ui->SetChecked("Zeal_NameplateInlineGuild", ZealService::get_instance()->nameplate->setting_inline_guild.get());
+	ui->SetChecked("Zeal_NameplateTargetColor", ZealService::get_instance()->nameplate->setting_target_color.get());
+	ui->SetChecked("Zeal_NameplateTargetMarker", ZealService::get_instance()->nameplate->setting_target_marker.get());
+	ui->SetChecked("Zeal_NameplateTargetHealth", ZealService::get_instance()->nameplate->setting_target_health.get());
 }
 
 void ui_options::UpdateOptionsFloatingDamage()

--- a/Zeal/uifiles/zeal/EQUI_Tab_Nameplate.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_Nameplate.xml
@@ -182,6 +182,36 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
+  <Button item="Zeal_NameplateInlineGuild">
+    <ScreenID>Zeal_NameplateInlineGuild</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>178</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Toggle inline guild name</TooltipReference>
+    <Text>Inline guild name</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
   <Button item="Zeal_NameplateTargetColor">
     <ScreenID>Zeal_NameplateTargetColor</ScreenID>
     <RelativePosition>true</RelativePosition>
@@ -299,6 +329,7 @@
 	<Pieces>Zeal_NameplateX</Pieces>
 	<Pieces>Zeal_NameplateHideRaidPets</Pieces>
 	<Pieces>Zeal_NameplateCharSelect</Pieces>
+	<Pieces>Zeal_NameplateInlineGuild</Pieces>
 	<Pieces>Zeal_NameplateTargetColor</Pieces>
 	<Pieces>Zeal_NameplateTargetMarker</Pieces>
 	<Pieces>Zeal_NameplateTargetHealth</Pieces>


### PR DESCRIPTION
- Refactored the nameplate code in preparation for adding a shadowed bitmap font option
- Patched the RealRender_World tint updates to also update the text immediately on target changes (fixes latency)
- Reproduced the client logic for generating StringSprite text so it can skip calling the client method
- Modified target markers from <target> to >>target<<
- Added an inline_guild option that adds the <guild> on the same line as the name versus separate line (legacy)
- Consolidated the /nameplate* commands to a single /nameplate version with a parser in preparation for adding more advanced configuration options
- Minor changes to coloring (self pets are always group, etc)