### PR TITLE
Add a check for view actor visibility

### DIFF
--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -161,6 +161,7 @@ namespace Zeal
 		inline Zeal::EqStructures::GuildName* guild_names = (Zeal::EqStructures::GuildName*)0x7F9C94;
 		bool collide_with_world(Vec3 start, Vec3 end, Vec3& result, char collision_type = 0x3, bool debug = false);
 		void get_camera_location();
+		bool is_view_actor_invisible(Zeal::EqStructures::Entity* entity);
 		std::vector<Zeal::EqStructures::Entity*> get_world_visible_actor_list(float max_dist, bool only_targetable = true);
 		Zeal::EqStructures::ActorLocation get_actor_location(int actor);
 		float get_target_blink_fade_factor(float speed_factor, bool auto_attack_only);  // Returns 0 to 1.0f.

--- a/Zeal/EqStructures.h
+++ b/Zeal/EqStructures.h
@@ -353,10 +353,10 @@ namespace Zeal
 
 		struct ViewActor
 		{
-			/* 0x0000 */ DWORD Unknown0000;
+			/* 0x0000 */ DWORD Type;  // Checked if it is set to 0x18 in GetClickedActor()
 			/* 0x0004 */ DWORD Unknown0004;
 			/* 0x0008 */ DWORD Unknown0008;
-			/* 0x000C */ DWORD Unknown000C;
+			/* 0x000C */ DWORD Flags;  // Bit 0x40000000 = invisible
 			/* 0x0010 */ Vec3 Position;
 			/* 0x001C */ DWORD Unknown001C;
 			/* 0x0020 */ DWORD Unknown0020;
@@ -488,8 +488,9 @@ namespace Zeal
 			/* 0x0160 */ DWORD FizzleTimeout;   // Set in the OP_MemorizeSpell handler.
 			/* 0x0164 */ BYTE Unknown0164[0x20];
 			/* 0x0184 */ DWORD Animation;
-			/* 0x0188 */ BYTE Unknown0188[16];
-			/* 0x0198 */ int Unsure_Strafe_Calc;
+			/* 0x0188 */ BYTE Unknown0188[0xc];
+			/* 0x0194 */ struct Entity* Entity0194;  // Entity is linked in UpdatePlayerVisibility.
+			/* 0x0198 */ struct Entity* Entity0198;  // Appears to be a horse entity in UpdatePlayerVisiblity.
 			/* 0x019C */ BYTE Unknown019c[24];
 			/* 0x01B4 */ DWORD IsInvisible; // NPCs only? used by /hidecorpses command
 			/* 0x01B8 */ BYTE Unknown01B8[10];
@@ -761,7 +762,7 @@ namespace Zeal
 				if (this && this->StandingState != new_stance)
 					reinterpret_cast<void(__thiscall*)(Entity*, unsigned char)>(0x50be3c)(this, new_stance);
 			}
-			/* 0x0000 */ BYTE Unknown0000; // always equals 0x03
+			/* 0x0000 */ BYTE StructType; // If != 0x03, this struct is invalid (e.g. bad ActorInfo pointer).
 			/* 0x0001 */ CHAR Name[30]; // [0x1E]
 			/* 0x001F */ BYTE Unknown001F[37];
 			/* 0x0044 */ DWORD ZoneId; // EQ_ZONE_ID_x

--- a/Zeal/cycle_target.cpp
+++ b/Zeal/cycle_target.cpp
@@ -34,7 +34,7 @@ Zeal::EqStructures::Entity* CycleTarget::get_next_ent(float dist, byte type)
 	near_ents.clear();
 	for (auto& ent : visible_ents)
 	{
-		if (ent->Unknown0000 != 3)
+		if (ent->StructType != 0x03)
 			continue;
 		if (ent->Type == type && ent->Level > 0)
 		{
@@ -77,9 +77,7 @@ Zeal::EqStructures::Entity* CycleTarget::get_nearest_ent(float dist, byte type)
 	near_ents.clear();
 	for (auto& ent : visible_ents)
 	{
-		if (ent->Unknown0000 != 3)
-			continue;
-		if (ent->ActorInfo && ent->ActorInfo->IsInvisible)
+		if (ent->StructType != 0x03)
 			continue;
 		if (ent->Type == type && ent->Level > 0)
 		{

--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -210,7 +210,7 @@ void NamePlate::render_ui()
 	for (const auto& entity : visible_entities)
 	{
 		// Added Unknown0003 check due to some bad results with 0x05 at startup causing a crash.
-		if (!entity || entity->Unknown0000 != 0x03 || !entity->ActorInfo || !entity->ActorInfo->DagHeadPoint)
+		if (!entity || entity->StructType != 0x03 || !entity->ActorInfo || !entity->ActorInfo->DagHeadPoint)
 			continue;
 		auto it = nameplate_info_map.find(entity);
 		if (it == nameplate_info_map.end())

--- a/Zeal/player_movement.cpp
+++ b/Zeal/player_movement.cpp
@@ -150,7 +150,7 @@ void PlayerMovement::callback_main()
 			*Zeal::EqGame::strafe_speed *= .5f;
 		if (controlled_player->ActorInfo && controlled_player->ActorInfo->MovementSpeedModifier < 0)
 			*Zeal::EqGame::strafe_speed *= .5f;
-		if (controlled_player->ActorInfo && controlled_player->ActorInfo->Unsure_Strafe_Calc != 0)
+		if (controlled_player->ActorInfo && controlled_player->ActorInfo->Entity0198 != 0)
 			*Zeal::EqGame::strafe_speed *= .25f;
 		if (controlled_player->ActorInfo && controlled_player->ActorInfo->MovementSpeedModifier < -1000.0f)
 		{


### PR DESCRIPTION
- Updated get_world_visible_actor_list() and is_targetable() to also check if the viewactor is invisible to screen out entities. The viewactor invisible flag is set in updateplayervisibility and impacted by the IsInvisible flag set as part of /hidecorpses as well as the normal invisibility checks.
  - This should make zeal nameplates and targeting more consistent with the default client
- Also added a check that the entity type (field [0]) is set to 0x03 as was seeing cases where the ActorInfo pointer was bad when it wasn't (different struct layout?)