### PR TITLE
Clean up combobox option and fcd settings

### DIFF
--- a/Zeal/floating_damage.cpp
+++ b/Zeal/floating_damage.cpp
@@ -372,7 +372,7 @@ void FloatingDamage::init_ui()
 	clean_ui();  // Just in case releases all resources and clears textures.
 	std::string current_ui = (char*)0x63D3C0;
 	std::string path = current_ui;
-	std::string default_path = "./UIFILES/default/";
+	std::string default_path = "./uifiles/default/";
 	for (int i = 1; i <= 3; i++)
 	{
 		std::stringstream filepath;
@@ -384,13 +384,6 @@ void FloatingDamage::init_ui()
 		if (!add_texture(filepath.str()))
 			Zeal::EqGame::print_chat("Texture not found: %s", filepath.str().c_str());
 	}
-	auto ini = ZealService::get_instance()->ini.get();  // Short-life pointer.
-	if (ini)
-	{
-		if (!ini->exists("Zeal", "FloatingDamageFont"))
-			ini->setValue<std::string>("Zeal", "FloatingDamageFont", std::string(""));
-		bitmap_font_filename = ini->getValue<std::string>("Zeal", "FloatingDamageFont");
-	}
 }
 
 void FloatingDamage::clean_ui()
@@ -400,21 +393,6 @@ void FloatingDamage::clean_ui()
 			texture->Release();
 	textures.clear();
 	bitmap_font.reset();
-}
-
-bool FloatingDamage::set_font(std::string font_name) {
-	if (bitmap_font && bitmap_font_filename == font_name)
-		return true;  // Already loaded.
-
-	bitmap_font.reset();  // Release all resources and reset to nullptr.
-	if (font_name == kUseClientFontString)
-		font_name = "";  // Disables the bitmap font.
-	bitmap_font_filename = font_name;  // Attempts to load at next render pass.
-
-	if (ZealService::get_instance() && ZealService::get_instance()->ini)
-		ZealService::get_instance()->ini->setValue<std::string>("Zeal", "FloatingDamageFont", bitmap_font_filename);
-
-	return true;  // Always succeed for now.
 }
 
 std::vector<std::string> FloatingDamage::get_available_fonts() const {
@@ -428,30 +406,22 @@ std::vector<std::string> FloatingDamage::get_available_fonts() const {
 
 // Loads the bitmap font for real-time text rendering to screen.
 void FloatingDamage::load_bitmap_font() {
-	if (bitmap_font || bitmap_font_filename.empty())
+	if (bitmap_font || bitmap_font_filename.get().empty() ||
+		bitmap_font_filename.get() == kUseClientFontString)
 		return;
 
 	IDirect3DDevice8* device = ZealService::get_instance()->dx->GetDevice();
 	if (device != nullptr)
-		bitmap_font = BitmapFont::create_bitmap_font(*device, bitmap_font_filename);
+		bitmap_font = BitmapFont::create_bitmap_font(*device, bitmap_font_filename.get());
 	if (!bitmap_font) {
-		Zeal::EqGame::print_chat("Failed to load font: %s", bitmap_font_filename.c_str());
-		bitmap_font_filename = "";  // Disable future attempts and use CTexture font.
+		Zeal::EqGame::print_chat("Failed to load font: %s", bitmap_font_filename.get().c_str());
+		bitmap_font_filename.set(kUseClientFontString);  // Disable attempts and use CTexture font.
 	}
 }
 
 FloatingDamage::FloatingDamage(ZealService* zeal, IO_ini* ini)
 {
 	//mem::write<BYTE>(0x4A594B, 0x14);
-	if (!ini->exists("Zeal", "FloatingDamage"))
-		ini->setValue<bool>("Zeal", "FloatingDamage", true);
-	if (!ini->exists("Zeal", "FloatingDamageSpells"))
-		ini->setValue<bool>("Zeal", "FloatingDamageSpells", true);
-	if (!ini->exists("Zeal", "FloatingDamageIcons"))
-		ini->setValue<bool>("Zeal", "FloatingDamageIcons", true);
-	enabled = ini->getValue<bool>("Zeal", "FloatingDamage");
-	spells = ini->getValue<bool>("Zeal", "FloatingDamageSpells");
-	spell_icons = ini->getValue<bool>("Zeal", "FloatingDamageIcons");
 	zeal->callbacks->AddGeneric([this]() { callback_deferred(); }, callback_type::DrawWindows);
 	zeal->callbacks->AddGeneric([this]() { callback_render(); }, callback_type::RenderUI);
 	zeal->callbacks->AddReportSuccessfulHit([this](Zeal::EqStructures::Entity* source, Zeal::EqStructures::Entity* target, WORD type, short spell_id, short damage, int heal, char output_text) { add_damage(source, target, damage, heal, spell_id); });
@@ -460,12 +430,12 @@ FloatingDamage::FloatingDamage(ZealService* zeal, IO_ini* ini)
 	zeal->callbacks->AddGeneric([this]() { clean_ui(); }, callback_type::DXReset);  // Just release all resources.
 
 	zeal->commands_hook->Add("/fcd", {}, "Toggles floating combat text or adjusts the fonts with arguments",
-		[this, ini](std::vector<std::string>& args) {
+		[this](std::vector<std::string>& args) {
 			int new_size = 5;
 			if (args.size() == 3 && args[1] == "font")
 			{
-				set_font(args[2]); 
-				Zeal::EqGame::print_chat("Floating combat font set to %s", bitmap_font_filename.c_str());
+				bitmap_font_filename.set(args[2]);  // Releases to force a reload.
+				Zeal::EqGame::print_chat("Floating combat font set to %s", bitmap_font_filename.get().c_str());
 			}
 			else if (args.size() == 2 && args[1] == "font") {
 				auto fonts = BitmapFont::get_available_fonts();
@@ -478,7 +448,7 @@ FloatingDamage::FloatingDamage(ZealService* zeal, IO_ini* ini)
 			{
 				font_size = new_size;
 				Zeal::EqGame::print_chat("Floating combat font size is now %i", font_size);
-				set_font("");  // Releases resources and disables the bitmap_font path.
+				bitmap_font_filename.set(kUseClientFontString);  // Releases and disables bitmap font path.
 			}
 			else if (args.size() == 1)
 			{

--- a/Zeal/floating_damage.h
+++ b/Zeal/floating_damage.h
@@ -37,8 +37,9 @@ public:
 	ZealSetting<bool> enabled = { true, "FloatingDamage", "Enabled", true };
 	ZealSetting<bool> spell_icons = { true, "FloatingDamage", "Icons", true };
 	ZealSetting<bool> spells = { true, "FloatingDamage", "Spells", true };
+	ZealSetting<std::string> bitmap_font_filename = { std::string(kUseClientFontString),
+		"FloatingDamage", "Font", true, [this](std::string val) { bitmap_font.reset(); } };
 	bool set_font(std::string font_name);
-	std::string get_font() const { return bitmap_font_filename; }
 	std::vector<std::string> get_available_fonts() const;
 	void init_ui();
 	void clean_ui();
@@ -55,7 +56,6 @@ private:
 	void render_spells();
 	void render_text();  // Called in "render" for bitmap_font or "deferred" for CTextureFont.
 	std::unique_ptr<BitmapFont> bitmap_font = nullptr;
-	std::string bitmap_font_filename;
 	int font_size = 5;
 	std::unordered_map<Zeal::EqStructures::Entity*, std::vector<DamageData>> damage_numbers;
 };

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -291,7 +291,7 @@ void ui_options::InitFloatingDamage()
 			Zeal::EqUI::CXSTR selected_name;
 			wnd->CmbListWnd->GetItemText(&selected_name, value, 0);
 			if (selected_name.Data) {
-				font_name = std::string(selected_name.Data->Text);
+				font_name = std::string(selected_name);
 				selected_name.FreeRep();
 			}
 		}
@@ -360,7 +360,7 @@ void ui_options::InitMap()
 			Zeal::EqUI::CXSTR selected_name;
 			wnd->CmbListWnd->GetItemText(&selected_name, value, 0);
 			if (selected_name.Data) {
-				font_name = std::string(selected_name.Data->Text);
+				font_name = std::string(selected_name);
 				selected_name.FreeRep();
 			}
 		}
@@ -419,7 +419,7 @@ void ui_options::InitTargetRing()
 			wnd->CmbListWnd->GetItemText(&texture_name, value, 0);
 			if (texture_name.Data)
 			{
-				ZealService::get_instance()->target_ring->texture_name.set(texture_name.Data->Text);
+				ZealService::get_instance()->target_ring->texture_name.set(std::string(texture_name));
 				texture_name.FreeRep();
 			}
 		}
@@ -655,7 +655,7 @@ int ui_options::FindComboIndex(std::string combobox, std::string text_value) {
 		if (!selected_name.Data)
 			return -1;  // End of list.
 
-		std::string value_label = std::string(selected_name.Data->Text);
+		std::string value_label = std::string(selected_name);
 		selected_name.FreeRep();
 		if (Zeal::String::compare_insensitive(value_label, text_value))
 			return value;

--- a/Zeal/ui_options.h
+++ b/Zeal/ui_options.h
@@ -33,6 +33,8 @@ private:
 	void RenderUI();
 	void Deactivate();
 	int FindComboIndex(std::string combobox, std::string text_value);
+	void UpdateComboBox(const std::string& name, const std::string& label,
+		const std::string& default_label);
 
 	Zeal::EqUI::EQWND* wnd = nullptr;
 	std::unordered_map<int, Zeal::EqUI::BasicWnd*> color_buttons;


### PR DESCRIPTION
    Clean up combobox option and fcd settings

  - Increased the maximum limit of combobox entries in the find
      function to 50 from 20.  Capped the size of the dynamic
      load of the comboboxes to 50 so they stay in sync.
  - Removed some deprecated floating combat damage ini code
      that was interfering with the new zealsettings
  - Routed some CXSTR text through functions to properly cast to char*

Should fix some of the reports of resetting to default values
