### PR TITLE
Extend /protect to also cover selling items

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,14 +161,14 @@ ___
   - **Arguments:** `on`, `off`, `value`, `item`, `<item_link>`, `list`
   - **Example:** `/protect value 10` Protects against dropping or destroying items >= 10 pp
   - **Example:** `/protect list` Prints the list of currently protected items
-  - **Example:** `/protect item 10931` Toggles protection from dropping or destroying Crown of Rile (10931)
-  - **Example:** `/protect <item_link>` Toggles protection from dropping or destroying the item_link item.
+  - **Example:** `/protect item 10931` Toggles protection from dropping, destroying, or selling the Crown of Rile (10931)
+  - **Example:** `/protect <item_link>` Toggles protection from dropping, destroying, or selling the item_link item.
   - **Description:** Secondary protection against accidental loss of items. This should *not* be relied
           upon as the primary method of protection and you will not be reimbursed if it doesn't protect
-          you from your own mistake.  Zeal intercepts the client calls to destroy or drop cursor
-          contents and blocks the action if it is a non-empty container, the item_value is >= value,
-          or the item is on the protect list. The enable, value, and protected list are stored per
-          character with the list stored in the `./<character_name>_protected.ini` file.
+          you from your own mistake.  Zeal intercepts the client calls to sell, destroy, or drop cursor
+          contents and blocks the action if it is a non-empty container, the item_value is >= value (not
+          checked for sell), or the item is on the protect list. The enable, value, and protected list
+          are stored per character with the list stored in the `./<character_name>_protected.ini` file.
 
 - `/hidecorpse`
   - **Arguments:** `looted`, `none`

--- a/Zeal/EqUI.h
+++ b/Zeal/EqUI.h
@@ -573,6 +573,22 @@ namespace Zeal
 			/* 0x000C */ DWORD Index;             // Index to CInvSlotMgr->invSlots[i]. This changes as containers are opened/closed.
 			/* 0x0010 */ Zeal::EqStructures::EQITEMINFOBASE* Item;
 		};
+		struct MerchantWnd : EQWND  // operator_new(0x3e4)
+		{
+			/*0x134*/  BYTE   Activated;         // 1 = activated, 0 = deactivated
+			/*0x135*/  BYTE   Unknown0x135[0xb];
+			/*0x140*/  DWORD  Unknown0x140[0x50];  // Likely ItemInfo*. Deleted when deactivated.
+			/*0x280*/  DWORD  Unknown0x280;
+			/*0x284*/  DWORD  InventoryItemSlot;
+			/*0x288*/  Zeal::EqStructures::EQITEMINFO** ItemInfo;  // Item used in selling.
+			/*0x28C*/  EQWND* MerchantName;      // MW_MerchantName
+			/*0x290*/  EQWND* SelectedItem;      // MW_SelectedItem
+			/*0x294*/  EQWND* BuyButton;         // MW_Buy_Button
+			/*0x298*/  EQWND* SellButton;        // MW_Sell_Button
+			/*0x29c*/  EQWND* InvSlotWnd[0x50];  // Unsure if InvSlot vs InvSlotWnd
+			/*0x3dc*/  EQWND* DoneButton;
+			/*0x3e0*/  EQWND* MerchantSlotsWnd;  // MerchantSlotsWnd
+		};
 		struct SliderWnd : BasicWnd // Uses a BaseVTable.
 		{
 			SliderWnd() {};

--- a/Zeal/looting.h
+++ b/Zeal/looting.h
@@ -19,7 +19,9 @@ public:
 	ZealSetting<bool> setting_alt_delimiter = { false, "Zeal", "LinkAllAltDelimiter", false };
 
 	// /protect functionality.  Command line-only for now.
-	bool is_cursor_protected(Zeal::EqStructures::EQCHARINFO* char_info);
+	bool is_cursor_protected(const Zeal::EqStructures::EQCHARINFO* char_info) const;
+	bool is_item_protected_from_selling(const Zeal::EqStructures::EQITEMINFO* item_info) const;
+
 protected:
 	ZealSetting<bool> setting_protect_enable = { false, "Protect", "Enabled", true };
 	ZealSetting<int> setting_protect_value = { 10, "Protect", "Value", true };


### PR DESCRIPTION
- /protect now protects against selling the items on the protect list. It does not check against value. It also blocks selling a non-empty container, but the client already does this.