### PR TITLE
Update tab completion to support flushing

### DIFF
--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -1733,6 +1733,14 @@ namespace Zeal
 			reinterpret_cast<void(__thiscall*)(Zeal::EqUI::ChatWnd*, Zeal::EqUI::CXSTR msg, short channel)>(ZealService::get_instance()->hooks->hook_map["AddOutputText"]->trampoline)(wnd, cxBuff, color);
 			cxBuff.FreeRep();
 		}
+		void destroy_held()
+		{
+			// Call void CInventoryWnd::DestroyHeld(void) which is effectively a static and doesn't use the
+			// class pointer. This will either destroy the cursor item immediately if fast destroy is set
+			// or it will pop up a confirmation dialog.
+			auto inventory_wnd = Zeal::EqGame::Windows->Inventory;
+			reinterpret_cast<void(__fastcall*)(Zeal::EqUI::EQWND*, int unused_edx)>(0x00421637)(inventory_wnd, 0);
+		}
 		int get_gamestate()
 		{
 			if (get_eq())

--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -223,6 +223,7 @@ namespace Zeal
 		void do_auction(std::string data);
 		void do_ooc(std::string data);
 		void send_raid_chat(std::string data);
+		void destroy_held();
 		int get_region_from_pos(Vec3* pos);
 		EqUI::CXWndManager* get_wnd_manager();
 		bool is_player_pet(const Zeal::EqStructures::Entity& entity);

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -114,7 +114,7 @@ void ui_options::LoadColors()
 	if (!ini->exists("ZealColors", "Color10")) //Adds default Nameplate Color to Button11 for new users
 	{
 		if (color_buttons.count(10))
-			color_buttons[10]->TextColor.ARGB = 0xFF000000; //Npc Corpse - Black
+			color_buttons[10]->TextColor.ARGB = 0xFF202020; //Npc Corpse - Dark gray
 	}
 	if (!ini->exists("ZealColors", "Color11")) //Adds default Nameplate Color to Button12 for new users
 	{

--- a/Zeal/uifiles/zeal/EQUI_Tab_Nameplate.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_Nameplate.xml
@@ -377,7 +377,7 @@
     <Style_HScroll>false</Style_HScroll>
     <Style_Transparent>false</Style_Transparent>
     <Style_Checkbox>true</Style_Checkbox>
-    <TooltipReference>Blink rate set by TargetRing rate slider</TooltipReference>
+    <TooltipReference>Requires Zeal Con or Target Color; Blink rate set by TargetRing slider</TooltipReference>
     <Text>Enable target blinking</Text>
     <TextColor>
       <R>255</R>


### PR DESCRIPTION
- Updated the tab completion logic to support flushing a typed message and enabling the tell cycle list if a tab is pressed
- The recent tells list is always added to the cycle list at the end after any partial tab completion matches
- To simplify the logic, tab completion will not work in a tell window if there is more than one open. The tab cycles between the tell windows. The main chat window still has tab completion.
- Modified the drop shadow color to avoid an artifact when the nameplate color is black and made default npc corpse dark gray
- Updated the nameplate health bar logic to only show health bars on entities that receive server updates
- Added a utility destroy_held() function