### PR TITLE
Update floating combat damage (heals, big hits)

### DIFF
--- a/Zeal/EqPackets.h
+++ b/Zeal/EqPackets.h
@@ -13,6 +13,7 @@ namespace Zeal
             CorpseDrag = 0x4114,
             CorpseDrop = 0x1337,
             TargetMouse = 0x4162,
+            HPUpdate = 0x40b2, // Note: Shared with MobHealth.
             RequestTrade = 0x40D1,
             WearChange = 0x4092,
             Illusion = 0x4091
@@ -60,6 +61,13 @@ namespace Zeal
         {
             /*000*/	UINT16	new_target; // Target spawn ID.
             /*002*/
+        };
+        struct SpawnHPUpdate_Struct  // Server encodes MobHealth's OP_MobHealth SpawnHPUpdate_Struct2 to this.
+        {
+            /*000*/ UINT32 spawn_id;  // Comment: Id of spawn to update
+            /*004*/ INT32 cur_hp;     // Comment:  Current hp of spawn
+            /*008*/ INT32 max_hp;     // Comment: Maximum hp of spawn
+            /*012*/
         };
         struct Tint_Struct {
             union {

--- a/Zeal/callbacks.cpp
+++ b/Zeal/callbacks.cpp
@@ -286,11 +286,12 @@ void __fastcall OutputText(Zeal::EqUI::ChatWnd* wnd, int u, Zeal::EqUI::CXSTR ms
 ///*00E*/	float	sequence; // see above notes in Action_Struct
 ///*012*/	float	pushup_angle; // associated with force.  Sine of this angle, multiplied by force, will be z push.
 /// 
-void CallbackManager::AddReportSuccessfulHit(std::function<void(struct Zeal::EqStructures::Entity* source, struct Zeal::EqStructures::Entity* target, WORD type, short spell_id, short damage, int heal, char output_text)> callback_function)
+void CallbackManager::AddReportSuccessfulHit(std::function<void(struct Zeal::EqStructures::Entity* source,
+	struct Zeal::EqStructures::Entity* target, WORD type, short spell_id, short damage, char output_text)> callback_function)
 {
 	ReportSuccessfulHit_functions.push_back(callback_function);
 }
-void CallbackManager::invoke_ReportSuccessfulHit(Zeal::Packets::Damage_Struct* dmg, int heal, char output_text)
+void CallbackManager::invoke_ReportSuccessfulHit(Zeal::Packets::Damage_Struct* dmg, char output_text)
 {
 	auto em = ZealService::get_instance()->entity_manager.get();
 	Zeal::EqStructures::Entity* target = em->Get(dmg->target);
@@ -298,14 +299,14 @@ void CallbackManager::invoke_ReportSuccessfulHit(Zeal::Packets::Damage_Struct* d
 	if (target && source)
 	{
 		for (auto& fn : ReportSuccessfulHit_functions)
-			fn(source, target, dmg->type, dmg->spellid, dmg->damage, heal, output_text);
+			fn(source, target, dmg->type, dmg->spellid, dmg->damage, output_text);
 	}
 }
 
-void __fastcall ReportSuccessfulHit(int t, int u, Zeal::Packets::Damage_Struct* dmg, char output_text, int heal)
+static void __fastcall ReportSuccessfulHit(int t, int u, Zeal::Packets::Damage_Struct* dmg, char output_text, int always_zero)
 {
-	ZealService::get_instance()->callbacks->invoke_ReportSuccessfulHit(dmg, heal, output_text);
-	ZealService::get_instance()->hooks->hook_map["ReportSuccessfulHit"]->original(ReportSuccessfulHit)(t, u, dmg, output_text, heal);
+	ZealService::get_instance()->callbacks->invoke_ReportSuccessfulHit(dmg, output_text);
+	ZealService::get_instance()->hooks->hook_map["ReportSuccessfulHit"]->original(ReportSuccessfulHit)(t, u, dmg, output_text, always_zero);
 	chatfilter* cf = ZealService::get_instance()->chatfilter_hook.get();
 	if (cf)
 	{

--- a/Zeal/callbacks.h
+++ b/Zeal/callbacks.h
@@ -41,8 +41,8 @@ public:
 	void AddDelayed(std::function<void()> callback_function, int ms);
 	void AddEntity(std::function<void(struct Zeal::EqStructures::Entity*)> callback_function, callback_type cb);
 	void AddOutputText(std::function<void(struct Zeal::EqUI::ChatWnd*& wnd, std::string& msg, short& channel)> callback_function);
-	void AddReportSuccessfulHit(std::function<void(struct Zeal::EqStructures::Entity* source, struct Zeal::EqStructures::Entity* target, WORD type, short spell_id, short damage, int heal, char output_text)> callback_function);
-	void invoke_ReportSuccessfulHit(struct Zeal::Packets::Damage_Struct* dmg, int heal, char output_text);
+	void AddReportSuccessfulHit(std::function<void(struct Zeal::EqStructures::Entity* source, struct Zeal::EqStructures::Entity* target, WORD type, short spell_id, short damage, char output_text)> callback_function);
+	void invoke_ReportSuccessfulHit(struct Zeal::Packets::Damage_Struct* dmg, char output_text);
 	void invoke_player(struct Zeal::EqStructures::Entity* ent, callback_type cb);
 	void invoke_generic(callback_type fn);
 	bool invoke_packet(callback_type fn, UINT opcode, char* buffer, UINT len);
@@ -60,6 +60,6 @@ private:
 	std::unordered_map<callback_type, std::vector<std::function<bool(UINT, BOOL)>>> cmd_functions;
 	std::unordered_map<callback_type, std::vector<std::function<void(struct Zeal::EqStructures::Entity*)>>> player_spawn_functions;
 	std::vector<std::function<void(struct Zeal::EqUI::ChatWnd*& wnd,std::string& msg, short& channel)>> output_text_functions;
-	std::vector<std::function<void(struct Zeal::EqStructures::Entity* source, struct Zeal::EqStructures::Entity* victim, WORD type, short spell_id, short damage, int heal, char output_text)>> ReportSuccessfulHit_functions;
+	std::vector<std::function<void(struct Zeal::EqStructures::Entity* source, struct Zeal::EqStructures::Entity* victim, WORD type, short spell_id, short damage, char output_text)>> ReportSuccessfulHit_functions;
 };
 

--- a/Zeal/chatfilter.cpp
+++ b/Zeal/chatfilter.cpp
@@ -361,15 +361,15 @@ char* __fastcall serverGetString(int stringtable, int unused, int string_id, boo
 chatfilter::chatfilter(ZealService* zeal, IO_ini* ini)
 {
     zeal->hooks->Add("DamageOutputText", 0x52A8C1, CChatManager, hook_type_replace_call);
-    zeal->callbacks->AddReportSuccessfulHit([this](Zeal::EqStructures::Entity* source, Zeal::EqStructures::Entity* target, WORD type, short spell_id, short damage, int heal, char output_text) { 
+    zeal->callbacks->AddReportSuccessfulHit([this](Zeal::EqStructures::Entity* source, Zeal::EqStructures::Entity* target, WORD type, short spell_id, short damage, char output_text) { 
         if (output_text) { 
             isDamage = true; 
-            damageData = { source, target, type, spell_id, damage, heal }; 
+            damageData = { source, target, type, spell_id, damage }; 
         }
         if (spell_id > 0 && damage > 0 && source != Zeal::EqGame::get_self() && target != Zeal::EqGame::get_self())
         {
             isDamage = true;
-            damageData = { source, target, type, spell_id, damage, heal };
+            damageData = { source, target, type, spell_id, damage };
             if (source->Position.Dist2D(Zeal::EqGame::get_self()->Position) < 500 || target->Position.Dist2D(Zeal::EqGame::get_self()->Position) < 500)
                 Zeal::EqGame::print_chat(USERCOLOR_NON_MELEE, "%s hit %s for %i points of non-melee damage.", Zeal::EqGame::strip_name(source->Name), Zeal::EqGame::strip_name(target->Name), damage);
         }

--- a/Zeal/chatfilter.h
+++ b/Zeal/chatfilter.h
@@ -35,7 +35,6 @@ struct damage_data
 	WORD type = 0;
 	short spell_id = 0; 
 	short damage = 0; 
-	int heal = 0;
 };
 
 class chatfilter

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -173,13 +173,53 @@ void ui_options::LoadColors()
 	}
 	if (!ini->exists("ZealColors", "Color21")) //My Pet Say
 	{
-		if (color_buttons.count(19))
+		if (color_buttons.count(21))
 			color_buttons[21]->TextColor.ARGB = D3DCOLOR_ARGB(0xff, 0xf0, 0xf0, 0xf0); //Default White
 	}
 	if (!ini->exists("ZealColors", "Color22")) //Other Pet Say
 	{
-		if (color_buttons.count(20))
+		if (color_buttons.count(22))
 			color_buttons[22]->TextColor.ARGB = D3DCOLOR_ARGB(0xff, 0xf0, 0xf0, 0xf0); //Default White
+	}
+	if (!ini->exists("ZealColors", "Color32")) // FCD: My melee damage
+	{
+		if (color_buttons.count(32))
+			color_buttons[32]->TextColor.ARGB = D3DCOLOR_XRGB(0x00, 0xf0, 0xf0); // Light blue
+	}
+	if (!ini->exists("ZealColors", "Color33")) // FCD: My spell damage
+	{
+		if (color_buttons.count(33))
+			color_buttons[33]->TextColor.ARGB = D3DCOLOR_XRGB(0x00, 0xf0, 0xf0); // Light blue
+	}
+	if (!ini->exists("ZealColors", "Color34")) // FCD: Melee hitting me
+	{
+		if (color_buttons.count(34))
+			color_buttons[34]->TextColor.ARGB = D3DCOLOR_XRGB(0xf0, 0x00, 0x00);  // Red
+	}
+	if (!ini->exists("ZealColors", "Color35")) // FCD: Spells hitting me
+	{
+		if (color_buttons.count(35))
+			color_buttons[35]->TextColor.ARGB = D3DCOLOR_XRGB(0xf0, 0x00, 0x00);  // Red
+	}
+	if (!ini->exists("ZealColors", "Color36")) // FCD: Melee hitting others
+	{
+		if (color_buttons.count(36))
+			color_buttons[36]->TextColor.ARGB = D3DCOLOR_XRGB(0xff, 0x80, 0x00);  // Orange
+	}
+	if (!ini->exists("ZealColors", "Color37")) // FCD: Spells hitting others
+	{
+		if (color_buttons.count(37))
+			color_buttons[37]->TextColor.ARGB = D3DCOLOR_XRGB(0xff, 0x80, 0x00);  // Orange
+	}
+	if (!ini->exists("ZealColors", "Color38")) // FCD: Melee hitting NPCs
+	{
+		if (color_buttons.count(38))
+			color_buttons[38]->TextColor.ARGB = D3DCOLOR_XRGB(0xf0, 0xf0, 0xf0);  // White
+	}
+	if (!ini->exists("ZealColors", "Color39")) // FCD: Spells hitting NPCs
+	{
+		if (color_buttons.count(39))
+			color_buttons[39]->TextColor.ARGB = D3DCOLOR_XRGB(0xf0, 0xf0, 0xf0);  // White
 	}
 
 	for (auto& [index, btn] : color_buttons)
@@ -301,8 +341,12 @@ void ui_options::InitFloatingDamage()
 	ui->AddCheckboxCallback(wnd, "Zeal_FloatingOthers", [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->floating_damage->show_others.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_FloatingMelee", [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->floating_damage->show_melee.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_FloatingSpells", [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->floating_damage->show_spells.set(wnd->Checked); });
+	ui->AddLabel(wnd, "Zeal_FloatingBigHit_Value");
 	ui->AddCheckboxCallback(wnd, "Zeal_FloatingSpellIcons", [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->floating_damage->spell_icons.set(wnd->Checked); });
-
+	ui->AddSliderCallback(wnd, "Zeal_FloatingBigHit_Slider", [this](Zeal::EqUI::SliderWnd* wnd, int value) {
+		ZealService::get_instance()->floating_damage->big_hit_threshold.set(value * 10);
+		ui->SetLabelValue("Zeal_FloatingBigHit_Value", "%i", value * 10);
+		});
 	ui->AddComboCallback(wnd, "Zeal_FloatingFont_Combobox", [this](Zeal::EqUI::BasicWnd* wnd, int value) {
 		std::string font_name("");
 		if (value >= 0) {
@@ -651,6 +695,9 @@ void ui_options::UpdateOptionsFloatingDamage()
 	ui->SetChecked("Zeal_FloatingMelee", ZealService::get_instance()->floating_damage->show_melee.get());
 	ui->SetChecked("Zeal_FloatingSpells", ZealService::get_instance()->floating_damage->show_spells.get());
 	ui->SetChecked("Zeal_FloatingSpellIcons", ZealService::get_instance()->floating_damage->spell_icons.get());
+	int big_hit_threshold = ZealService::get_instance()->floating_damage->big_hit_threshold.get();
+	ui->SetLabelValue("Zeal_FloatingBigHit_Value", "%i", big_hit_threshold);
+	ui->SetSliderValue("Zeal_FloatingBigHit_Slider", big_hit_threshold / 10);
 
 	std::string current_font = ZealService::get_instance()->floating_damage->bitmap_font_filename.get();
 	UpdateComboBox("Zeal_FloatingFont_Combobox", current_font, FloatingDamage::kUseClientFontString);

--- a/Zeal/uifiles/zeal/EQUI_Tab_Colors.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_Colors.xml
@@ -823,6 +823,288 @@
 			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
 		</ButtonDrawTemplate>
 	</Button>
+  <Label item="Section_FloatingCombat">
+    <ScreenID>Section_FloatingCombat</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>136</X>
+      <Y>447</Y>
+    </Location>
+    <Size>
+      <CX>160</CX>
+      <CY>16</CY>
+    </Size>
+    <Text>Floating combat damage</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
+  <Button item="Zeal_BtnDividerFloating">
+    <ScreenID>Zeal_BtnDividerFloating</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>0</X>
+      <Y>460</Y>
+    </Location>
+    <Size>
+      <CX>380</CX>
+      <CY>2</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>-</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_Color32">
+    <ScreenID>Zeal_Color32</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>470</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>33 - My melee</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_Color33">
+    <ScreenID>Zeal_Color33</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>200</X>
+      <Y>470</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>34 - My spells</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_Color34">
+    <ScreenID>Zeal_Color34</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>492</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>35 - Me hit by melee</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_Color35">
+    <ScreenID>Zeal_Color35</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>200</X>
+      <Y>492</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>36 - Me hit by spells</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_Color36">
+    <ScreenID>Zeal_Color36</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>514</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>37 - Player hit by melee</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_Color37">
+    <ScreenID>Zeal_Color37</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>200</X>
+      <Y>514</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>38 - Player hit by spells</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_Color38">
+    <ScreenID>Zeal_Color38</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>536</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>39 - NPC hit by meleee</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_Color39">
+    <ScreenID>Zeal_Color39</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>200</X>
+      <Y>536</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>40 - NPC hit by spells</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
   <Page item="Tab_Colors">
 	<ScreenID>Tab_Colors</ScreenID>
 	 <RelativePosition>true</RelativePosition>
@@ -872,6 +1154,17 @@
 	<Pieces>Zeal_Color20</Pieces>
 	<Pieces>Zeal_Color21</Pieces>
 	<Pieces>Zeal_Color22</Pieces>
+    <Pieces>Section_FloatingCombat</Pieces>
+    <Pieces>Zeal_BtnDividerFloating</Pieces>
+    <Pieces>Zeal_Color32</Pieces>
+    <Pieces>Zeal_Color33</Pieces>
+    <Pieces>Zeal_Color34</Pieces>
+    <Pieces>Zeal_Color35</Pieces>
+    <Pieces>Zeal_Color36</Pieces>
+    <Pieces>Zeal_Color37</Pieces>
+    <Pieces>Zeal_Color38</Pieces>
+    <Pieces>Zeal_Color39</Pieces>
+
     <Location>
       <X>0</X>
       <Y>22</Y>

--- a/Zeal/uifiles/zeal/EQUI_Tab_FloatingDamage.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_FloatingDamage.xml
@@ -256,7 +256,62 @@
     <Style_Border>true</Style_Border>
     <Choices>default</Choices>
   </Combobox>
-
+  <!-- Bit hit value slider -->
+  <Label item="Zeal_FloatingBigHit_Label">
+    <ScreenID>Zeal_FloatingBigHit_Label</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>200</X>
+      <Y>70</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>14</CY>
+    </Size>
+    <Text>Big hit threshold value</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
+  <Slider item="Zeal_FloatingBigHit_Slider">
+    <ScreenID>Zeal_FloatingBigHit_Slider</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>197</X>
+      <Y>90</Y>
+    </Location>
+    <Size>
+      <CX>100</CX>
+      <CY>16</CY>
+    </Size>
+    <SliderArt>SDT_DefSlider</SliderArt>
+  </Slider>
+  <Label item="Zeal_FloatingBigHit_Value">
+    <ScreenID>Zeal_FloatingBigHit_Value</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>297</X>
+      <Y>90</Y>
+    </Location>
+    <Size>
+      <CX>50</CX>
+      <CY>16</CY>
+    </Size>
+    <Text>0</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>true</AlignRight>
+  </Label>
   <Page item="Tab_FloatingDamage">
     <ScreenID>Tab_FloatingDamage</ScreenID>
     <RelativePosition>true</RelativePosition>
@@ -284,6 +339,9 @@
     <Pieces>Zeal_FloatingMelee</Pieces>
     <Pieces>Zeal_FloatingSpells</Pieces>
     <Pieces>Zeal_FloatingSpellIcons</Pieces>
+    <Pieces>Zeal_FloatingBigHit_Label</Pieces>
+    <Pieces>Zeal_FloatingBigHit_Slider</Pieces>
+    <Pieces>Zeal_FloatingBigHit_Value</Pieces>
     <Pieces>Zeal_FloatingFont_Label</Pieces>
     <Pieces>Zeal_FloatingFont_Combobox</Pieces>
     <Location>


### PR DESCRIPTION
- Switched to using the HPUpdate packets to report heal events, which is mostly funcitonal. Note that self heals effectively bypass this since the client updates locally and there is no delta from the server packet
- Added a "big hit" slider to make some damage outputs persist longer and stronger (values above threshold)
- Added FCD specific color settings in the zeal colors tab for controlling the FCD colors (before shared with chat in general options and used some unlabeled values)