### PR TITLE
get_showPCname and get_showNPCname (add to new Nameplate logic) 

### DIFF
--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -2274,6 +2274,18 @@ namespace Zeal
 				class_string += " GuildMaster";
 			return class_string;
 		}
+		uint8_t get_showPCname()
+		{
+			//Holds value of Options -> Display -> Show PC Names
+			// 0 = off, 1 = on
+			return *reinterpret_cast<int8_t*>(0x0063D6C8);
+		}
+		uint8_t get_showNPCname()
+		{
+			//Holds value of Options -> Display -> Show NPC Names
+			// 0 = off, 1 = on
+			return *reinterpret_cast<int8_t*>(0x0063D6CC);
+		}
 		int get_showname()
 		{
 			// Holds value of /showname command.

--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -200,6 +200,8 @@ namespace Zeal
 		int* get_display();
 		float heading_to_yaw(float heading);
 		bool is_mouse_hovering_window();
+		uint8_t get_showPCname(); //Holds value of Options -> Display -> Show PC Names
+		uint8_t get_showNPCname(); //Holds value of Options -> Display -> Show NPC Names
 		int get_showname(); // Holds value of /showname command.
 		std::string class_name_short(int class_id);
 		std::string class_name(int class_id);

--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -454,7 +454,13 @@ std::string NamePlate::generate_nameplate_text(const Zeal::EqStructures::Entity&
 
 	// Handle other reasons for disabled nameplates.
 	const uint32_t show_name = Zeal::EqGame::get_showname();
+	const uint8_t show_PC_name = Zeal::EqGame::get_showPCname();
+	const uint8_t show_NPC_name = Zeal::EqGame::get_showNPCname();
 	if ((show == 0) || (show_name < 1 && (entity.Type != Zeal::EqEnums::NPC)))
+		return std::string();
+	if (show_PC_name == 0 && entity.Type == Zeal::EqEnums::Player)
+		return std::string();
+	if (show_NPC_name == 0 && entity.Type == Zeal::EqEnums::NPC)
 		return std::string();
 
 	const bool is_self = (&entity == Zeal::EqGame::get_self());


### PR DESCRIPTION
-adds logic to new zeal Nameplate to control for
-get_showPCname and get_showNPCname (buttons in Option menu, Display)