### PR TITLE
Patch- Song Window support for ui_buff.cpp

### DIFF
--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -2409,6 +2409,9 @@ namespace Zeal
 					return;
 				Windows->SpellGems->UpdateSpellGems(index);
 			}
+			bool IsValidSpellIndex(int spellid) {
+				return reinterpret_cast<bool(__cdecl*)(int)>(0x004D79EA)(spellid);
+			}
 		}
 
 		namespace OldUI

--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -112,6 +112,7 @@ namespace Zeal
 			void Memorize(int book_index, int gem_index);
 			void Forget(int index);
 			void UpdateGems(int index);
+			bool IsValidSpellIndex(int spellid);
 		}
 		namespace OldUI
 		{

--- a/Zeal/EqStructures.h
+++ b/Zeal/EqStructures.h
@@ -551,7 +551,7 @@ namespace Zeal
 		} EQINVENTORY, * PEQINVENTORY;
 		struct _EQBUFFINFO
 		{
-			/* 0x0000 */ BYTE Valid; // Whether this buff slot is active or empty
+			/* 0x0000 */ BYTE BuffType; // Active buffs have a non-zero value
 			/* 0x0001 */ BYTE CasterLevel; // level of player who casted the buff
 			/* 0x0002 */ BYTE Modifier; // divide by 10 to get Bard song modifier
 			/* 0x0003 */ BYTE Activated; // Copied from spell data to buff struct.  Only a few spells have this set to 1, the rest are 0
@@ -623,6 +623,12 @@ namespace Zeal
 			bool can_i_see_invis() // CanISeeInvis()
 			{
 				return reinterpret_cast<bool(__thiscall*)(EQCHARINFO*)>(0x004c0d02)(this);
+			}
+			_EQBUFFINFO* GetBuff(WORD buff_slot) { // Supports 0..29
+				return reinterpret_cast<_EQBUFFINFO*(__thiscall*)(EQCHARINFO*, WORD)>(0x004C465A)(this, buff_slot);
+			}
+			int GetMaxBuffs() {
+				return reinterpret_cast<BYTE(__thiscall*)(EQCHARINFO*)>(0x004C4637)(this);
 			}
 			/* 0x0000 */ BYTE Unknown0000[2];
 			/* 0x0002 */ CHAR Name[64]; // [0x40]

--- a/Zeal/EqUI.h
+++ b/Zeal/EqUI.h
@@ -420,7 +420,7 @@ namespace Zeal
 				CXSTR INIStorageName;
 				struct _EQINVSLOT* pEQInvSlot;
 			};
-			/*0x124*/   DWORD   Unknown0x124; /* CTextureAnimation */
+			/*0x124*/   struct CTextureAnimation*  BackgroundTexture;
 			/*0x128*/   DWORD   Unknown0x128; /* CTextureAnimation */
 			/*0x12c*/   DWORD   ContextMenu;  /* CTextureAnimation its an id for the menu*/
 			/*0x130*/	BYTE    Unknown0x130; /* CTextureAnimation */
@@ -428,11 +428,25 @@ namespace Zeal
 			/*0x132*/	BYTE    Unknown0x132; /* CTextureAnimation */
 			/*0x133*/	BYTE    Unknown0x133; /* CTextureAnimation */
 		};
-		struct BuffWindow : EQWND
+		struct BuffWindowButton : EQWND
 		{
 			/* 0x0134 */ int Unknown1;
-			/* 0x0138 */ BYTE Unknown0138[68];
-			/* 0x017C */ struct EQWND* BuffButtonWnd[EQ_NUM_BUFFS]; // CButtonWnd
+			/* 0x0138 */ struct CTextureAnimation* BuffIcon; // Background stored in 0x124
+		};
+		struct BuffWindow : EQWND
+		{
+			/* 0x0134 */ BYTE Unknown00134; // Initialization flag
+			/* 0x0135 */ BYTE Unknown00135; // Initialization flag
+			/* 0x0136 */ BYTE Unknown00136;
+			/* 0x0137 */ BYTE Unknown00137;
+			/* 0x0138 */ struct CTextureAnimation* BlueIconBackground;
+			/* 0x013C */ struct CTextureAnimation* RedIconBackground;
+			/* 0x0140 */ struct CTextureAnimation* CTextureAnimations[EQ_NUM_BUFFS];
+			/* 0x017C */ BuffWindowButton* BuffButtonWnd[EQ_NUM_BUFFS];
+			/* 0x01B8 */ DWORD NextRefreshTime;
+			/* 0x01BC */ DWORD Width;
+			/* 0x01C0 */ DWORD Height;
+			/* End    */
 		};
 		struct CharSelect : EQWND
 		{

--- a/Zeal/labels.cpp
+++ b/Zeal/labels.cpp
@@ -86,6 +86,22 @@ bool GetLabelFromEq(int EqType, Zeal::EqUI::CXSTR* str, bool* override_color, UL
 		}
 		return true;
 	}
+	case 135: // Buff 16
+	case 136: // Buff 17
+	case 137: // Buff 18
+	case 138: // Buff 19
+	case 139: // Buff 20
+	case 140: // Buff 21
+	case 141: // Buff 22
+	case 142: // Buff 23
+	case 143: // Buff 24
+	case 144: // Buff 25
+	case 145: // Buff 26
+	case 146: // Buff 27
+	case 147: // Buff 28
+	case 148: // Buff 29
+	case 149: // Buff 30
+		break; // Reserved - These labels are supported by the eqgame.dll
 	case 255: //debug label
 	{
 		Zeal::EqGame::CXStr_PrintString(str, "%s", ZealService::get_instance()->labels_hook->debug_info.c_str());

--- a/Zeal/ui_buff.cpp
+++ b/Zeal/ui_buff.cpp
@@ -47,25 +47,32 @@ int __fastcall BuffWindow_Refresh(Zeal::EqUI::BuffWindow* this_ptr, void* not_us
 	if (!ZealService::get_instance()->ui->buffs->BuffTimers.get())
 		return result;
 	Zeal::EqStructures::EQCHARINFO* charInfo = Zeal::EqGame::get_char_info();
-
 	if (!charInfo)
 		return result;
 
+	int max_buffs = charInfo->GetMaxBuffs();
+
+	// Detects whether we are using the Normal Buff Window or the Song Window.
+	int start_buff_offset = (this_ptr == Zeal::EqGame::Windows->BuffWindowNORMAL) ? 0 : EQ_NUM_BUFFS;
+
 	for (size_t i = 0; i < EQ_NUM_BUFFS; i++)
 	{
-		int spellId = charInfo->Buff[i].SpellId;
+		int buff_slot = i + start_buff_offset;
+		if (buff_slot >= max_buffs) {
+			break;
+		}
 
-		if (spellId == kInvalidSpellId)
+		Zeal::EqStructures::_EQBUFFINFO* buff = charInfo->GetBuff(buff_slot);
+		if (buff->BuffType == 0 || !Zeal::EqGame::Spells::IsValidSpellIndex(buff->SpellId))
 			continue;
 
-		int buffTicks = charInfo->Buff[i].Ticks;
-
+		int buffTicks = buff->Ticks;
 		if (!buffTicks)
 			continue;
 
 		char buffTimeText[128];
 		std::snprintf(buffTimeText, sizeof(buffTimeText) - 1, " %s", EQ_GetShortTickTimeString(buffTicks).c_str());
-		Zeal::EqUI::EQWND* buffButtonWnd = this_ptr->BuffButtonWnd[i];
+		Zeal::EqUI::BuffWindowButton* buffButtonWnd = this_ptr->BuffButtonWnd[i];
 		if (buffButtonWnd && buffButtonWnd->ToolTipText.Data)
 			buffButtonWnd->ToolTipText.Append(buffTimeText);
 	}
@@ -81,19 +88,29 @@ int __fastcall BuffWindow_PostDraw(Zeal::EqUI::BuffWindow* this_ptr, void* not_u
 	if (!charInfo)
 		return result;
 
+	int max_buffs = charInfo->GetMaxBuffs();
+
+	// Detects whether we are using the Normal Buff Window or the Song Window.
+	int start_buff_offset = (this_ptr == Zeal::EqGame::Windows->BuffWindowNORMAL) ? 0 : EQ_NUM_BUFFS;
+
 	for (size_t i = 0; i < EQ_NUM_BUFFS; i++)
 	{
-		if (charInfo->Buff[i].SpellId == kInvalidSpellId)
+		int buff_slot = i + start_buff_offset;
+		if (buff_slot >= max_buffs) {
+			break;
+		}
+
+		Zeal::EqStructures::_EQBUFFINFO* buff = charInfo->GetBuff(buff_slot);
+		if (buff->BuffType == 0 || !Zeal::EqGame::Spells::IsValidSpellIndex(buff->SpellId))
 			continue;
 
-		int buffTicks = charInfo->Buff[i].Ticks;
-
+		int buffTicks = buff->Ticks;
 		if (!buffTicks)
 			continue;
 
 		char buffTimeText[128];
 		std::snprintf(buffTimeText, sizeof(buffTimeText) - 1, "%s", EQ_GetShortTickTimeString(buffTicks).c_str());
-		Zeal::EqUI::EQWND* buffButtonWnd = this_ptr->BuffButtonWnd[i];
+		Zeal::EqUI::BuffWindowButton* buffButtonWnd = this_ptr->BuffButtonWnd[i];
 		if (buffButtonWnd && buffButtonWnd->ToolTipText.Data)
 		{
 				std::string orig = buffButtonWnd->ToolTipText.Data->Text;


### PR DESCRIPTION
Backwards compatible.

Small changes that makes `ui_buff.cpp` forward compatible with the Song Window's refresh callback, to properly render buff durations instead of showing junk data in song slots.

- Note: We may also want to add song support for the named_pipe stuff, but that can come in a separate patch.