### PR TITLE
Add nameplate healthbars and fix fast target code's show value

### DIFF
--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -2280,6 +2280,18 @@ namespace Zeal
 			//  1 = first names, 2 = first/last names, 3 = first/last/guild names, 4 = everything
 			return *reinterpret_cast<int32_t*>(0x007d01e4);
 		}
+		int get_show_pc_names()
+		{
+			// Holds value of Options -> Display -> Show PC Names
+			// 0 = off, 1 = on
+			return *reinterpret_cast<int*>(0x0063D6C8);
+		}
+		int get_show_npc_names()
+		{
+			// Holds value of Options -> Display -> Show NPC Names
+			// 0 = off, 1 = on
+			return *reinterpret_cast<int*>(0x0063D6CC);
+		}
 		std::string get_full_zone_name(int zone_id) {
 			const int fn_GetFullZoneName = 0x00523e49;
 			void* pWorld = *reinterpret_cast<void**>(0x007F9494);

--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -201,6 +201,8 @@ namespace Zeal
 		float heading_to_yaw(float heading);
 		bool is_mouse_hovering_window();
 		int get_showname(); // Holds value of /showname command.
+		int get_show_pc_names(); // Holds value of Options -> Display -> Show PC Names.
+		int get_show_npc_names(); // Holds value of Options -> Display -> Show NPC Names. 
 		std::string class_name_short(int class_id);
 		std::string class_name(int class_id);
 		static constexpr int kInvalidZoneId = 0;  // get_index_from_zone_name() returns 0 if no matches.

--- a/Zeal/bitmap_font.h
+++ b/Zeal/bitmap_font.h
@@ -23,6 +23,10 @@ public:
     static constexpr char kFontFileExtension[] = ".spritefont";
     static constexpr char kDefaultFontName[] = "default";
 
+    // Support display of a health bar using non-visible ASCII values.
+    static constexpr char kHealthBarBackground = 1;  // ASCII '\x01' draws the background.
+    static constexpr char kHealthBarValue = 2;  // ASCII '\x02' draws the health value.
+
     // Utility method to report the available fonts.
     static std::vector<std::string> get_available_fonts();
 
@@ -47,6 +51,7 @@ public:
     void set_drop_shadow(bool enable) { drop_shadow = enable; }
     void set_outlined(bool enable) { outlined = enable; }
     void set_align_bottom(bool enable) { align_bottom = enable; }
+    void set_hp_percent(int value) { hp_percent = value; }  // Set before queue_string().
     
     // Primary interface for drawing text. The position is in screen pixel coordinates
     // and specifies the center (true) or the upper left (false).
@@ -68,6 +73,7 @@ protected:
     struct Lines {
         std::string text;
         Vec2 upper_left;
+        int hp_percent;
     };
 
     // Describes a single character bitmap glyph.
@@ -88,10 +94,12 @@ protected:
     };
 
     static constexpr int kNumGlyphs = 128;  // Support ASCII 0 - 127.
+    static constexpr float kHealthBarHeight = 6;
+    static constexpr float kHealthBarWidth = 120;
 
     void queue_lines(const std::vector<Lines>& lines, D3DCOLOR color, Vec2 offset = Vec2(0,0));
     const Glyph* get_glyph(char character) const;
-    void create_texture(uint32_t width, uint32_t height, D3DFORMAT format,
+    RECT create_texture(uint32_t width, uint32_t height, D3DFORMAT format,
         uint32_t stride, uint32_t rows, const uint8_t* data);
     bool create_index_buffer();
 
@@ -105,6 +113,7 @@ protected:
     bool drop_shadow = false;
     bool outlined = false;
     bool align_bottom = false;  // Applies only when text is queued with center flag.
+    int hp_percent = 0;
 
     IDirect3DDevice8& device;
     Glyph glyph_table[kNumGlyphs] = {};
@@ -193,6 +202,7 @@ protected:
         Vec3 position;  // Origin anchor point for a string of glyphs.
         int start_index;
         int stop_index;  // Exclusive.
+        int hp_percent;  // Value of internal hp_percent when queued.
     };
 
     // Vertices allow texturing and color modulation.

--- a/Zeal/nameplate.h
+++ b/Zeal/nameplate.h
@@ -50,6 +50,7 @@ public:
 	ZealSetting<bool> setting_inline_guild = { false, "Zeal", "NameplateInlineGuild", false };
 
 	// Advanced fonts
+	ZealSetting<bool> setting_health_bars = { false, "Zeal", "NameplateHealthBars", false };
 	ZealSetting<bool> setting_zeal_fonts = { false, "Zeal", "NamePlateZealFonts", false,
 		[this](bool val) { clean_ui(); } };
 	ZealSetting<bool> setting_drop_shadow = { false, "Zeal", "NamePlateDropShadow", false,

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -491,6 +491,7 @@ void ui_options::InitNameplate()
 	ui->AddCheckboxCallback(wnd, "Zeal_NameplateAttackOnly", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->setting_attack_only.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_NameplateZealFonts", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->setting_zeal_fonts.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_NameplateDropShadow", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->setting_drop_shadow.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_NameplateHealthBars", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->nameplate->setting_health_bars.set(wnd->Checked); });
 
 	ui->AddComboCallback(wnd, "Zeal_NameplateFont_Combobox", [this](Zeal::EqUI::BasicWnd* wnd, int value) {
 		std::string font_name("");
@@ -613,6 +614,7 @@ void ui_options::UpdateOptionsNameplate()
 	ui->SetChecked("Zeal_NameplateAttackOnly", ZealService::get_instance()->nameplate->setting_attack_only.get());
 	ui->SetChecked("Zeal_NameplateZealFonts", ZealService::get_instance()->nameplate->setting_zeal_fonts.get());
 	ui->SetChecked("Zeal_NameplateDropShadow", ZealService::get_instance()->nameplate->setting_drop_shadow.get());
+	ui->SetChecked("Zeal_NameplateHealthBars", ZealService::get_instance()->nameplate->setting_health_bars.get());
 
 	std::string current_font = ZealService::get_instance()->nameplate->setting_fontname.get();
 	UpdateComboBox("Zeal_NameplateFont_Combobox", current_font, BitmapFont::kDefaultFontName);

--- a/Zeal/uifiles/zeal/EQUI_Tab_Nameplate.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_Nameplate.xml
@@ -332,36 +332,36 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
-	<Button item="Zeal_NameplateTargetBlink">
-		<ScreenID>Zeal_NameplateTargetBlink</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>200</X>
-			<Y>90</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>20</CY>
-		</Size>
-		<Style_VScroll>false</Style_VScroll>
-		<Style_HScroll>false</Style_HScroll>
-		<Style_Transparent>false</Style_Transparent>
-		<Style_Checkbox>true</Style_Checkbox>
-		<TooltipReference>Blink rate set by TargetRing rate slider</TooltipReference>
-		<Text>Enable target blinking</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<ButtonDrawTemplate>
-			<Normal>A_BtnNormal</Normal>
-			<Pressed>A_BtnPressed</Pressed>
-			<Flyby>A_BtnFlyby</Flyby>
-			<Disabled>A_BtnDisabled</Disabled>
-			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
-		</ButtonDrawTemplate>
-	</Button>
+  <Button item="Zeal_NameplateTargetBlink">
+    <ScreenID>Zeal_NameplateTargetBlink</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>200</X>
+      <Y>90</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Blink rate set by TargetRing rate slider</TooltipReference>
+    <Text>Enable target blinking</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
   <Button item="Zeal_NameplateAttackOnly">
     <ScreenID>Zeal_NameplateAttackOnly</ScreenID>
     <RelativePosition>true</RelativePosition>
@@ -393,89 +393,119 @@
     </ButtonDrawTemplate>
   </Button>
   <Button item="Zeal_NameplateZealFonts">
-		<ScreenID>Zeal_NameplateZealFonts</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>200</X>
-			<Y>134</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>20</CY>
-		</Size>
-		<Style_VScroll>false</Style_VScroll>
-		<Style_HScroll>false</Style_HScroll>
-		<Style_Transparent>false</Style_Transparent>
-		<Style_Checkbox>true</Style_Checkbox>
-		<TooltipReference>Toggle use of zeal fonts for nameplate</TooltipReference>
-		<Text>Zeal fonts</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<ButtonDrawTemplate>
-			<Normal>A_BtnNormal</Normal>
-			<Pressed>A_BtnPressed</Pressed>
-			<Flyby>A_BtnFlyby</Flyby>
-			<Disabled>A_BtnDisabled</Disabled>
-			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
-		</ButtonDrawTemplate>
-	</Button>
-	<!-- Font Combobox -->
-	<Combobox item="Zeal_NameplateFont_Combobox">
-		<ScreenID>Zeal_NameplateFont_Combobox</ScreenID>
-		<DrawTemplate>WDT_Inner</DrawTemplate>
-		<Location>
-			<X>200</X>
-			<Y>156</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>24</CY>
-		</Size>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<ListHeight>70</ListHeight>
-		<Button>BDT_Combo</Button>
-		<Style_Border>true</Style_Border>
-		<Choices>default</Choices>
-	</Combobox>
-	<Button item="Zeal_NameplateDropShadow">
-		<ScreenID>Zeal_NameplateDropShadow</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>200</X>
-			<Y>182</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>20</CY>
-		</Size>
-		<Style_VScroll>false</Style_VScroll>
-		<Style_HScroll>false</Style_HScroll>
-		<Style_Transparent>false</Style_Transparent>
-		<Style_Checkbox>true</Style_Checkbox>
-		<TooltipReference>Enable font drop shadow</TooltipReference>
-		<Text>Add drop shadow</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<ButtonDrawTemplate>
-			<Normal>A_BtnNormal</Normal>
-			<Pressed>A_BtnPressed</Pressed>
-			<Flyby>A_BtnFlyby</Flyby>
-			<Disabled>A_BtnDisabled</Disabled>
-			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
-		</ButtonDrawTemplate>
-	</Button>
-	
-	<Page item="Tab_Nameplate">
+    <ScreenID>Zeal_NameplateZealFonts</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>200</X>
+      <Y>134</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Toggle use of zeal fonts for nameplate</TooltipReference>
+    <Text>Zeal fonts</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <!-- Font Combobox -->
+  <Combobox item="Zeal_NameplateFont_Combobox">
+    <ScreenID>Zeal_NameplateFont_Combobox</ScreenID>
+    <DrawTemplate>WDT_Inner</DrawTemplate>
+    <Location>
+      <X>200</X>
+      <Y>156</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>24</CY>
+    </Size>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ListHeight>70</ListHeight>
+    <Button>BDT_Combo</Button>
+    <Style_Border>true</Style_Border>
+    <Choices>default</Choices>
+  </Combobox>
+  <Button item="Zeal_NameplateDropShadow">
+    <ScreenID>Zeal_NameplateDropShadow</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>200</X>
+      <Y>182</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Enable font drop shadow</TooltipReference>
+    <Text>Add drop shadow</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_NameplateHealthBars">
+    <ScreenID>Zeal_NameplateHealthBars</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>200</X>
+      <Y>204</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Enable health bars (zeal fonts only)</TooltipReference>
+    <Text>Show health bars</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  
+  <Page item="Tab_Nameplate">
     <ScreenID>Tab_Nameplate</ScreenID>
     <RelativePosition>true</RelativePosition>
     <!-- Pages are sized and positioned by their parent tab -->
@@ -495,24 +525,25 @@
       <B>0</B>
     </TabTextActiveColor>
     <Style_Sizable>true</Style_Sizable>
-	<Pieces>Zeal_NameplateColors</Pieces>
-	<Pieces>Zeal_NameplateConColors</Pieces>
-	<Pieces>Zeal_NameplateHideSelf</Pieces>
-	<Pieces>Zeal_NameplateX</Pieces>
-	<Pieces>Zeal_NameplateHideRaidPets</Pieces>
-	<Pieces>Zeal_NameplateCharSelect</Pieces>
-	<Pieces>Zeal_NameplateInlineGuild</Pieces>
-	<Pieces>Zeal_NameplateTargetColor</Pieces>
-	<Pieces>Zeal_NameplateTargetMarker</Pieces>
-	<Pieces>Zeal_NameplateTargetHealth</Pieces>
-	<Pieces>Zeal_NameplateTargetBlink</Pieces>
-  <Pieces>Zeal_NameplateAttackOnly</Pieces>
-  <Pieces>Zeal_NameplateZealFonts</Pieces>
-	<Pieces>Zeal_NameplateDropShadow</Pieces>
-	<Pieces>Zeal_NameplateFont_Combobox</Pieces>
-	<Pieces>Zeal_NameplateShowPetOwnerName</Pieces>
-		
-		<Location>
+    <Pieces>Zeal_NameplateColors</Pieces>
+    <Pieces>Zeal_NameplateConColors</Pieces>
+    <Pieces>Zeal_NameplateHideSelf</Pieces>
+    <Pieces>Zeal_NameplateX</Pieces>
+    <Pieces>Zeal_NameplateHideRaidPets</Pieces>
+    <Pieces>Zeal_NameplateCharSelect</Pieces>
+    <Pieces>Zeal_NameplateInlineGuild</Pieces>
+    <Pieces>Zeal_NameplateTargetColor</Pieces>
+    <Pieces>Zeal_NameplateTargetMarker</Pieces>
+    <Pieces>Zeal_NameplateTargetHealth</Pieces>
+    <Pieces>Zeal_NameplateTargetBlink</Pieces>
+    <Pieces>Zeal_NameplateAttackOnly</Pieces>
+    <Pieces>Zeal_NameplateZealFonts</Pieces>
+    <Pieces>Zeal_NameplateDropShadow</Pieces>
+    <Pieces>Zeal_NameplateHealthBars</Pieces>
+    <Pieces>Zeal_NameplateFont_Combobox</Pieces>
+    <Pieces>Zeal_NameplateShowPetOwnerName</Pieces>
+
+    <Location>
       <X>0</X>
       <Y>22</Y>
     </Location>
@@ -521,4 +552,4 @@
       <CY>339</CY>
     </Size>
   </Page>
-  </XML>
+</XML>


### PR DESCRIPTION
Add health bar option to nameplates
    - Adds an option to display a health bar at the bottom of
      visible nameplates
    - The health bar update rate depends on when the server decides
      to share (so fast for your target, might be slow if crowded)

 Make fast target update respect name viz settings
    - The fast target update logic was always setting show = 1
      for the targeted entity. Updated that to respect the
      general display options show pc and show npc settings.