### PR TITLE
Fix - One version of do_say() wasn't silencing chat echoes

### DIFF
--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -1548,13 +1548,13 @@ namespace Zeal
 		{
 			byte orig[13] = {0};
 			if (hide_local)
-				mem::set(0x4f828b, 0x90, 13, orig);
+				mem::set(0x538672, 0x90, 13, orig);
 
 			EqGameInternal::do_say(get_self(), data.c_str());
 
 			if (hide_local && orig)
 			{
-				mem::copy(0x4f828b, orig, 13);
+				mem::copy(0x538672, orig, 13);
 			}
 		}
 


### PR DESCRIPTION
One of the do_say() calls wasn't suppressing the say echo, making a hidden message visible  in the HelmManager code.

Copied the memory address from the other one and that seems to have fixed the issue.

I'm still unsure why I noticed this, because I don't understand why HelmManager was binding to the second(bugged) function to begin with, since it's calling with vargs.

Should the second one also switch to `std::string&` while we're at it?

```
 Zeal::EqGame::do_say(true, "#showhelm %s%s", ShowHelmEnabled.get() ? "on" : "off", server_silent ? " silent" : "");
```

Comparison
```
void do_say(bool hide_local, const char* format, ...)
{
	byte orig[13] = {0};
	if (hide_local)
		mem::set(0x538672, 0x90, 13, orig);
```
vs
```
void do_say(bool hide_local, std::string data)
{
	byte orig[13] = {0};
	if (hide_local)
		mem::set(0x4f828b, 0x90, 13, orig);
```