### PR TITLE
Cleanup conversions of cxstr (encoding)

### DIFF
--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -2337,7 +2337,7 @@ namespace Zeal
 				for (int c = 0; c < num_cols; ++c)
 				{
 					list_wnd->GetItemText(&temp, r, c);
-					data[r].push_back(temp.Data->Text);
+					data[r].push_back(std::string(temp));
 				}
 			}
 			temp.FreeRep();  // Need to release the temporary reference count.

--- a/Zeal/callbacks.cpp
+++ b/Zeal/callbacks.cpp
@@ -263,9 +263,6 @@ void __fastcall EQPlayerDeconstruct(Zeal::EqStructures::Entity* ent, int unused)
 void __fastcall OutputText(Zeal::EqUI::ChatWnd* wnd, int u, Zeal::EqUI::CXSTR msg, short channel)
 {
 	ZealService* zeal = ZealService::get_instance();
-	//int multiByteSize = WideCharToMultiByte(CP_UTF8, 0, (wchar_t*)msg.Data->Text, -1, NULL, 0, NULL, NULL);
-	//std::string msg_data(multiByteSize, '\0');
-	//WideCharToMultiByte(CP_UTF8, 0, (wchar_t*)msg.Data->Text, -1, msg_data.data(), multiByteSize, NULL, NULL);
 	short new_channel = channel;
 	if (msg.Data)
 	{

--- a/Zeal/chat.cpp
+++ b/Zeal/chat.cpp
@@ -324,17 +324,6 @@ static bool is_autocycle_tell(const std::string& text, const char* prefix) {
     return (second_space == text.length() - 1);
 }
 
-// Safely convert a wide Unicode string to an UTF8 string.
-static std::string wchar_to_utf8(const wchar_t* input)
-{
-    std::wstring wstr = input;
-    if (wstr.empty()) return std::string();
-    int size_needed = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), NULL, 0, NULL, NULL);
-    std::string result(size_needed, 0);
-    WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &result[0], size_needed, NULL, NULL);
-    return result;
-}
-
 // Enhance the /tell tab completion to include the raid and zone player list and also enable
 // it for /t and /consent.
 static bool check_for_tab_completion(Zeal::EqUI::EditWnd* active_edit, UINT32 key, int modifier, char keydown)
@@ -354,10 +343,7 @@ static bool check_for_tab_completion(Zeal::EqUI::EditWnd* active_edit, UINT32 ke
     // First check if the start of the text is one that supports tab completion.
     // We cycle through this even if we already have matches just to re-use code.
     std::vector<const char*> prefix_list = { "/tell", "/t", "/consent" };
-    const char* input_text = active_edit->InputText.Data->Text;
-    std::string text = (active_edit->InputText.Data->Encoding == 0) ?
-        std::string(input_text) :
-        wchar_to_utf8(reinterpret_cast<const wchar_t*>(input_text));
+    std::string text = std::string(active_edit->InputText);
     for (const char* prefix : prefix_list)
     {
         if (!text.starts_with(prefix))

--- a/Zeal/labels.cpp
+++ b/Zeal/labels.cpp
@@ -126,9 +126,9 @@ int GetGaugeFromEq(int EqType, Zeal::EqUI::CXSTR* str)
 		case 15:
 		{
 			const Zeal::EqStructures::GroupInfo* group_info = Zeal::EqGame::GroupInfo;
-			if (group_info->is_in_group() && strcmp(str->Data->Text, group_info->LeaderName) == 0)
+			if (group_info->is_in_group() && strcmp(str->CastToCharPtr(), group_info->LeaderName) == 0)
 			{
-				std::string name = std::string(str->Data->Text) + "*";
+				std::string name = std::string(*str) + "*";
 				str->FreeRep();
 				*str = Zeal::EqUI::CXSTR(name.c_str());
 			}
@@ -173,7 +173,7 @@ bool labels::GetLabel(int EqType, std::string& str)
 	bool val = GetLabelFromEq(EqType, (Zeal::EqUI::CXSTR*)&tmp, &override, &color);
 	if (tmp.Data)
 	{
-		str = tmp.Data->Text;
+		str = std::string(tmp);
 		tmp.FreeRep();
 	}
 	return val;
@@ -184,7 +184,7 @@ int labels::GetGauge(int EqType, std::string& str)
 	int value = GetGaugeFromEq(EqType, (Zeal::EqUI::CXSTR*)&tmp);
 	if (tmp.Data)
 	{
-		str = tmp.Data->Text;
+		str = std::string(tmp);
 		tmp.FreeRep();
 	}
 	return value;
@@ -207,7 +207,7 @@ labels::labels(ZealService* zeal)
 				ULONG color = 0;
 				GetLabelFromEq(i, (Zeal::EqUI::CXSTR*)&tmp, &override, &color);
 				if (tmp.Data)
-					Zeal::EqGame::print_chat("label: %i value: %s", i, tmp.Data->Text);
+					Zeal::EqGame::print_chat("label: %i value: %s", i, tmp.CastToCharPtr());
 			}
 			return true; //return true to stop the game from processing any further on this command, false if you want to just add features to an existing cmd
 		});

--- a/Zeal/tellwindows.cpp
+++ b/Zeal/tellwindows.cpp
@@ -133,7 +133,7 @@ bool TellWindows::HandleTell(std::string& cmd_data)
         Zeal::EqUI::ChatWnd* wnd = Zeal::EqGame::Windows->ChatManager->ChatWindows[Zeal::EqGame::Windows->ChatManager->ActiveChatWnd];
         if (IsTellWindow(wnd))
         {
-                std::string window_title = wnd->Text.Data->Text;
+                std::string window_title = std::string(wnd->Text);
                 cmd_data = "/tell " + window_title.substr(1, window_title.length()-1) + " " + cmd_data;
                 return true;
         }
@@ -148,7 +148,7 @@ Zeal::EqUI::ChatWnd* TellWindows::FindTellWnd(std::string& name)
         Zeal::EqUI::ChatWnd* cwnd = Zeal::EqGame::Windows->ChatManager->ChatWindows[i];
         if (cwnd && cwnd->Text.Data)
         {
-            std::string title = cwnd->Text.Data->Text;
+            std::string title = std::string(cwnd->Text);
             if (IsTellWindow(cwnd) && Zeal::String::compare_insensitive(title.substr(1, title.length() - 1), name))
                 return cwnd;
         }
@@ -251,7 +251,7 @@ bool TellWindows::IsTellWindow(Zeal::EqUI::ChatWnd* wnd)
 {
     if (wnd && wnd->Text.Data)
     {
-        std::string title = wnd->Text.Data->Text;
+        std::string title = std::string(wnd->Text);
         if (title.substr(0, 1) == TellWindowIdentifier)
         {
             return true;
@@ -348,7 +348,7 @@ TellWindows::TellWindows(ZealService* zeal, IO_ini* ini)
                     Zeal::EqUI::ChatWnd* wnd = Zeal::EqGame::Windows->ChatManager->ChatWindows[Zeal::EqGame::Windows->ChatManager->ActiveChatWnd];
                     if (IsTellWindow(wnd))
                     {
-                        std::string window_title = wnd->Text.Data->Text;
+                        std::string window_title = std::string(wnd->Text);
                         Zeal::EqGame::do_target(window_title.substr(1, window_title.length() - 1).c_str());
                         return true;
                     }

--- a/Zeal/ui_guild.cpp
+++ b/Zeal/ui_guild.cpp
@@ -46,7 +46,7 @@ ui_guild::ui_guild(ZealService* zeal, IO_ini* ini, ui_manager* mgr)
 						members->GetItemText(&name, i, 0);
 						members->GetItemText(&level, i, 1);
 						members->GetItemText(&_class, i, 2);
-						Zeal::EqGame::print_chat("%s %s %s", name.Data->Text, level.Data->Text, _class.Data->Text);
+						Zeal::EqGame::print_chat("%s %s %s", name.CastToCharPtr(), level.CastToCharPtr(), _class.CastToCharPtr());
 					}
 				}
 				return true;


### PR DESCRIPTION
- Replace all naked accesses to the raw CXSTR text field with calls that go through the CastToCharPtr() call that fixes the encoding to 0 if needed