### PR TITLE
Add tab command completion and boot heap check

### DIFF
--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -456,6 +456,42 @@ namespace Zeal
 		{
 			reinterpret_cast<void(__thiscall*)(int, bool)>(0x5493b5)(0x798540, enabled);
 		}
+		const Zeal::EqStructures::EQCommand* get_command_struct(const std::string& command)
+		{
+			auto command_list = reinterpret_cast<const Zeal::EqStructures::EQCommand*>(0x00609af8);
+			for (int i = 0; i < Zeal::EqStructures::EQCommand::kNumCommands; ++i)
+			{
+				if ((command_list[i].localized_name && command == command_list[i].localized_name) ||
+					(command == command_list[i].name))
+					return &command_list[i];
+			}
+			return nullptr;
+		}
+		int get_command_function(const std::string& command)
+		{
+			auto eq_command = get_command_struct(command);
+			if (eq_command)
+				return eq_command->fn;
+			return 0;
+		}
+		std::vector<std::string> get_command_matches(const std::string& start_of_name) {
+			std::vector<std::string> result;
+			auto command_list = reinterpret_cast<const Zeal::EqStructures::EQCommand*>(0x00609af8);
+			for (int i = 0; i < Zeal::EqStructures::EQCommand::kNumCommands; ++i)
+			{
+				const char* localized_name = command_list[i].localized_name;
+				const char* name = command_list[i].name;
+				if (localized_name && (start_of_name.empty() ||
+					_strnicmp(localized_name, start_of_name.c_str(), start_of_name.length()) == 0))
+					result.push_back(command_list[i].localized_name);
+
+				if ((start_of_name.empty() || 
+					_strnicmp(name, start_of_name.c_str(), start_of_name.length()) == 0)
+					&& (!localized_name || _stricmp(localized_name, name)))
+					result.push_back(command_list[i].name);
+			}
+			return result;
+		}
 		Zeal::EqStructures::ViewActor* get_view_actor()
 		{
 			Zeal::EqStructures::ViewActor* v = *(Zeal::EqStructures::ViewActor**)Zeal::EqGame::ViewActor;

--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -154,6 +154,9 @@ namespace Zeal
 		Vec3 get_view_actor_head_pos();
 		void pet_command(int cmd, short spawn_id);
 		float encum_factor();
+		const Zeal::EqStructures::EQCommand* get_command_struct(const std::string& command);
+		int get_command_function(const std::string& command);  // Returns function pointer of command.
+		std::vector<std::string> get_command_matches(const std::string& start_of_command);
 		Zeal::EqStructures::Entity* get_view_actor_entity();
 		inline Zeal::EqStructures::GuildName* guild_names = (Zeal::EqStructures::GuildName*)0x7F9C94;
 		bool collide_with_world(Vec3 start, Vec3 end, Vec3& result, char collision_type = 0x3, bool debug = false);

--- a/Zeal/EqStructures.h
+++ b/Zeal/EqStructures.h
@@ -1010,10 +1010,13 @@ namespace Zeal
 		};
 		struct EQCommand
 		{
-			int string_id;
-			const char* name;
-			const char* localized_name;
-			int fn;
+			static constexpr int kNumCommands = 0x116;  // The array has 0x116 entries.
+			int string_id;  // For localization table.
+			const char* name;  // Internal name.
+			const char* localized_name;  // Loaded in LoadString from str.txt files.
+			int fn;  // Command function pointer.
+			short gm_command;  // If != 0, needs entity.IsGameMaster to be set.
+			short category;  // Help command category type.
 		};
 	}
 }

--- a/Zeal/commands.cpp
+++ b/Zeal/commands.cpp
@@ -362,6 +362,19 @@ ChatCommands::ChatCommands(ZealService* zeal)
 				ZealService::get_instance()->entity_manager.get()->Dump();
 				return true;
 			}
+			if (args.size() == 3 && args[1] == "get_command")
+			{
+				auto command = Zeal::EqGame::get_command_struct(args[2]);
+				if (command)
+					Zeal::EqGame::print_chat("%s: id: %i, name: %s, localized: %s, gm: %i, category: %i, fn: 0x%08x",
+						args[2].c_str(), command->string_id, command->name ? command->name : "null",
+						command->localized_name ? command->localized_name : "null",
+						command->gm_command, command->category, command->fn);
+				else
+					Zeal::EqGame::print_chat("no matches");
+
+				return true;
+			}
 			if (args.size() == 2 && args[1] == "target_name")  // Report name parsing of current target.
 			{
 				Zeal::EqStructures::Entity* target = Zeal::EqGame::get_target();

--- a/Zeal/crash_handler.cpp
+++ b/Zeal/crash_handler.cpp
@@ -196,6 +196,7 @@ void WriteMiniDump(EXCEPTION_POINTERS* pep, const std::string& reason) {
                     int zone_id = self ? self->ZoneId : -1;
                     reasonFile << "Zone ID: " << zone_id << std::endl;
                     reasonFile << "Game state: " << Zeal::EqGame::get_gamestate() << std::endl;
+                    reasonFile << "ShowSpellEffects: " << *reinterpret_cast<unsigned int*>(0x007cf290) << std::endl;
                     if (ZealService::get_instance() && ZealService::get_instance()->callbacks)
                         reasonFile << "Callbacks: " << ZealService::get_instance()->callbacks->get_trace();
                 }


### PR DESCRIPTION
- Added support for tab completion of /commands. Works like bash with first tab filling out common prefix and second tabs supporting cycling through match list.
- Added simple heap checks at zeal construction (boot) that will generate a modal dialog box if any corruption detected
- Added showspelleffects state to the reasonsfile
- Added a /zeal get_command utility that will retrieve the command info struct including callback function address