### PR TITLE
Add /selfclickthru command and option

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,10 @@ ___
 - `/camp`
   - **Description:** Auto sits before camping.
 
+- `/selfclickthru`
+  - **Arguments:** `on`, `off`
+  - **Description:** Disables (on) click on self in third person and allows 'u' to activate doors.
+
 - `/useitem`
   - **Arguments:** `slot_#` (+ optional `quiet` that suppresses warnings if no click effect)
   - **Description:** Activates a click effect on item in slot_#.

--- a/Zeal/camera_mods.h
+++ b/Zeal/camera_mods.h
@@ -26,7 +26,7 @@ public:
 	ZealSetting<float> user_sensitivity_y_3rd = { 0.1f, "Zeal", "MouseSensitivityY3rd", false };
 	ZealSetting<float> fov = { 45.f, "Zeal", "Fov", false, [this](float val) { Zeal::EqStructures::CameraInfo* ci = Zeal::EqGame::get_camera();	if (ci) ci->FieldOfView = val; } };
 	ZealSetting<int> pan_delay = { 0, "Zeal", "PanDelay", false };
-
+	ZealSetting<bool> setting_selfclickthru = { false, "Zeal", "SelfClickThru", false };
 
 	const float max_zoom_out = 100;
 	const float zoom_speed = 5.f;

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -277,6 +277,7 @@ void ui_options::InitGeneral()
 	ui->AddCheckboxCallback(wnd, "Zeal_LinkAllAltDelimiter",    [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->looting_hook->setting_alt_delimiter.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_EnableContainerLock",    [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->ui->options->setting_enable_container_lock.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_ExportOnCamp",           [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->outputfile->setting_export_on_camp.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_SelfClickThru",          [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->camera_mods->setting_selfclickthru.set(wnd->Checked); });
 	ui->AddComboCallback(wnd,	 "Zeal_Timestamps_Combobox",	[](Zeal::EqUI::BasicWnd* wnd, int value) { ZealService::get_instance()->chat_hook->TimeStampsStyle.set(value); });
 	ui->AddSliderCallback(wnd,	 "Zeal_HoverTimeout_Slider",	[this](Zeal::EqUI::SliderWnd* wnd, int value) {	int val = value * 5; ZealService::get_instance()->tooltips->set_timer(val); ui->SetLabelValue("Zeal_HoverTimeout_Value", "%i ms", val); });
 	ui->AddLabel(wnd, "Zeal_HoverTimeout_Value");
@@ -532,6 +533,7 @@ void ui_options::UpdateOptionsGeneral()
 	ui->SetChecked("Zeal_LinkAllAltDelimiter", ZealService::get_instance()->looting_hook->setting_alt_delimiter.get());
 	ui->SetChecked("Zeal_EnableContainerLock", ZealService::get_instance()->ui->options->setting_enable_container_lock.get());
 	ui->SetChecked("Zeal_ExportOnCamp", ZealService::get_instance()->outputfile->setting_export_on_camp.get());
+	ui->SetChecked("Zeal_SelfClickThru", ZealService::get_instance()->camera_mods->setting_selfclickthru.get());
 	ui->SetChecked("Zeal_ClassicClasses", ZealService::get_instance()->chat_hook->UseClassicClassNames.get());
 	ui->SetLabelValue("Zeal_VersionValue", "%s (%s)", ZEAL_VERSION, ZEAL_BUILD_VERSION);
 	ui->SetChecked("Zeal_BlueCon", ZealService::get_instance()->chat_hook->UseBlueCon.get());

--- a/Zeal/uifiles/zeal/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_General.xml
@@ -571,7 +571,36 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
-
+  <Button item="Zeal_SelfClickThru">
+    <ScreenID>Zeal_SelfClickThru</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>354</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Disables third person click on self (/selfclickthru)</TooltipReference>
+    <Text>Self-click thru</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
   <!-- end -->
     
   <Page item="Tab_General">
@@ -616,6 +645,7 @@
     <Pieces>Zeal_LinkAllAltDelimiter</Pieces>
     <Pieces>Zeal_EnableContainerLock</Pieces>
     <Pieces>Zeal_ExportOnCamp</Pieces>
+    <Pieces>Zeal_SelfClickThru</Pieces>
     <Pieces>Zeal_Timestamps_Combobox</Pieces>
     <Location>
       <X>0</X>


### PR DESCRIPTION
- Added a /selfclickthru command that reduces the self bounding box to be very small during the check for a click on an actor
  - Using 'u' to open doors and open merchant windows now works
- Added an options toggle for it in the zeal general tab