### PR TITLE
Add self-pet and loc text to map

### DIFF
--- a/Zeal/bitmap_font.cpp
+++ b/Zeal/bitmap_font.cpp
@@ -167,6 +167,7 @@ BitmapFontBase::BitmapFontBase(IDirect3DDevice8& device, std::span<const uint8_t
     }
 
     line_spacing = reader.read<float>();
+    line_spacing = static_cast<float>(static_cast<int>(line_spacing + 0.5f));  // ceil().
 
     // Read in the default character and set all uninitialized table entries to it.
     uint32_t file_default_character = reader.read<uint32_t>();
@@ -223,7 +224,7 @@ BitmapFontBase::~BitmapFontBase() {
 void BitmapFontBase::dump() const {
     Zeal::EqGame::print_chat("drop_shadow: %d, outlined: %d, align_bottom: %d",
         drop_shadow, outlined, align_bottom);
-    Zeal::EqGame::print_chat("line_spacing: %d, default_character: %c",
+    Zeal::EqGame::print_chat("line_spacing: %f, default_character: %c",
         line_spacing, default_character);
 
     if (texture) {

--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -475,9 +475,11 @@ std::string NamePlate::generate_nameplate_text(const Zeal::EqStructures::Entity&
 			text += generate_target_postamble(entity);
 		if (setting_show_pet_owner_name.get() && Zeal::EqGame::is_player_pet(entity))
 		{
-			text += "\n(";
-			text += Zeal::EqGame::trim_name(Zeal::EqGame::get_entity_by_id(entity.PetOwnerSpawnId)->Name);
-			text += "'s Pet)";
+			auto pet_owner = Zeal::EqGame::get_entity_by_id(entity.PetOwnerSpawnId);
+			if (pet_owner && pet_owner != Zeal::EqGame::get_self())
+				text += std::format("\n({}'s Pet)", Zeal::EqGame::trim_name(pet_owner->Name));
+			else
+				text += "\n(Pet)";  // Self-pet or missing owner.
 		}
 		return text;
 	}

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -350,6 +350,7 @@ void ui_options::InitMap()
 	ui->AddCheckboxCallback(wnd, "Zeal_MapExternalWindow", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->zone_map->set_external_enable(wnd->Checked, true); });
 	ui->AddCheckboxCallback(wnd, "Zeal_MapShowRaid", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->zone_map->set_show_raid(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_MapShowGrid", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->zone_map->set_show_grid(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_MapAddLocText", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->zone_map->setting_add_loc_text.set(wnd->Checked); });
 	ui->AddComboCallback(wnd, "Zeal_MapShowGroup_Combobox", [this](Zeal::EqUI::BasicWnd* wnd, int value) { ZealService::get_instance()->zone_map->set_show_group_mode(value); });
 	ui->AddComboCallback(wnd, "Zeal_MapBackground_Combobox", [this](Zeal::EqUI::BasicWnd* wnd, int value) { ZealService::get_instance()->zone_map->set_background(value); });
 	ui->AddComboCallback(wnd, "Zeal_MapAlignment_Combobox", [this](Zeal::EqUI::BasicWnd* wnd, int value) { ZealService::get_instance()->zone_map->set_alignment(value); });
@@ -630,6 +631,7 @@ void ui_options::UpdateOptionsMap()
 	ui->SetChecked("Zeal_MapExternalWindow", ZealService::get_instance()->zone_map->is_external_enabled());
 	ui->SetChecked("Zeal_MapShowRaid", ZealService::get_instance()->zone_map->is_show_raid_enabled());
 	ui->SetChecked("Zeal_MapShowGrid", ZealService::get_instance()->zone_map->is_show_grid_enabled());
+	ui->SetChecked("Zeal_MapAddLocText", ZealService::get_instance()->zone_map->setting_add_loc_text.get());
 	ui->SetComboValue("Zeal_MapShowGroup_Combobox", ZealService::get_instance()->zone_map->get_show_group_mode());
 	ui->SetComboValue("Zeal_MapBackground_Combobox", ZealService::get_instance()->zone_map->get_background());
 	ui->SetComboValue("Zeal_MapAlignment_Combobox", ZealService::get_instance()->zone_map->get_alignment());

--- a/Zeal/uifiles/zeal/EQUI_Tab_Map.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_Map.xml
@@ -937,6 +937,36 @@
     <Choices>Both</Choices>
     <Choices>External</Choices>
   </Combobox>
+  <Button item="Zeal_MapAddLocText">
+    <ScreenID>Zeal_MapAddLocText</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>197</X>
+      <Y>458</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Adds location coordinates to map</TooltipReference>
+    <Text>Add /loc text</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
 
   <!-- *** Zeal Map Tab *** -->
   <Page item="Tab_Map">
@@ -984,6 +1014,7 @@
     <Pieces>Zeal_MapFadedZLevelAlpha_Slider</Pieces>
     <Pieces>Zeal_MapFadedZLevelAlpha_Value</Pieces>
     <Pieces>Zeal_MapAutoFadeEnable</Pieces>
+    <Pieces>Zeal_MapAddLocText</Pieces>
     <Pieces>Zeal_MapNamesLength_Label</Pieces>
     <Pieces>Zeal_MapNamesLength_Slider</Pieces>
     <Pieces>Zeal_MapNamesLength_Value</Pieces>

--- a/Zeal/zone_map.h
+++ b/Zeal/zone_map.h
@@ -12,6 +12,7 @@
 #include <unordered_map>
 #include <vector>
 #include <windows.h>
+#include "ZealSettings.h"
 
 
 class ZoneMap
@@ -66,6 +67,7 @@ public:
 	bool set_zoom(int zoom_percent);  // Note: 100% = 1x.
 	bool set_font(std::string font_name, bool update_default = true);
 	void set_marauders_map(bool enable) { map_show_all = enable; }  // Resets to false on zone.
+	ZealSetting<bool> setting_add_loc_text = { false, "Zeal", "MapAddLocText", false };
 
 	bool is_external_enabled() const { return external_enabled; }
 	bool is_show_raid_enabled() const { return map_show_raid; }
@@ -109,7 +111,7 @@ public:
 	void process_on_resize(int width, int height);
 
 private:
-	enum class LabelType { Normal, AddMarker, PositionLabel };
+	enum class LabelType { Normal, LeftJustified, AddMarker, PositionLabel };
 
 	// DynamicLabels are added using add_label() and are in addition to the static map data labels.
 	struct DynamicLabel {
@@ -213,6 +215,7 @@ private:
 	std::vector<ZoneMap::MapVertex> calculate_grid_vertices(const ZoneMapData& zone_map_data) const;
 	void add_position_marker_vertices(float map_y, float map_x, float heading, float size,
 		D3DCOLOR color, std::vector<MapVertex>& vertices) const;
+	void add_self_pet_position_vertices(std::vector<MapVertex>& vertices) const;
 	void add_group_member_position_vertices(std::vector<MapVertex>& vertices) const;
 	void add_raid_member_position_vertices(std::vector<MapVertex>& vertices) const;
 	void add_non_ally_position_vertices(std::vector<MapVertex>& vertices,


### PR DESCRIPTION
- Added a small dull yellow position marker for self-pet if show group members is enabled
- Added a new options checkbox that enables text with your current location in the upper left corner
- Updated the nameplate code so pet name only shows (Pet) for the self-pet
- Aligned bitmap font line spacing to the grid so second line text was cleaner for the 2D bitmap mode