### PR TITLE
Add bag lock option and quiet use_item flag

### DIFF
--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -1767,7 +1767,7 @@ namespace Zeal
 			oss << std::put_time(&timeinfo, "%Y-%m-%d_%H-%M-%S");
 			return oss.str();
 		}
-		bool use_item(int item_index)
+		bool use_item(int item_index, bool quiet)
 		{
 			Zeal::EqStructures::EQCHARINFO* chr = Zeal::EqGame::get_char_info();
 			Zeal::EqStructures::Entity* self = Zeal::EqGame::get_self();
@@ -1789,12 +1789,14 @@ namespace Zeal
 
 			if (!item)
 			{
-				Zeal::EqGame::print_chat("There isn't an item at %i", item_index);
+				if (!quiet)
+					Zeal::EqGame::print_chat("There isn't an item at %i", item_index);
 				return false;
 			}
 			if (item->Type != 0 || !item->Common.SpellId)
 			{
-				Zeal::EqGame::print_chat("Item %s does not have a spell attached to it.", item->Name);
+				if (!quiet)
+					Zeal::EqGame::print_chat("Item %s does not have a spell attached to it.", item->Name);
 				return false;
 			}
 			// List of checks copied from eqemu/zone/client_packet.cpp:
@@ -1803,7 +1805,8 @@ namespace Zeal
 				(item->Common.EffectType != Zeal::EqEnums::ItemEffect::ItemEffectEquipClick) &&
 				(item->Common.EffectType != Zeal::EqEnums::ItemEffect::ItemEffectClick2))
 			{
-				Zeal::EqGame::print_chat("Item %s does not have a click effect.", item->Name);
+				if (!quiet)
+					Zeal::EqGame::print_chat("Item %s does not have a click effect.", item->Name);
 				return false;
 			}
 			if (!self->ActorInfo || self->ActorInfo->CastingSpellId != kInvalidSpellId)

--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -228,7 +228,7 @@ namespace Zeal
 		void print_raid_ungrouped();
 		void dump_raid_state();
 		std::string generateTimestamp();
-		bool use_item(int item_index);
+		bool use_item(int item_index, bool quiet = false);
 		enum class SortType {Ascending, Descending, Toggle};
 		void sort_list_wnd(Zeal::EqUI::ListWnd* list_wnd, int sort_column,
 			SortType sort_type = SortType::Ascending);

--- a/Zeal/EqUI.h
+++ b/Zeal/EqUI.h
@@ -293,7 +293,7 @@ namespace Zeal
 			/* 0x0010 */ BYTE FadedAlpha;  // Alpha transparency value when faded
 			/* 0x0011 */ BYTE IsNotFaded;  // Set to 0 when faded, 1 when not faded
 			/* 0x0012 */ BYTE IsLocked;
-			/* 0x0013 */ BYTE Unknown0013;
+			/* 0x0013 */ BYTE LockEnable;  // Enable Lock option in CContextMenuManager::WarnDefaultMenu.
 			/* 0x0014 */ PVOID Unknown0014;
 			/* 0x0018 */ DWORD Unknown0018;
 			/* 0x001C */ struct EQWND* ParentWnd;

--- a/Zeal/commands.cpp
+++ b/Zeal/commands.cpp
@@ -227,7 +227,8 @@ ChatCommands::ChatCommands(ZealService* zeal)
 			{
 				if (char_info->Class == Zeal::EqEnums::ClassTypes::Bard && ZealService::get_instance()->melody->use_item(item_index))
 					return true;
-				Zeal::EqGame::use_item(item_index);
+				bool quiet = args.size() > 2 && args[2] == "quiet";
+				Zeal::EqGame::use_item(item_index, quiet);
 			}
 			else
 			{

--- a/Zeal/ui_options.h
+++ b/Zeal/ui_options.h
@@ -2,6 +2,7 @@
 #include "hook_wrapper.h"
 #include "memory.h"
 #include "EqUI.h"
+#include "ZealSettings.h"
 
 class ui_options
 {
@@ -18,6 +19,9 @@ public:
 	DWORD GetColor(int index) const;
 	ui_options(class ZealService* zeal, class IO_ini* ini, class ui_manager* mgr);
 	~ui_options();
+
+	ZealSetting<bool> setting_enable_container_lock = { false, "Zeal", "EnableContainerLock", false };
+
 private:
 	void InitUI();
 	void InitColors();

--- a/Zeal/uifiles/zeal/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_General.xml
@@ -481,37 +481,67 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
-	<Button item="Zeal_LinkAllAltDelimiter">
-		<ScreenID>Zeal_LinkAllAltDelimiter</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>10</X>
-			<Y>288</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>20</CY>
-		</Size>
-		<Style_VScroll>false</Style_VScroll>
-		<Style_HScroll>false</Style_HScroll>
-		<Style_Transparent>false</Style_Transparent>
-		<Style_Checkbox>true</Style_Checkbox>
-		<TooltipReference>Enables alternative link all delimiter</TooltipReference>
-		<Text>Alt LinkAll Delimiter</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<ButtonDrawTemplate>
-			<Normal>A_BtnNormal</Normal>
-			<Pressed>A_BtnPressed</Pressed>
-			<Flyby>A_BtnFlyby</Flyby>
-			<Disabled>A_BtnDisabled</Disabled>
-			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
-		</ButtonDrawTemplate>
-	</Button>
-	<!-- end -->
+  <Button item="Zeal_LinkAllAltDelimiter">
+    <ScreenID>Zeal_LinkAllAltDelimiter</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>288</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Enables alternative link all delimiter</TooltipReference>
+    <Text>Alt LinkAll Delimiter</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_EnableContainerLock">
+    <ScreenID>Zeal_EnableContainerLock</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>310</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Enables lock in container context menu (requires the bag to be re-opened to take effect)</TooltipReference>
+    <Text>Enable container lock</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <!-- end -->
     
   <Page item="Tab_General">
     <ScreenID>Tab_General</ScreenID>
@@ -544,7 +574,7 @@
     <Pieces>Zeal_HoverTimeout_Value</Pieces>
     <Pieces>Zeal_AltContainerTooltips</Pieces>
     <Pieces>Zeal_SpellbookAutoStand</Pieces>
-	<Pieces>Zeal_RightClickToEquip</Pieces>
+    <Pieces>Zeal_RightClickToEquip</Pieces>
     <Pieces>Zeal_Timestamps_Label</Pieces>
     <Pieces>Zeal_VersionLabel</Pieces>
     <Pieces>Zeal_VersionValue</Pieces>
@@ -552,8 +582,9 @@
     <Pieces>Zeal_ClassicClasses</Pieces>
     <Pieces>Zeal_TellWindows</Pieces>
     <Pieces>Zeal_TellWindowsHist</Pieces>
-		<Pieces>Zeal_LinkAllAltDelimiter</Pieces>
-		<Pieces>Zeal_Timestamps_Combobox</Pieces>
+    <Pieces>Zeal_LinkAllAltDelimiter</Pieces>
+    <Pieces>Zeal_EnableContainerLock</Pieces>
+    <Pieces>Zeal_Timestamps_Combobox</Pieces>
     <Location>
       <X>0</X>
       <Y>22</Y>


### PR DESCRIPTION
- Added a zeal general tab option to enable container locking (context menu popup will allow toggling "Lock")
- Added an optional quiet parameter (/useitem # quiet) that will suppress warnings if the slot doesn't have a click effect (empty slot or no valid click). Still complains if invalid command (slot #) or blocked due to casting.
- Upgraded hook trampolines to patch relative jump / call instructions with the correct addresses (tested as functional in a ContainerWnd::Activate hook that was reverted)