### PR TITLE
Add zeal assist, suppress notes, disable self-ring

### DIFF
--- a/Zeal/EqAddresses.h
+++ b/Zeal/EqAddresses.h
@@ -49,6 +49,7 @@ namespace Zeal
 		static int max_pitch = 0x5e86d0;
 		static EqStructures::KeyboardInput* KeyInput = (EqStructures::KeyboardInput*)0x7ce058;
 		static char* in_game = (char*)0x798550;
+		static int* attack_on_assist = (int*)0x007cf204;  // 1 = attack on assist
 
 		//Vec3* camera_position = *(Vec3**)0x9c08128;
 	}

--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -1855,7 +1855,14 @@ namespace Zeal
 		{
 			return *(Zeal::EqStructures::Entity**)Zeal::EqGame::EntListPtr;
 		}
-
+		bool get_attack_on_assist()
+		{
+			return *Zeal::EqGame::attack_on_assist != 0;
+		}
+		void set_attack_on_assist(bool enable)
+		{
+			*Zeal::EqGame::attack_on_assist = enable;
+		}
 		long get_user_color(int index)
 		{
 			index -= 1;

--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -174,6 +174,8 @@ namespace Zeal
 		long get_user_color(int index);
 		void set_target(Zeal::EqStructures::Entity* target); //this will target an entity without question
 		void do_target(const char* name); //this function is used by /target and /rt with range limitations
+		bool get_attack_on_assist();
+		void set_attack_on_assist(bool enable);
 		bool can_move();
 		bool is_on_ground(Zeal::EqStructures::Entity* ent);
 		void log(std::string& data);

--- a/Zeal/chatfilter.cpp
+++ b/Zeal/chatfilter.cpp
@@ -279,6 +279,9 @@ void __fastcall PrintAutoSplit(int t, int unused, const char* data, short color_
 void __fastcall serverPrintChat(int t, int unused, const char* data, short color_index, bool u)
 {
     chatfilter* cf = ZealService::get_instance()->chatfilter_hook.get();
+    if (cf->setting_suppress_missed_notes.get() && !strncmp("A missed note brings ", data, 21))
+        return;  // Just drop missed note messages from others (String ID 1219).
+
     if (cf->isMyPetSay)
         color_index = CHANNEL_MYPETSAY;
     else if (cf->isPetMessage)

--- a/Zeal/chatfilter.h
+++ b/Zeal/chatfilter.h
@@ -3,6 +3,7 @@
 #include "memory.h"
 #include "EqUI.h"
 #include <functional>
+#include "ZealSettings.h"
 
 #define CHANNEL_MYPETDMG 1000
 #define CHANNEL_OTHERPETDMG 1001
@@ -46,6 +47,7 @@ class chatfilter
 	void AddOutputText(Zeal::EqUI::ChatWnd*& wnd, std::string msg, short& channel);
 	void LoadSettings(Zeal::EqUI::CChatManager* cm);
 	void callback_clean_ui();
+	ZealSetting<bool> setting_suppress_missed_notes = { false, "Zeal", "SuppressMissedNotes", false };
 	bool isExtendedCM(int channelMap, int applyOffset = 0);
 	bool isStandardCM(int channelMap, int applyOffset = 0);
 	bool isDamage=false;

--- a/Zeal/cycle_target.cpp
+++ b/Zeal/cycle_target.cpp
@@ -4,6 +4,7 @@
 #include "EqFunctions.h"
 #include "Zeal.h"
 #include <algorithm>
+#include "string_util.h"
 
 static size_t last_index = -1;
 static std::vector<Zeal::EqStructures::Entity*> near_ents;
@@ -113,4 +114,20 @@ CycleTarget::CycleTarget(ZealService* zeal)
 {
 	//originally this used a hook and replaced target nearest but now uses a bind
 	//	hook = zeal->hooks->Add("NearestEnt", Zeal::EqGame::EqGameInternal::fn_targetnearestnpc, get_nearest_ent, hook_type_detour, 6);
+
+	zeal->commands_hook->Add("/assist", {}, "Supports optional per character settings for /assist on/off.",
+		[this](std::vector<std::string>& args) {
+			if (setting_use_zeal_assist_on.get() && args.size() == 2) {
+				bool turn_on = Zeal::String::compare_insensitive(args[1], "on");
+				bool turn_off = !turn_on && Zeal::String::compare_insensitive(args[1], "off");
+				if (turn_on || turn_off) {
+					setting_assist_on.set(turn_on);
+					Zeal::EqGame::set_attack_on_assist(turn_on);
+					Zeal::EqGame::print_chat("Per character attack on assist: %s",
+						turn_on ? "ON" : "OFF");
+					return true;  // Skip normal /assist processing.
+				}
+			}
+			return false;  // Let normal /assist handle things.
+		});
 }

--- a/Zeal/cycle_target.h
+++ b/Zeal/cycle_target.h
@@ -2,6 +2,7 @@
 #include "hook_wrapper.h"
 #include "memory.h"
 #include "EqStructures.h"
+#include "ZealSettings.h"
 class CycleTarget
 {
 public:
@@ -9,6 +10,13 @@ public:
 	~CycleTarget();
 	Zeal::EqStructures::Entity* get_next_ent(float dist, BYTE type);
 	Zeal::EqStructures::Entity* get_nearest_ent(float dist, BYTE type);
+
+	// Assist on/off placed here since commands.cpp can't use settings and it is target related.
+	ZealSetting<bool> setting_assist_on = { false, "Zeal", "AssistOn", true };
+
+	ZealSetting<bool> setting_use_zeal_assist_on = { false, "Zeal", "UseZealAssistOn", true,
+		[this](bool val) {if (val) Zeal::EqGame::set_attack_on_assist(setting_assist_on.get()); },
+		true };
 private:
 	hook* hook;
 };

--- a/Zeal/target_ring.cpp
+++ b/Zeal/target_ring.cpp
@@ -390,6 +390,8 @@ void TargetRing::callback_render() {
 	Zeal::EqStructures::Entity* target = Zeal::EqGame::get_target();
 	if (!target || !target->ActorInfo || !target->ActorInfo->ViewActor_)
 		return;
+	if (disable_for_self.get() && (target == Zeal::EqGame::get_self()))
+		return;
 	float radius = 10.f;// Zeal::EqGame::CalcCombatRange(Zeal::EqGame::get_self(), target);
 
 	// ### Target Ring Color ###

--- a/Zeal/target_ring.h
+++ b/Zeal/target_ring.h
@@ -59,6 +59,7 @@ public:
 	~TargetRing();
 
 	ZealSetting<bool> enabled = { false, "TargetRing", "Enabled", true, [](bool val) { Zeal::EqGame::print_chat("Target ring is %s", val ? "Enabled" : "Disabled"); } };
+	ZealSetting<bool> disable_for_self = { false, "TargetRing", "DisableForSelf", true };
 	ZealSetting<bool> attack_indicator = { false, "TargetRing", "AttackIndicator", true };
 	ZealSetting<bool> rotate_match_heading = { false, "TargetRing", "MatchHeading", true };
 	ZealSetting<bool> use_cone = { false, "TargetRing", "Cone", true };

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -278,7 +278,9 @@ void ui_options::InitGeneral()
 	ui->AddCheckboxCallback(wnd, "Zeal_BuffTimers",				[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->ui->buffs->BuffTimers.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_BrownSkeletons",			[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->game_patches->BrownSkeletons.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_ClassicMusic",			[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->music->ClassicMusic.set(wnd->Checked); });
-		
+	ui->AddCheckboxCallback(wnd, "Zeal_SuppressMissedNotes",	[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->chatfilter_hook->setting_suppress_missed_notes.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_UseZealAssistOn",		[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->cycle_target->setting_use_zeal_assist_on.set(wnd->Checked); });
+
 	
 	ui->AddCheckboxCallback(wnd, "Zeal_LinkAllAltDelimiter",    [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->looting_hook->setting_alt_delimiter.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_EnableContainerLock",    [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->ui->options->setting_enable_container_lock.set(wnd->Checked); });
@@ -421,6 +423,7 @@ void ui_options::InitTargetRing()
 	ui->AddLabel(wnd, "Zeal_TargetRingTransparency_Value");
 
 	ui->AddCheckboxCallback(wnd, "Zeal_TargetRing", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->target_ring->enabled.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_TargetRingDisableForSelf", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->target_ring->disable_for_self.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_TargetRingAttackIndicator", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->target_ring->attack_indicator.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_TargetRingForward", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->target_ring->rotate_match_heading.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_TargetRingCone", [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->target_ring->use_cone.set(wnd->Checked); });
@@ -556,6 +559,8 @@ void ui_options::UpdateOptionsGeneral()
 	ui->SetChecked("Zeal_BuffTimers", ZealService::get_instance()->ui->buffs->BuffTimers.get());
 	ui->SetChecked("Zeal_BrownSkeletons", ZealService::get_instance()->game_patches->BrownSkeletons.get());
 	ui->SetChecked("Zeal_ClassicMusic", ZealService::get_instance()->music->ClassicMusic.get());
+	ui->SetChecked("Zeal_SuppressMissedNotes", ZealService::get_instance()->chatfilter_hook->setting_suppress_missed_notes.get());
+	ui->SetChecked("Zeal_UseZealAssistOn", ZealService::get_instance()->cycle_target->setting_use_zeal_assist_on.get());
 }
 void ui_options::UpdateOptionsCamera()
 {
@@ -584,6 +589,7 @@ void ui_options::UpdateOptionsTargetRing()
 		return;
 
 	ui->SetChecked("Zeal_TargetRing", ZealService::get_instance()->target_ring->enabled.get());
+	ui->SetChecked("Zeal_TargetRingDisableForSelf", ZealService::get_instance()->target_ring->disable_for_self.get());
 	ui->SetChecked("Zeal_TargetRingAttackIndicator", ZealService::get_instance()->target_ring->attack_indicator.get());
 	ui->SetChecked("Zeal_TargetRingForward", ZealService::get_instance()->target_ring->rotate_match_heading.get());
 	ui->SetChecked("Zeal_TargetRingCone", ZealService::get_instance()->target_ring->use_cone.get());

--- a/Zeal/uifiles/zeal/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_General.xml
@@ -722,6 +722,66 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
+  <Button item="Zeal_SuppressMissedNotes">
+    <ScreenID>Zeal_SuppressMissedNotes</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>464</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Suppress missed note messages from other bards</TooltipReference>
+    <Text>No missed notes</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_UseZealAssistOn">
+    <ScreenID>Zeal_UseZealAssistOn</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>486</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Enable per character /assist on settings</TooltipReference>
+    <Text>Use Zeal /assist on</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
   <!-- end -->
     
   <Page item="Tab_General">
@@ -768,10 +828,12 @@
     <Pieces>Zeal_ExportOnCamp</Pieces>
     <Pieces>Zeal_SelfClickThru</Pieces>
     <Pieces>Zeal_Timestamps_Combobox</Pieces>
-	<Pieces>Zeal_BuffTimers</Pieces>
-	<Pieces>Zeal_CastAutoStand</Pieces>
-	<Pieces>Zeal_BrownSkeletons</Pieces>
-	<Pieces>Zeal_ClassicMusic</Pieces>
+    <Pieces>Zeal_BuffTimers</Pieces>
+    <Pieces>Zeal_CastAutoStand</Pieces>
+    <Pieces>Zeal_BrownSkeletons</Pieces>
+    <Pieces>Zeal_ClassicMusic</Pieces>
+    <Pieces>Zeal_SuppressMissedNotes</Pieces>
+    <Pieces>Zeal_UseZealAssistOn</Pieces>
     <Location>
       <X>0</X>
       <Y>22</Y>

--- a/Zeal/uifiles/zeal/EQUI_Tab_TargetRing.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_TargetRing.xml
@@ -32,12 +32,42 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
+  <Button item="Zeal_TargetRingDisableForSelf">
+    <ScreenID>Zeal_TargetRingDisableForSelf</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>11</X>
+      <Y>32</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Disables target ring when self-targeting</TooltipReference>
+    <Text>Disable for self</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
   <Button item="Zeal_TargetRingAttackIndicator">
     <ScreenID>Zeal_TargetRingAttackIndicator</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>11</X>
-      <Y>32</Y>
+      <Y>54</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -67,7 +97,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>11</X>
-      <Y>54</Y>
+      <Y>76</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -97,7 +127,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>11</X>
-      <Y>76</Y>
+      <Y>98</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -127,7 +157,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>11</X>
-      <Y>98</Y>
+      <Y>120</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -552,6 +582,7 @@
     </TabTextActiveColor>
     <Style_Sizable>true</Style_Sizable>
     <Pieces>Zeal_TargetRing</Pieces>
+    <Pieces>Zeal_TargetRingDisableForSelf</Pieces>
     <Pieces>Zeal_TargetRingFill_Label</Pieces>
     <Pieces>Zeal_TargetRingFill_Slider</Pieces>
     <Pieces>Zeal_TargetRingFill_Value</Pieces>
@@ -572,9 +603,9 @@
     <Pieces>Zeal_TargetRingTransparency_Value</Pieces>
     <Pieces>Zeal_TargetRingTexture_Label</Pieces>
     <Pieces>Zeal_TargetRingAttackIndicator</Pieces>
-	<Pieces>Zeal_TargetRingForward</Pieces>
+    <Pieces>Zeal_TargetRingForward</Pieces>
     <Pieces>Zeal_TargetRingTexture_Combobox</Pieces>
-	<Pieces>Zeal_TargetRingCone</Pieces>
+    <Pieces>Zeal_TargetRingCone</Pieces>
     <Pieces>Zeal_TargetRingColor</Pieces>
     <Location>
       <X>0</X>


### PR DESCRIPTION
- Added a general tab option to use zeal for the /assist on/off setting as a per character control
- Added a general tab option to suppress 'A missed note' messages from other players (bards)
- Added a target ring option to disable the ring when self-targeting