### PR TITLE
Add target color option to target ring

### DIFF
--- a/Zeal/target_ring.cpp
+++ b/Zeal/target_ring.cpp
@@ -11,6 +11,11 @@
 
 static constexpr char const * kTextureDirectoryPath = "./uifiles/zeal/targetrings/";
 
+static D3DCOLOR get_target_color() {
+	const int kTargetColorIndex = 18; // NamePlate::ColorIndex::Target
+	return ZealService::get_instance()->ui->options->GetColor(kTargetColorIndex);
+}
+
 RenderState::RenderState(IDirect3DDevice8* device, DWORD state, DxStateType_ type)
 	: state(state), type(type)
 {

--- a/Zeal/target_ring.cpp
+++ b/Zeal/target_ring.cpp
@@ -390,7 +390,11 @@ void TargetRing::callback_render() {
 	ULONGLONG currentTime = GetTickCount64(); // Get the current time in milliseconds
 
 	// ### Target Ring Color ###
-	DWORD originalColor = Zeal::EqGame::GetLevelCon(target);
+	DWORD originalColor;
+	if (target_color.get())
+		originalColor = get_target_color();
+	else
+		originalColor = Zeal::EqGame::GetLevelCon(target);
 	// Max Red, Green, and Blue by default
 	DWORD Color = originalColor;
 		/*Color = D3DCOLOR_ARGB(0xFF,

--- a/Zeal/target_ring.h
+++ b/Zeal/target_ring.h
@@ -62,6 +62,7 @@ public:
 	ZealSetting<bool> attack_indicator = { false, "TargetRing", "AttackIndicator", true };
 	ZealSetting<bool> rotate_match_heading = { false, "TargetRing", "MatchHeading", true };
 	ZealSetting<bool> use_cone = { false, "TargetRing", "Cone", true };
+	ZealSetting<bool> target_color = { false, "TargetRing", "TargetColor", true, [](bool val) { Zeal::EqGame::print_chat("Target ring using Target Color is %s", val ? "Enabled" : "Disabled"); } };
 	ZealSetting<float> inner_percent = { 0.50f, "TargetRing", "InnerSize", true };
 	ZealSetting<float> outer_size = { 10.0f, "TargetRing", "Size", true };
 	ZealSetting<float> rotation_speed = { 1.0f, "TargetRing", "RotateSpeed", true };

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -411,6 +411,7 @@ void ui_options::InitTargetRing()
 	ui->AddCheckboxCallback(wnd, "Zeal_TargetRingAttackIndicator", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->target_ring->attack_indicator.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_TargetRingForward", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->target_ring->rotate_match_heading.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_TargetRingCone", [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->target_ring->use_cone.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_TargetRingColor", [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->target_ring->target_color.set(wnd->Checked); });
 	
 	ui->AddComboCallback(wnd, "Zeal_TargetRingTexture_Combobox", [this](Zeal::EqUI::BasicWnd* wnd, int value) {
 		if (value >= 0)
@@ -545,6 +546,7 @@ void ui_options::UpdateOptionsTargetRing()
 	ui->SetChecked("Zeal_TargetRingAttackIndicator", ZealService::get_instance()->target_ring->attack_indicator.get());
 	ui->SetChecked("Zeal_TargetRingForward", ZealService::get_instance()->target_ring->rotate_match_heading.get());
 	ui->SetChecked("Zeal_TargetRingCone", ZealService::get_instance()->target_ring->use_cone.get());
+	ui->SetChecked("Zeal_TargetRingColor", ZealService::get_instance()->target_ring->target_color.get());
 	ui->SetSliderValue("Zeal_TargetRingFill_Slider", ScaleFloatToSlider(ZealService::get_instance()->target_ring->inner_percent.get(), 0, 1, ui->GetSlider("Zeal_TargetRingFill_Slider")));
 	ui->SetSliderValue("Zeal_TargetRingSize_Slider", ScaleFloatToSlider(ZealService::get_instance()->target_ring->outer_size.get(), 0, 20, ui->GetSlider("Zeal_TargetRingSize_Slider")));
 	ui->SetSliderValue("Zeal_TargetRingRotation_Slider", ScaleFloatToSlider(ZealService::get_instance()->target_ring->rotation_speed.get(), -1, 1, ui->GetSlider("Zeal_TargetRingSize_Slider")));

--- a/Zeal/uifiles/zeal/EQUI_Tab_TargetRing.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_TargetRing.xml
@@ -122,6 +122,36 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
+  <Button item="Zeal_TargetRingColor">
+    <ScreenID>Zeal_TargetRingColor</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>11</X>
+      <Y>98</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Renders Target ring color using Target Color</TooltipReference>
+    <Text>Target Color</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
    <!-- Zeal Target Ring Fill slider -->
   <Label item="Zeal_TargetRingFill_Label">
     <ScreenID>Zeal_TargetRingFill_Label</ScreenID>
@@ -545,6 +575,7 @@
 	<Pieces>Zeal_TargetRingForward</Pieces>
     <Pieces>Zeal_TargetRingTexture_Combobox</Pieces>
 	<Pieces>Zeal_TargetRingCone</Pieces>
+    <Pieces>Zeal_TargetRingColor</Pieces>
     <Location>
       <X>0</X>
       <Y>22</Y>


### PR DESCRIPTION
-Default in Target Ring is to continue to use Con Colors for Target Ring
-Added Target Color option to Target Ring tab enabling user to alternate between using Con Colors and Target Color if desired.  This is preperation for the upcoming new feature Nameplate blinking indicator that syncs with Target Ring autoattack indicator. Target Color provides further syncing options.
-Connected new Target Color option in Target Ring tab to XML button and UI Options so that it is can be toggled