### PR TITLE
Polish nameplate invis handling (and targeting)

### DIFF
--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -1499,14 +1499,18 @@ namespace Zeal
 			int* cObject = *(int**)(disp + 0x2CDC);
 			Zeal::EqStructures::Entity* current_ent;
 			
+			auto char_info = Zeal::EqGame::get_char_info();
+			bool can_see_invis = char_info && char_info->can_i_see_invis();
 			std::vector<Zeal::EqStructures::Entity*> rEnts;
 			for (int i = 0; i < ent_count; i++)
 			{
-				if (*cObject)
+				if (cObject[i])
 				{
 					bool add_to_list = !only_targetable;
-					current_ent = *(Zeal::EqStructures::Entity**)(*cObject + 0x60);
-					if (current_ent && current_ent->Position.Dist2D(Zeal::EqGame::get_self()->Position)<= mdist)
+					current_ent = *(Zeal::EqStructures::Entity**)(cObject[i] + 0x60);
+					if (!current_ent || current_ent == self || current_ent->TargetType > 0x40)
+						continue;  // Skip self or invalid target spawn types.
+					if (current_ent->Position.Dist2D(self->Position)<= mdist)
 					{
 						if (only_targetable)
 						{
@@ -1532,30 +1536,14 @@ namespace Zeal
 								i++;
 							}
 						}
-						if (current_ent != EqGame::get_self() && !current_ent->IsHidden && add_to_list)
+						bool is_visible = (current_ent->IsHidden != 0x01) ||
+							(can_see_invis && (self->IsGameMaster || !current_ent->IsGameMaster));
+						if (add_to_list && is_visible)
 							rEnts.push_back(current_ent);
 					}
 				}
-				cObject += 1;
 			}
 			return rEnts;
-		}
-
-		bool can_target(Zeal::EqStructures::Entity* ent)
-		{
-			bool rval=1;
-			DWORD addr = 0x4afa90;
-			DWORD self = (DWORD)EqGame::get_self();
-			DWORD x = (DWORD)EqGame::get_display();
-			__asm
-			{
-				push ent
-				push self
-				mov ecx, x
-				call addr
-				mov rval, al
-			}
-			return rval;
 		}
 
 		float get_target_attack_fade_factor(float speed_factor) {
@@ -2311,9 +2299,19 @@ namespace Zeal
 		}
 		bool is_targetable(Zeal::EqStructures::Entity* ent)
 		{
-			
-			if (!ent->IsHidden && !ent->ActorInfo->IsInvisible)
-				return true;
+			if (!ent || !ent->ActorInfo || ent->ActorInfo->IsInvisible)
+				return false;
+
+			if (ent->IsHidden == 0x01)
+			{
+				auto self = Zeal::EqGame::get_self();
+				auto char_info = Zeal::EqGame::get_char_info();
+				if (self && char_info)
+				{
+					bool can_see_invis = char_info && char_info->can_i_see_invis();
+					return (can_see_invis && (self->IsGameMaster || !ent->IsGameMaster));
+				}
+			}
 			return false;
 		}
 		bool is_in_game()

--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -2299,7 +2299,7 @@ namespace Zeal
 		}
 		bool is_targetable(Zeal::EqStructures::Entity* ent)
 		{
-			if (!ent || !ent->ActorInfo || ent->ActorInfo->IsInvisible)
+			if (!ent || !ent->ActorInfo || ent->ActorInfo->IsInvisible || ent->TargetType > 0x40)
 				return false;
 
 			if (ent->IsHidden == 0x01)
@@ -2311,8 +2311,9 @@ namespace Zeal
 					bool can_see_invis = char_info && char_info->can_i_see_invis();
 					return (can_see_invis && (self->IsGameMaster || !ent->IsGameMaster));
 				}
+				return false;
 			}
-			return false;
+			return true;
 		}
 		bool is_in_game()
 		{

--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -47,7 +47,7 @@ namespace Zeal
 
 			static mem::function<void __fastcall(int t, int unused, const char* data, short color, bool un)> print_chat = 0x537f99;
 			//static mem::function<void __stdcall(const char* data)> log = 0x5240dc;
-			static mem::function<char __fastcall(int display, int unused, Zeal::EqStructures::Entity*, Zeal::EqStructures::Entity*)> can_target = 0x4afa90;
+			static mem::function<char __stdcall(Zeal::EqStructures::Entity* viewer, Zeal::EqStructures::Entity* target)> is_invisible = 0x4afa90;  // can_target
 			static mem::function<char __fastcall(int, int, int, int, float*, float, UINT32)> get_world_visible_actor_list = 0x7f9850;
 			static mem::function<char __fastcall(int, int, int, int, float*, float, UINT32)> get_camera_location = 0x7f99d4;
 			static mem::function<char __fastcall(int, int, float, float, float, float, float, float, float*, float*, float* , char) > s3dCollideSphereWithWorld = 0x4b3c45;
@@ -163,7 +163,6 @@ namespace Zeal
 		void get_camera_location();
 		std::vector<Zeal::EqStructures::Entity*> get_world_visible_actor_list(float max_dist, bool only_targetable = true);
 		Zeal::EqStructures::ActorLocation get_actor_location(int actor);
-		bool can_target(Zeal::EqStructures::Entity* ent);
 		float get_target_attack_fade_factor(float speed_factor);  // Returns 0 to 1.0f if autoattacking.
 		bool is_view_actor_me();
 		void print_chat_hook(const char* format, ...);

--- a/Zeal/EqStructures.h
+++ b/Zeal/EqStructures.h
@@ -619,6 +619,10 @@ namespace Zeal
 			{
 				return reinterpret_cast<void(__thiscall*)(EQCHARINFO*, UINT, WORD)>(0x4cb510)(this, reason, spell_id);
 			}
+			bool can_i_see_invis() // CanISeeInvis()
+			{
+				return reinterpret_cast<bool(__thiscall*)(EQCHARINFO*)>(0x004c0d02)(this);
+			}
 			/* 0x0000 */ BYTE Unknown0000[2];
 			/* 0x0002 */ CHAR Name[64]; // [0x40]
 			/* 0x0042 */ CHAR LastName[70]; // [0x46] ; surname or title

--- a/Zeal/cycle_target.cpp
+++ b/Zeal/cycle_target.cpp
@@ -36,7 +36,7 @@ Zeal::EqStructures::Entity* CycleTarget::get_next_ent(float dist, byte type)
 	{
 		if (ent->Unknown0000 != 3)
 			continue;
-		if (!ent->IsHidden && ent->Type == type && ent->Level>0 && ent->TargetType<66)
+		if (ent->Type == type && ent->Level > 0)
 		{
 			if (ent->PetOwnerSpawnId)
 			{
@@ -81,7 +81,7 @@ Zeal::EqStructures::Entity* CycleTarget::get_nearest_ent(float dist, byte type)
 			continue;
 		if (ent->ActorInfo && ent->ActorInfo->IsInvisible)
 			continue;
-		if (!ent->IsHidden && ent->Type == type && ent->Level > 0 && ent->TargetType < 66)
+		if (ent->Type == type && ent->Level > 0)
 		{
 			if (ent->PetOwnerSpawnId)
 			{


### PR DESCRIPTION
- Updated nameplate code to properly exclude self when unable to see self
- Updated nameplate code to properly only treat IsHidden = 0x01 (normal invis) as invis with (x)
- Updated the get_world_visible_actor_list() call to properly check for target visibility (not invisible or if invisible can see invisible and the target isn't a GM)
- Also fixed the target_type check from < 66 (0x42) to < 0x41 to match the client