### PR TITLE
Add /protect command

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,20 @@ ___
   - **Arguments:** `ms delay`, `none`
   - **Example:** `/pandelay 200`
   - **Description:** changes the amount of delay before left click panning will start to happen
-    
+
+- `/protect`
+  - **Arguments:** `on`, `off`, `value`, `item`, `<item_link>`, `list`
+  - **Example:** `/protect value 10` Protects against dropping or destroying items >= 10 pp
+  - **Example:** `/protect list` Prints the list of currently protected items
+  - **Example:** `/protect item 10931` Toggles protection from dropping or destroying Crown of Rile (10931)
+  - **Example:** `/protect <item_link>` Toggles protection from dropping or destroying the item_link item.
+  - **Description:** Secondary protection against accidental loss of items. This should *not* be relied
+          upon as the primary method of protection and you will not be reimbursed if it doesn't protect
+          you from your own mistake.  Zeal intercepts the client calls to destroy or drop cursor
+          contents and blocks the action if it is a non-empty container, the item_value is >= value,
+          or the item is on the protect list. The enable, value, and protected list are stored per
+          character with the list stored in the `./<character_name>_protected.ini` file.
+
 - `/hidecorpse`
   - **Arguments:** `looted`, `none`
   - **Aliases:** `/hideco`, `/hidec`, `/hc`

--- a/Zeal/floating_damage.cpp
+++ b/Zeal/floating_damage.cpp
@@ -494,6 +494,11 @@ FloatingDamage::FloatingDamage(ZealService* zeal, IO_ini* ini)
 				for (const auto& font : fonts)
 					Zeal::EqGame::print_chat("  %s", font.c_str());
 			}
+			else if (args.size() == 3 && args[1] == "bighit" && Zeal::String::tryParse(args[2], &new_size)
+				&& new_size > 0) {
+				big_hit_threshold.set(new_size);
+				Zeal::EqGame::print_chat("Floating combat big hit threshold is now %i", new_size);
+			}
 			else if (args.size() == 2 && Zeal::String::tryParse(args[1], &new_size))
 			{
 				font_size = new_size;
@@ -510,6 +515,7 @@ FloatingDamage::FloatingDamage(ZealService* zeal, IO_ini* ini)
 				Zeal::EqGame::print_chat("Usage: `/fcd <#>` selects the client font size (1 to 6)");
 				Zeal::EqGame::print_chat("Usage: `/fcd font` prints the available fonts");
 				Zeal::EqGame::print_chat("Usage: `/fcd font <fontname>` selects the zeal font <fontname>");
+				Zeal::EqGame::print_chat("Usage: `/fcd bighit <threshold>` sets the big hit threshold");
 			}
 
 			return true;

--- a/Zeal/looting.h
+++ b/Zeal/looting.h
@@ -17,6 +17,22 @@ public:
 	~looting();
 
 	ZealSetting<bool> setting_alt_delimiter = { false, "Zeal", "LinkAllAltDelimiter", false };
+
+	// /protect functionality.  Command line-only for now.
+	bool is_cursor_protected(Zeal::EqStructures::EQCHARINFO* char_info);
+protected:
+	ZealSetting<bool> setting_protect_enable = { false, "Protect", "Enabled", true };
+	ZealSetting<int> setting_protect_value = { 10, "Protect", "Value", true };
+
+	struct ProtectedItem {
+		int id;
+		std::string name;
+	};
+	bool parse_protect(const std::vector<std::string>& args);
+	void update_protected_item(int item_id, const std::string& name);
+	void load_protected_items();
+	std::vector<ProtectedItem> protected_items;
+
 private:
 	int last_looted = -1;
 };


### PR DESCRIPTION
- The new /protect command provides secondary protection against accidental item loss. It blocks destroying or dropping items if a non-empty container, value is above a threshold, or the item is on a protection list.