### PR TITLE
Add export inv/spellbook on /camp option

### DIFF
--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -1880,6 +1880,31 @@ namespace Zeal
 		{
 			return *(Zeal::EqStructures::SPELLMGR**)0x805CB0;
 		}
+		int get_spell_level(int spell_id)
+		{
+			Zeal::EqStructures::EQCHARINFO* char_info = Zeal::EqGame::get_char_info();
+			const auto* spell_mgr = Zeal::EqGame::get_spell_mgr();
+			if (spell_id < 1 || spell_id >= EQ_NUM_SPELLS || !spell_mgr || !char_info)
+				return -1;
+
+			const auto* spell = spell_mgr->Spells[spell_id];
+			if (!spell)
+				return -1;
+
+			return spell->ClassLevel[char_info->Class];
+		}
+		const char* get_spell_name(int spell_id) 
+		{
+			const auto* spell_mgr = Zeal::EqGame::get_spell_mgr();
+			if (spell_id < 1 || spell_id >= EQ_NUM_SPELLS || !spell_mgr)
+				return nullptr;
+
+			const auto* spell = spell_mgr->Spells[spell_id];
+			if (!spell)
+				return nullptr;
+
+			return spell->Name;
+		}
 		Zeal::EqStructures::Entity* get_self()
 		{
 			return *(Zeal::EqStructures::Entity**)Zeal::EqGame::Self;

--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -184,6 +184,8 @@ namespace Zeal
 		Zeal::EqStructures::Entity* get_self();
 		Zeal::EqStructures::Entity* get_pet();
 		Zeal::EqStructures::SPELLMGR* get_spell_mgr();
+		int get_spell_level(int spell_id);
+		const char* get_spell_name(int spell_id);
 		Zeal::EqStructures::Entity* get_controlled();
 		Zeal::EqStructures::CameraInfo* get_camera();
 		Zeal::EqStructures::Entity* get_entity_by_id(short id);  // Returns nullptr if invalid id.

--- a/Zeal/commands.cpp
+++ b/Zeal/commands.cpp
@@ -317,6 +317,10 @@ ChatCommands::ChatCommands(ZealService* zeal)
 		[](std::vector<std::string>& args) {
 			if (Zeal::EqGame::is_in_game() && !Zeal::EqGame::EqGameInternal::IsNoSlashWndActive())
 				Zeal::EqGame::get_self()->ChangeStance(Stance::Sit);
+			if (ZealService::get_instance()->outputfile->setting_export_on_camp.get()) {
+				ZealService::get_instance()->outputfile->export_inventory();
+				ZealService::get_instance()->outputfile->export_spellbook();
+			}
 			return false;
 		});
 	Add("/showhelm", { "/helm" }, "Toggles your show helm setting on/off.",

--- a/Zeal/outputfile.cpp
+++ b/Zeal/outputfile.cpp
@@ -67,7 +67,7 @@ static bool ItemIsStackable(Zeal::EqStructures::EQITEMINFO* item)
   return ((item->Common.IsStackable) && (item->Common.SpellId == 0));
 }
 
-void OutputFile::export_inventory(std::vector<std::string>& args)
+void OutputFile::export_inventory(const std::vector<std::string>& args)
 {
   Zeal::EqStructures::Entity* self = Zeal::EqGame::get_self();
 
@@ -193,27 +193,26 @@ void OutputFile::export_inventory(std::vector<std::string>& args)
     oss << "Bank-Coin" << t << "Currency" << t << 0 << t << coin << t << 0 << std::endl;
   }
 
-  std::string optional_name = "";
+  std::string optional_name = "";  // Blank optional_name results in "<char_name>-Inventory.txt".
   if (args.size() > 2) {
     optional_name = args[2];
   }
   write_to_file(oss.str(), "Inventory", optional_name);
 }
 
-// This function on the Titanium client prints out the spell level and actual name of the spell.
-// Unfortuantely, we currently lack functionality to figure out spell data solely based off of SpellId,
-// so we'll settle for just printing out that information for now.
-void OutputFile::export_spellbook(std::vector<std::string>& args)
+void OutputFile::export_spellbook(const std::vector<std::string>& args)
 {
   Zeal::EqStructures::Entity* self = Zeal::EqGame::get_self();
 
   std::stringstream oss;
-  oss << "Index\tSpell Id" << std::endl;
+  oss << "Index\tSpellId\tLevel\tName" << std::endl;
   for (size_t i = 0; i < EQ_NUM_SPELL_BOOK_SPELLS; ++i) {
     WORD SpellId = self->CharInfo->SpellBook[i];
-    // EQITEMINFO->EquipSlot value only updates when a load happens. Don't use it for this.
-    if (SpellId != USHRT_MAX) {
-      oss << i << "\t" << SpellId << std::endl;
+    int Level = Zeal::EqGame::get_spell_level(SpellId);
+    const char* Name = Zeal::EqGame::get_spell_name(SpellId);
+    Name = Name ? Name : "Unknown";
+    if (SpellId && SpellId != USHRT_MAX) {
+      oss << i << "\t" << SpellId << "\t" << Level << "\t" << Name << std::endl;
     }
   }
 

--- a/Zeal/outputfile.h
+++ b/Zeal/outputfile.h
@@ -1,15 +1,19 @@
 #pragma once
 #include "hook_wrapper.h"
 #include "memory.h"
+#include "ZealSettings.h"
 
 class OutputFile
 {
 public:
   OutputFile(class ZealService* zeal);
   ~OutputFile() {};
+  void export_inventory(const std::vector<std::string>& args = {});
+  void export_spellbook(const std::vector<std::string>& args = {});
+
+  ZealSetting<bool> setting_export_on_camp = { false, "Zeal", "ExportOnCamp", false };
+
 private:
-  void export_inventory(std::vector<std::string>& args);
-  void export_spellbook(std::vector<std::string>& args);
   void export_raidlist(std::vector<std::string>& args);
   void write_to_file(std::string data, std::string filename, std::string optional_name);
 };

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -276,6 +276,7 @@ void ui_options::InitGeneral()
 	ui->AddCheckboxCallback(wnd, "Zeal_TellWindowsHist",		[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->tells->SetHist(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_LinkAllAltDelimiter",    [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->looting_hook->setting_alt_delimiter.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_EnableContainerLock",    [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->ui->options->setting_enable_container_lock.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_ExportOnCamp",           [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->outputfile->setting_export_on_camp.set(wnd->Checked); });
 	ui->AddComboCallback(wnd,	 "Zeal_Timestamps_Combobox",	[](Zeal::EqUI::BasicWnd* wnd, int value) { ZealService::get_instance()->chat_hook->TimeStampsStyle.set(value); });
 	ui->AddSliderCallback(wnd,	 "Zeal_HoverTimeout_Slider",	[this](Zeal::EqUI::SliderWnd* wnd, int value) {	int val = value * 5; ZealService::get_instance()->tooltips->set_timer(val); ui->SetLabelValue("Zeal_HoverTimeout_Value", "%i ms", val); });
 	ui->AddLabel(wnd, "Zeal_HoverTimeout_Value");
@@ -529,6 +530,7 @@ void ui_options::UpdateOptionsGeneral()
 	ui->SetChecked("Zeal_TellWindowsHist", ZealService::get_instance()->tells->hist_enabled);
 	ui->SetChecked("Zeal_LinkAllAltDelimiter", ZealService::get_instance()->looting_hook->setting_alt_delimiter.get());
 	ui->SetChecked("Zeal_EnableContainerLock", ZealService::get_instance()->ui->options->setting_enable_container_lock.get());
+	ui->SetChecked("Zeal_ExportOnCamp", ZealService::get_instance()->outputfile->setting_export_on_camp.get());
 	ui->SetChecked("Zeal_ClassicClasses", ZealService::get_instance()->chat_hook->UseClassicClassNames.get());
 	ui->SetLabelValue("Zeal_VersionValue", "%s (%s)", ZEAL_VERSION, ZEAL_BUILD_VERSION);
 	ui->SetChecked("Zeal_BlueCon", ZealService::get_instance()->chat_hook->UseBlueCon.get());

--- a/Zeal/uifiles/zeal/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_General.xml
@@ -541,6 +541,37 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
+  <Button item="Zeal_ExportOnCamp">
+    <ScreenID>Zeal_ExportOnCamp</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>332</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Exports current inventory and spellbook to files when /camp is executed</TooltipReference>
+    <Text>Export data on /camp</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+
   <!-- end -->
     
   <Page item="Tab_General">
@@ -584,6 +615,7 @@
     <Pieces>Zeal_TellWindowsHist</Pieces>
     <Pieces>Zeal_LinkAllAltDelimiter</Pieces>
     <Pieces>Zeal_EnableContainerLock</Pieces>
+    <Pieces>Zeal_ExportOnCamp</Pieces>
     <Pieces>Zeal_Timestamps_Combobox</Pieces>
     <Location>
       <X>0</X>


### PR DESCRIPTION
- New zeal general tab option to enable automatic export of inventory and spellbook data upon /camp
  - Saved to <name>-Inventory.txt and <name>-Spellbook.txt
- Updated the spellbook export to include level and name