### PR TITLE
Feature - Buff Stacking Fixes/Improvements

### DIFF
--- a/Zeal/EqPackets.h
+++ b/Zeal/EqPackets.h
@@ -15,7 +15,8 @@ namespace Zeal
             TargetMouse = 0x4162,
             RequestTrade = 0x40D1,
             WearChange = 0x4092,
-            Illusion = 0x4091
+            Illusion = 0x4091,
+            SpawnAppearance = 0x40F5,
         };
         struct TradeRequest_Struct {
             /*000*/	UINT16 to_id;
@@ -96,6 +97,12 @@ namespace Zeal
             /*014*/ short   unknown_void;
             /*016*/ int     size;
             /*020*/
+        };
+        struct SpawnAppearance_Struct { // sizeof=0x8
+            /*000*/ WORD spawn_id;
+            /*002*/ WORD type;
+            /*004*/ DWORD parameter;
+            /*008*/
         };
     }
 }

--- a/Zeal/EqStructures.h
+++ b/Zeal/EqStructures.h
@@ -1005,6 +1005,9 @@ namespace Zeal
 			/*0x10c**/   BYTE	ResistAdj;
 			/*0x10d*/   BYTE	Unknown0x10d[0xb];
 			/*0x114*/
+
+			inline bool IsBeneficial() { return SpellType; }
+			inline bool IsBardsong() { return ClassLevel[8] != 0xFF && ClassLevel[8] != 0; }
 		};
 		struct SPELLMGR {
 			 SPELL* Spells[EQ_NUM_SPELLS];

--- a/Zeal/patches.cpp
+++ b/Zeal/patches.cpp
@@ -103,10 +103,10 @@ Zeal::EqStructures::_EQBUFFINFO* __fastcall FindAffectSlot_hk(Zeal::EqStructures
 
 // BuffStacking Patch - IsStackBlocked()
 // ---------------------------------------------------------------------------------------------------
-// Without Patch - Very broken!! Uses the target's class instead and the spell's class for detecting a bard song.
+// Without Patch - Uses the TARGET's class (which makes zero sense) and the spell's class for detecting a bard song.
 // * is_bard_song == spell->IsBardsong() && this->IsBard()
 // ---------------------------------------------------------------------------------------------------
-// With Patch - Ignores the class of recipient, only cares whether the spell is a bard spell or not.
+// With Patch - Ignores the class of target, only cares whether the spell is a bard spell or not.
 // * is_bard_song == spell->IsBardsong()
 // ---------------------------------------------------------------------------------------------------
 bool __fastcall IsStackBlocked_hk(Zeal::EqStructures::EQCHARINFO* this_char_info, int unused, Zeal::EqStructures::SPELL* spell)

--- a/Zeal/patches.cpp
+++ b/Zeal/patches.cpp
@@ -9,7 +9,7 @@ constexpr WORD kSpawnAppearanceTypeZealFeature = 257;
 // These IDs must match up with the server (eq_constants.h) so it knows what feature we are enabling.
 constexpr DWORD kZealFeatureFixBuffStacking_Id = 1; // "fix buffstacking" feature
 
-// The value for send if turning on the "fix buffstacking" feature flag.
+// The value to send for turning on the "fix buffstacking" feature flag.
 constexpr DWORD kZealFeatureFixBuffStacking_Version_1 = 1;
 
 // SPA spelleffect


### PR DESCRIPTION
Cleanup is a WIP to get some feedback. Some of the organization stuff is still messy as well. But everything is operational and working on my test server with an unreleased server build.

TODOs
- Double check Bard NPC (Nexona) buff stacking.
- Investigate the mechanics of double invis (invis / ivu), as well as testing how the current changes effect invis stacking with bard + regular invis, etc.

------------------

This is a feature that is mirrored on the Server. Both sides are able to do a handshake via `OP_SpawnAppearance` packets when zoning to detect/enable the patch bidirectionally, which ensure that clients never get out of sync when using new buff logic because the server will mirror the same logic after a handshake.

## Patch Notes
- Selo's Accelerando and Selo's Song of Travel buffs can now stack with non-bard movement speed buffs, as a separate buff. The movement speed of Selo's is still nullified while under the effects of any slowing effects such as snare, root, illusion root, or Torpor (these always have higher precedence).
- Fixed broken client logic that would use the wrong class check for certain spell stacking behaviors:
  - Example: Fixes the problem where Bards could not overwrite Jboots with SoW/FungiStaff, even though other classes could.

## Stacking Tests
Stacking logic looks much better with the changes. And fixes some of the stranger bugs like Bards being unable to overwrite JBoots with SoW. There's probably more weird stacking issues that this fixed too, but so far it looks solid.

```
MyClass   CasterClass     CurrentBuff     CastBuff      With Patch                   Before Patch
Any       Bard            Selos           Travel        Overwrite                    Overwrite
Any       Any             Fungus          Jboots        Blocked                      Blocked
Any       SHM/Any         Jboots/SoW      Torpor        Stacks                       Stacks
Any       SHM/Any         Selos           Torpor        Stacks (Fixed/New)           Spell did not take hold (Bug)
Bard      Bard            Jboots          SoW/Fungus    Overwrite (Fixed)            Spell did not take hold (Bug)
Non-Bard  Non-Bard        Jboots          SoW/Fungus    Overwrite                    Overwrite
Any       Bard            Jboots/SoW      Selo/Travel   Stacks (Fixed/New)           Spell did not take hold
Any       Bard            Jboots/Sow/Selo BardSnare     Stacks                       Stacks
```

## Movement Speed Tests
When multiple movement effects are present, the client is already correctly applying the right movement speed modifier without needing any help.

```
Buff1   Buff2    Buff3   Run Speed
Selos                    Selos
Selos   SoW              Selos
Selos   Fungus           Fungus
SoW     Selos            Selos
Selos   Snare            Snare
Snare   Selos            Snare
Selos   Torpor           Torpor
Torpor  Selos            Torpor
Selos   SoW     Torpor   Torpor
```
