### PR TITLE
Add knowledge of EQWorldData to map

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,14 +549,18 @@ button click. The external window also supports a middle mouse button click to d
 
 * Key bind: "Toggle Map Interactive Mode" - toggles internal overlay between transparent and interactive
 
-#### Show zone mode
+#### Show zone mode and world data search
 Zone maps other than the player's current location can be explored using the show_zone command. The
 target zone is specified using the zone's short name (like /who all). Interactive mode, levels, grid,
 labels, and poi search all work for the selected zone.
 
+The world command allows browsing the available zone names in EQWorldData. See command examples below.
+
 * Command examples
   - `/map show_zone gukbottom` shows the zone map for the Ruins of Old Guk
   - `/map show_zone` exits show_zone mode
+  - `/map world dump` prints the zone ids, short names, and long names of all available zones
+  - `/map world search karan` prints all available zones that contain 'karan' in their short or long names
 
 #### Map grid
 A simple background grid aligned at a selectable pitch is available. The x == 0 and y == 0 axes

--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -2273,10 +2273,23 @@ namespace Zeal
 		std::string get_full_zone_name(int zone_id) {
 			const int fn_GetFullZoneName = 0x00523e49;
 			void* pWorld = *reinterpret_cast<void**>(0x007F9494);
-			char buffer[512];  // Size used in client SetNameSpriteState.
-			buffer[0] = 0;
+			char buffer[512];  // LongName is only 0x80 in EQZONEINFO.
+			buffer[0] = 0;  // Returns "Unknown Zone" if invalid index 
 			reinterpret_cast<void(__thiscall*)(void* this_world, int zone_id, char* buffer)>(fn_GetFullZoneName)(pWorld, zone_id, buffer);
 			return std::string(buffer);
+		}
+		std::string get_zone_name_from_index(int zone_id) {
+			const int fn_GetZoneNameFromIndex = 0x00523f73;
+			void* pWorld = *reinterpret_cast<void**>(0x007F9494);
+			char buffer[512];  // ShortName is only 0x20 in EQZONEINFO.
+			if (!reinterpret_cast<bool(__thiscall*)(void* this_world, int zone_id, char* buffer)>(fn_GetZoneNameFromIndex)(pWorld, zone_id, buffer))
+				buffer[0] = 0;  // Return an empty buffer if not found.
+			return std::string(buffer);
+		}
+		int get_index_from_zone_name(const std::string& name) {
+			const int fn_GetIndexFromZoneName = 0x00523fa4;  // Returns 0 if not found.
+			void* pWorld = *reinterpret_cast<void**>(0x007F9494);
+			return reinterpret_cast<int(__thiscall*)(void* this_world, const char* buffer)>(fn_GetIndexFromZoneName)(pWorld, name.c_str());
 		}
 		std::string get_class_desc(int class_id) {
 			const int fn_GetClassDesc = 0x0052d5f1;

--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -202,7 +202,11 @@ namespace Zeal
 		int get_showname(); // Holds value of /showname command.
 		std::string class_name_short(int class_id);
 		std::string class_name(int class_id);
+		static constexpr int kInvalidZoneId = 0;  // get_index_from_zone_name() returns 0 if no matches.
+		static constexpr int kNumZoneIds = 1000;  // 0 = invalid, 999 = last reliable entry in EQWorldData
 		std::string get_full_zone_name(int zone_id);  // EQWorldData::GetFullZoneName()
+		std::string get_zone_name_from_index(int zone_id); // EqWorldData::GetZoneNameFromIndex()
+		int get_index_from_zone_name(const std::string& name);  // EqWorldData::GetIndexFromZoneName()
 		std::string get_class_desc(int class_id);  // CEverQuest::GetClassDesc()
 		std::string get_title_desc(int class_id, int aa_rank, int gender);  // CEverQuest::GetTitleDesc()
 		std::string get_player_guild_name(short guild_id); // GetPlayerGuildName()

--- a/Zeal/zone_map.h
+++ b/Zeal/zone_map.h
@@ -136,7 +136,7 @@ private:
 		std::unique_ptr<ZoneMapData> zone_map_data;
 	};
 
-	static constexpr int kInvalidZoneId = 0;
+	static constexpr int kInvalidZoneId = Zeal::EqGame::kInvalidZoneId;  // 0 == invalid.
 	static constexpr int kInvalidScreenValue = 0x7fff;  // EQ game sets mouse abs to this when not focused.
 	static constexpr int kInvalidPositionValue = 0x7fff;
 	static constexpr int kDefaultGridPitch = 1000;
@@ -164,6 +164,7 @@ private:
 	void parse_show_group(const std::vector<std::string>& args);
 	void parse_show_raid(const std::vector<std::string>& args);
 	void parse_show_zone(const std::vector<std::string>& args);
+	void parse_world_data(const std::vector<std::string>& args);
 	void parse_grid(const std::vector<std::string>& args);
 	void parse_ring(const std::vector<std::string>& args);
 	void parse_font(const std::vector<std::string>& args);


### PR DESCRIPTION
- Added get_zone_name_from_index() and get_index_from_zone_name() using the client's EQWorldData methods
- The map code will now search the EQWorldData if it can't find a zone name in it's internal lookup, which will support new zone_ids if the server populates world data and the new map data files are put in /map_files in /map data_mode external
- Added a /map world command that allows dumping of all available world data and also searching for a name fragment if you can't recall the official names