### PR TITLE
Add target blink and auto-attack only options

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,8 @@ The Zeal Nameplate options tab is the primary interface, but the redundant comma
 * `/nameplate showpetownername` - Toggles Players Pet Owner on Nameplate on and off
 * `/nameplate charselect` - Toggles Nameplate Choices Shown at Character Selection Screen on and off
 * `/nameplate targetcolor` - Toggles Target Nameplate Color on and off
-* `/nameplate targetblink` - Toggles auto-attack indicator on and off
+* `/nameplate targetblink` - Toggles blinking of target nameplate on and off (rate controlled by targetring slider)
+* `/nameplate attackonly` - Limits blinking of target nameplate to only when auto-attack is on
 * `/nameplate targetmarker` - Toggles Target Nameplate Marker on and off
 * `/nameplate targethealth` - Toggles Target Nameplate Health on and off
 * `/nameplate targethealth` - Toggles Target Nameplate Health on and off

--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -1546,8 +1546,8 @@ namespace Zeal
 			return rEnts;
 		}
 
-		float get_target_attack_fade_factor(float speed_factor) {
-			if (!(bool)(*(BYTE*)0x7f6ffe))  // Auto attack enabled.
+		float get_target_blink_fade_factor(float speed_factor, bool auto_attack_only) {
+			if (auto_attack_only && !(bool)(*(BYTE*)0x7f6ffe))  // Auto attack disabled.
 				return 1.0f; // No fading.
 
 			// Calculate a fraction of the cycle time. Phase alignment doesn't matter, so just

--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -163,7 +163,7 @@ namespace Zeal
 		void get_camera_location();
 		std::vector<Zeal::EqStructures::Entity*> get_world_visible_actor_list(float max_dist, bool only_targetable = true);
 		Zeal::EqStructures::ActorLocation get_actor_location(int actor);
-		float get_target_attack_fade_factor(float speed_factor);  // Returns 0 to 1.0f if autoattacking.
+		float get_target_blink_fade_factor(float speed_factor, bool auto_attack_only);  // Returns 0 to 1.0f.
 		bool is_view_actor_me();
 		void print_chat_hook(const char* format, ...);
 		void print_chat(std::string data);

--- a/Zeal/Zeal.cpp
+++ b/Zeal/Zeal.cpp
@@ -50,20 +50,33 @@ ZealService::ZealService()
 	floating_damage = std::make_shared<FloatingDamage>(this, ini.get());
 	mem_check(__LINE__);
 	give = std::make_shared<NPCGive>(this, ini.get());
+	mem_check(__LINE__);  // TODO: Added add'l mem_checks between NPCGive and Alarm after seeing coarser checks trip once.
 	game_patches = std::make_shared<patches>();
+	mem_check(__LINE__);
 	nameplate = std::make_shared<NamePlate>(this, ini.get());
+	mem_check(__LINE__);
 	tells = std::make_shared<TellWindows>(this, ini.get());
+	mem_check(__LINE__);
 	helm = std::make_shared<HelmManager>(this);
-
+	mem_check(__LINE__);
 	entity_manager = std::make_shared<EntityManager>(this, ini.get());
+	mem_check(__LINE__);
 	camera_mods = std::make_shared<CameraMods>(this, ini.get());
+	mem_check(__LINE__);
 	cycle_target = std::make_shared<CycleTarget>(this);
+	mem_check(__LINE__);
 	experience = std::make_shared<Experience>(this);
+	mem_check(__LINE__);
 	chat_hook = std::make_shared<chat>(this, ini.get());
+	mem_check(__LINE__);
 	chatfilter_hook = std::make_shared<chatfilter>(this, ini.get());
+	mem_check(__LINE__);
 	outputfile = std::make_shared<OutputFile>(this);
+	mem_check(__LINE__);
 	buff_timers = std::make_shared<BuffTimers>(this);
+	mem_check(__LINE__);
 	movement = std::make_shared<PlayerMovement>(this, binds_hook.get(), ini.get());
+	mem_check(__LINE__);
 	alarm = std::make_shared<Alarm>(this);
 	mem_check(__LINE__);
 	netstat = std::make_shared<Netstat>(this, ini.get());

--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -90,6 +90,7 @@ void NamePlate::parse_args(const std::vector<std::string>& args)
 		{"targetmarker", &setting_target_marker },
 		{"targethealth", &setting_target_health },
 		{"targetblink", &setting_target_blink },
+		{"attackonly", &setting_attack_only },
 		{"inlineguild", &setting_inline_guild },
 		{"zealfont", &setting_zeal_fonts },
 		{"dropshadow", &setting_drop_shadow },
@@ -120,7 +121,7 @@ void NamePlate::parse_args(const std::vector<std::string>& args)
 	}
 
 	Zeal::EqGame::print_chat("Usage: /nameplate option where option is one of");
-	Zeal::EqGame::print_chat("tint:  colors, concolors, targetcolor, targetblink, charselect");
+	Zeal::EqGame::print_chat("tint:  colors, concolors, targetcolor, targetblink, attackonly, charselect");
 	Zeal::EqGame::print_chat("text:  hideself, x, hideraidpets, showpetownername, targetmarker, targethealth, inlineguild");
 	Zeal::EqGame::print_chat("font:  zealfont, dropshadow");
 }
@@ -358,7 +359,8 @@ bool NamePlate::handle_SetNameSpriteTint(Zeal::EqStructures::Entity* entity)
 	{
 		// Share the flash speed slider with the target_ring so they aren't beating.
 		float flash_speed = ZealService::get_instance()->target_ring->flash_speed.get();
-		float fade_factor = Zeal::EqGame::get_target_attack_fade_factor(flash_speed);
+		float fade_factor = Zeal::EqGame::get_target_blink_fade_factor(flash_speed,
+			setting_attack_only.get());
 		if (fade_factor < 1.0f) {
 			BYTE faded_red = static_cast<BYTE>(((color >> 16) & 0xFF) * fade_factor);
 			BYTE faded_green = static_cast<BYTE>(((color >> 8) & 0xFF) * fade_factor);

--- a/Zeal/nameplate.h
+++ b/Zeal/nameplate.h
@@ -45,7 +45,8 @@ public:
 	ZealSetting<bool> setting_show_pet_owner_name = { false, "Zeal", "NameplateShowPetOwnerName", false };
 	ZealSetting<bool> setting_target_marker = { false, "Zeal", "NameplateTargetMarker", false };
 	ZealSetting<bool> setting_target_health = { false, "Zeal", "NameplateTargetHealth", false };
-	ZealSetting<bool> setting_target_blink = { false, "Zeal", "NameplateTargetBlink", false };
+	ZealSetting<bool> setting_target_blink = { true, "Zeal", "NameplateTargetBlink", false };
+	ZealSetting<bool> setting_attack_only = { false, "Zeal", "NameplateAttackOnly", false };
 	ZealSetting<bool> setting_inline_guild = { false, "Zeal", "NameplateInlineGuild", false };
 
 	// Advanced fonts

--- a/Zeal/target_ring.cpp
+++ b/Zeal/target_ring.cpp
@@ -401,7 +401,7 @@ void TargetRing::callback_render() {
 	// ### Auto Attack Indicator (fade/unfade target's color while autoattack turned on)###
 	if (attack_indicator.get()) // auto attack is enabled
 	{
-		float fadeFactor = Zeal::EqGame::get_target_attack_fade_factor(flash_speed.get());
+		float fadeFactor = Zeal::EqGame::get_target_blink_fade_factor(flash_speed.get(), true);
 		if (fadeFactor < 1.0f) {
 			// Extract the ARGB components from the original color
 			BYTE originalA = (originalColor >> 24) & 0xFF;

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -487,6 +487,7 @@ void ui_options::InitNameplate()
 	ui->AddCheckboxCallback(wnd, "Zeal_NameplateTargetMarker", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->setting_target_marker.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_NameplateTargetHealth", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->setting_target_health.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_NameplateTargetBlink", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->setting_target_blink.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_NameplateAttackOnly", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->setting_attack_only.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_NameplateZealFonts", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->setting_zeal_fonts.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_NameplateDropShadow", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->setting_drop_shadow.set(wnd->Checked); });
 
@@ -607,6 +608,7 @@ void ui_options::UpdateOptionsNameplate()
 	ui->SetChecked("Zeal_NameplateTargetMarker", ZealService::get_instance()->nameplate->setting_target_marker.get());
 	ui->SetChecked("Zeal_NameplateTargetHealth", ZealService::get_instance()->nameplate->setting_target_health.get());
 	ui->SetChecked("Zeal_NameplateTargetBlink", ZealService::get_instance()->nameplate->setting_target_blink.get());
+	ui->SetChecked("Zeal_NameplateAttackOnly", ZealService::get_instance()->nameplate->setting_attack_only.get());
 	ui->SetChecked("Zeal_NameplateZealFonts", ZealService::get_instance()->nameplate->setting_zeal_fonts.get());
 	ui->SetChecked("Zeal_NameplateDropShadow", ZealService::get_instance()->nameplate->setting_drop_shadow.get());
 

--- a/Zeal/uifiles/zeal/EQUI_Tab_Nameplate.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_Nameplate.xml
@@ -347,8 +347,8 @@
 		<Style_HScroll>false</Style_HScroll>
 		<Style_Transparent>false</Style_Transparent>
 		<Style_Checkbox>true</Style_Checkbox>
-		<TooltipReference>Uses targetring rate slider</TooltipReference>
-		<Text>Target autoattack indicator</Text>
+		<TooltipReference>Blink rate set by TargetRing rate slider</TooltipReference>
+		<Text>Enable target blinking</Text>
 		<TextColor>
 			<R>255</R>
 			<G>255</G>
@@ -362,7 +362,37 @@
 			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
 		</ButtonDrawTemplate>
 	</Button>
-	<Button item="Zeal_NameplateZealFonts">
+  <Button item="Zeal_NameplateAttackOnly">
+    <ScreenID>Zeal_NameplateAttackOnly</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>200</X>
+      <Y>112</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Limit blinking to only when auto-attacking</TooltipReference>
+    <Text>Autoattack only</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_NameplateZealFonts">
 		<ScreenID>Zeal_NameplateZealFonts</ScreenID>
 		<RelativePosition>true</RelativePosition>
 		<Location>
@@ -476,7 +506,8 @@
 	<Pieces>Zeal_NameplateTargetMarker</Pieces>
 	<Pieces>Zeal_NameplateTargetHealth</Pieces>
 	<Pieces>Zeal_NameplateTargetBlink</Pieces>
-	<Pieces>Zeal_NameplateZealFonts</Pieces>
+  <Pieces>Zeal_NameplateAttackOnly</Pieces>
+  <Pieces>Zeal_NameplateZealFonts</Pieces>
 	<Pieces>Zeal_NameplateDropShadow</Pieces>
 	<Pieces>Zeal_NameplateFont_Combobox</Pieces>
 	<Pieces>Zeal_NameplateShowPetOwnerName</Pieces>


### PR DESCRIPTION
- Modified the target blink enable so it enables blinking that can then be gated with a new auto-attack only option that restricts the blinking to when auto-attack is on
- Also added additional temporary heap corruption checking after seeing the dialog once at line 68 (between NPCGive and Alarm)