### PR TITLE
Added Tint support to Helm/Weapon models. Finalized Velious helm support. Internal cleanup.

### DIFF
--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -2446,6 +2446,37 @@ namespace Zeal
 			}
 		}
 
+		namespace Graphics
+		{
+			bool IsWorldInitialized() {
+				return Zeal::EqGame::get_display() && Zeal::EqGame::get_display()[1] && *(int*)0x7F9A24 != 0;
+			}
+			DWORD s3dGetNumSkinsAttachedToHierarchicalSprite(Zeal::EqStructures::_EQMODELINFO* actorModelInfo) {
+				return reinterpret_cast<DWORD(__cdecl*)(Zeal::EqStructures::_EQMODELINFO*)>(*(int*)0x7F9844)(actorModelInfo);
+			}
+			Zeal::EqStructures::DMSprite* s3dGetSkinAttachedToHierarchicalSprite(int index, Zeal::EqStructures::_EQMODELINFO* actorModelInfo) {
+				return reinterpret_cast<Zeal::EqStructures::DMSprite*(__cdecl*)(int, Zeal::EqStructures::_EQMODELINFO*)>(*(int*)0x7F9848)(index, actorModelInfo);
+			}
+			Zeal::EqStructures::DMSprite* s3dGetSkinAttachedToHierarchicalSpriteLinkUpdatesToDAGIndex(int index, Zeal::EqStructures::_EQMODELINFO* actorModelInfo) {
+				return reinterpret_cast<Zeal::EqStructures::DMSprite*(__cdecl*)(int, Zeal::EqStructures::_EQMODELINFO*)>(*(int*)0x7F984C)(index, actorModelInfo);
+			}
+			Zeal::EqStructures::DMSpriteDefinition* s3dGetDMSpriteDefinition(Zeal::EqStructures::DMSprite* element) {
+				return reinterpret_cast<Zeal::EqStructures::DMSpriteDefinition*(__cdecl*)(Zeal::EqStructures::DMSprite*)>(*(int*)0x7F9830)(element);
+			}
+			Zeal::EqStructures::MaterialPalette* s3dDuplicateMaterialPalette(Zeal::EqStructures::MaterialPalette* material_palette) {
+				return reinterpret_cast<Zeal::EqStructures::MaterialPalette*(__cdecl*)(int, Zeal::EqStructures::MaterialPalette*)>(*(int*)0x7F9824)(Zeal::EqGame::get_display()[1], material_palette);
+			}
+			Zeal::EqStructures::MaterialPalette* s3dGetDMSpriteMaterialPalette(Zeal::EqStructures::DMSprite* dmsprite) {
+				return reinterpret_cast<Zeal::EqStructures::MaterialPalette*(__cdecl*)(void*)>(*(int*)0x7F9834)(dmsprite);
+			}
+			int t3dGetObjectTag(void* graphics_object, char* out_tag) {
+				return reinterpret_cast<int(__cdecl*)(void*, char*)>(*(int*)0x7F9A20)(graphics_object, out_tag);
+			}
+			Zeal::EqStructures::GraphicsObject* t3dGetPointerFromDictionary(const char* key) {
+				return reinterpret_cast<Zeal::EqStructures::GraphicsObject*(__cdecl*)(int, const char*)>(*(int*)0x7F9A24)(Zeal::EqGame::get_display()[1], key);
+			}
+		}
+
 		// Primitive comparison with simple numeric string support.
 		static bool sort_list_wnd_compare(const std::vector<std::string>& a,
 			const std::vector<std::string>& b, int sort_column)
@@ -2516,5 +2547,12 @@ namespace Zeal
 			}
 		}
 
+		Zeal::EqStructures::EQDAGINFO* get_dag(Zeal::EqStructures::Entity* entity, int wear_slot, bool alternate)
+		{
+			return reinterpret_cast<Zeal::EqStructures::EQDAGINFO*(__stdcall*)(Zeal::EqStructures::Entity*, int, bool)>(0x4A00D9)(entity, wear_slot, alternate);
+		}
+		int set_dag_sprite_tint(Zeal::EqStructures::EQDAGINFO* dag, DWORD tint) {
+			return reinterpret_cast<int(__thiscall*)(int*, void*, DWORD*)>(0x49FF51)(Zeal::EqGame::get_display(), dag, &tint);
+		}
 	}
 }

--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -117,6 +117,18 @@ namespace Zeal
 		{
 			bool spellbook_window_open();
 		}
+		namespace Graphics {
+			// Checks for CDisplay->World and the 't3dGetPointerFromDictionary' function pointer existing
+			bool IsWorldInitialized();
+			DWORD s3dGetNumSkinsAttachedToHierarchicalSprite(Zeal::EqStructures::_EQMODELINFO* actorModelInfo);
+			struct Zeal::EqStructures::DMSprite* s3dGetSkinAttachedToHierarchicalSprite(int index, Zeal::EqStructures::_EQMODELINFO* actorModelInfo);
+			struct Zeal::EqStructures::DMSprite* s3dGetSkinAttachedToHierarchicalSpriteLinkUpdatesToDAGIndex(int index, Zeal::EqStructures::_EQMODELINFO* actorModelInfo);
+			struct Zeal::EqStructures::DMSpriteDefinition* s3dGetDMSpriteDefinition(struct Zeal::EqStructures::DMSprite* DMSprite);
+			struct Zeal::EqStructures::MaterialPalette* s3dDuplicateMaterialPalette(struct Zeal::EqStructures::MaterialPalette* material_palette);
+			struct Zeal::EqStructures::MaterialPalette* s3dGetDMSpriteMaterialPalette(struct Zeal::EqStructures::DMSprite* dmsprite);
+			int t3dGetObjectTag(void* graphics_object, char* out_tag);
+			Zeal::EqStructures::GraphicsObject* t3dGetPointerFromDictionary(const char* tag);
+		}
 		int GetSpellCastingTime();  // Used by CCastingWnd. Returns -1 if done otherwise in units of 0.1% of time left.
 		DWORD GetLevelCon(Zeal::EqStructures::Entity* ent);
 		bool IsPlayableRace(WORD race);
@@ -241,5 +253,7 @@ namespace Zeal
 		enum class SortType {Ascending, Descending, Toggle};
 		void sort_list_wnd(Zeal::EqUI::ListWnd* list_wnd, int sort_column,
 			SortType sort_type = SortType::Ascending);
+		Zeal::EqStructures::EQDAGINFO* get_dag(Zeal::EqStructures::Entity* entity, int wear_slot, bool alternate = false); // GetDag() - alternate is used for left/right arm,bracer,leg,etc
+		int set_dag_sprite_tint(Zeal::EqStructures::EQDAGINFO* dag, DWORD tint); // CDisplay::SetDagSpriteTint()
 	}
 }

--- a/Zeal/EqStructures.h
+++ b/Zeal/EqStructures.h
@@ -351,6 +351,46 @@ namespace Zeal
 			/* ...... */
 		} EQITEMINFO, * PEQITEMINFO;
 
+		// Common Header for most of the s3d/t3d related objects. Not used by DAGs, though they do have Type at 0x000.
+		struct GraphicsObject
+		{
+			/* 0x000 */  DWORD Type;
+			/* 0x004 */  DWORD Unknown004;
+			/* 0x008 */  char* Tag;
+			/* 0x00C */  DWORD Flags;
+			/* 0x010 */  DWORD RefCount;
+		};
+		struct MaterialDefinition : GraphicsObject
+		{
+			/* 0x0014 */ DWORD Unknown0014;
+			/* 0x0018 */ DWORD ConstantIntensity;
+			/* 0x001C */ DWORD AmbientScalar;
+			/* 0x0020 */ DWORD TwoSided;
+			/* 0x0024 */ struct SimpleSprite* SimpleSprite;
+			/* 0x0028 */ DWORD Unknown0028;
+			/* 0x002C */ DWORD Unknown002C;
+			/* 0x0030 */ DWORD UVShift; // Unsure if swapped with UVShiftMs
+			/* 0x0034 */ DWORD UVShiftMs;
+			/* 0x0038 */ DWORD Unknown0038;
+			/* 0x003C */ DWORD Unknown003C;
+			/* 0x0040 */ char Name[1]; // Object is allocated to fit the name
+		};
+		struct MaterialPalette : GraphicsObject
+		{
+			/* 0x014 */ DWORD NumEntries;
+			/* 0x018 */ MaterialDefinition** Entries;
+			/* 0x01C */ DWORD* Colors;
+			/* 0x020 */ DWORD Unknown020;
+			/* 0x024 */ DWORD CDisplay_0x04_0x08; // CDisplay->World->Unknown008
+		};
+		struct DMSpriteDefinition : GraphicsObject {
+			/* 0x0014 */
+		};
+		struct DMSprite : GraphicsObject {
+			static constexpr DWORD kType = 0x48;
+			/* 0x0014 */
+		};
+
 		struct ViewActor
 		{
 			/* 0x0000 */ DWORD Type;  // Checked if it is set to 0x18 in GetClickedActor()

--- a/Zeal/IO_ini.h
+++ b/Zeal/IO_ini.h
@@ -14,8 +14,10 @@ class IO_ini {
 private:
     std::string filename;
 public:
+
+    static constexpr char kClientFilename[] = ".\\eqclient.ini";
+
     IO_ini(const std::string& filename, bool import_check = false) : filename(filename) {
-        static constexpr char kClientFilename[] = ".\\eqclient.ini";
         if (import_check  && filename != std::string(kClientFilename) && !std::filesystem::exists(filename)) {
             static constexpr int kMaxSectionSize = 32767;  // Maximum size for a section read.
             auto buffer = std::make_unique<char[]>(kMaxSectionSize);

--- a/Zeal/helm_manager.h
+++ b/Zeal/helm_manager.h
@@ -10,14 +10,15 @@ public:
 	HelmManager(class ZealService* zeal);
 	~HelmManager();
 
+    static int GetHeadID(Zeal::EqStructures::Entity* entity, int default_value = 0);
     static WORD GetHelmMaterial(Zeal::EqStructures::EQITEMINFO* item);
-    static WORD ToCanonicalHelmID(WORD material, WORD race);
-    static WORD ToRacialHelmMaterial(WORD material, WORD race, BYTE gender);
+    static WORD GetItemMaterial(Zeal::EqStructures::EQITEMINFO* item);
+    static WORD ToCanonicalHelmMaterial(WORD material, WORD race);
 
     // Hook implementations
-    void HandleWearChangeArmor(int cDisplay, Zeal::EqStructures::Entity* spawn, int wear_slot, WORD new_material, WORD old_material, DWORD color_tint, int local_only);
-    int HandleSwapHead(int cDisplay, Zeal::EqStructures::Entity* entity, int new_material, int old_material, DWORD color, int local_only);
-    int HandleIllusion(Zeal::EqStructures::Entity* entity, Zeal::Packets::Illusion_Struct* illusion);
+    void HandleWearChangeArmor(int* cDisplay, Zeal::EqStructures::Entity* spawn, int wear_slot, WORD new_material, WORD old_material, DWORD color_tint, bool from_server);
+    int HandleSwapHead(int* cDisplay, Zeal::EqStructures::Entity* entity, int new_material, int old_material, DWORD color, bool from_server);
+    int HandleSwapModel(int* cdisplay, Zeal::EqStructures::Entity* entity, BYTE wear_slot, char* ITstr, bool from_server);
 
     // Refreshes your helmet graphics to your current equipment and ShowHelm toggle.
     void RefreshHelm(bool local_only = false, int delay_ms = 64);    
@@ -30,8 +31,8 @@ private:
     bool Handle_In_OP_WearChange(Zeal::Packets::WearChange_Struct* data);
     bool Handle_Out_OP_WearChange(Zeal::Packets::WearChange_Struct * data);
 
-    // Checks if this race/gender combination needs special handling for Velious helms
-    bool IsHelmBuggedOldModel(WORD race, BYTE gender);
+    // Checks if this race/gender combination can be fixed
+    bool IsPatchedOldModel(WORD race, BYTE gender);
 
     void RefreshHelmCallback(bool local_only);
 
@@ -39,11 +40,11 @@ private:
     void OnZone();
 
     // Sends the '#showhelm' command to the server with our current toggle.
-    void SyncShowHelm(bool server_silent);
+    void SyncShowHelm(bool hide_response);
 
     // This call generally doesn't succeed until partway into the enter-world process.
     // So we do just-in-time detection when the first SwapHead() hook is called.
-    void DetectInstalledFixes();
+    bool DetectInstalledFixes();
 
     // Suppresses outbound helm WearChange packets from being sent when positive.
     // Sometimes enabled when we are internally manipulating things and don't want that to generate uncessary outbound packets.
@@ -52,7 +53,6 @@ private:
 
     // Used by RefreshHelmetCallback to prevent running multiple times if queued in succession.
     bool refresh_helm_pending = false;
-    Zeal::Packets::WearChange_Struct last_wc = { 0 };
 
     // We do some initialization on enter world once per-character
     std::string last_seen_character = "";

--- a/Zeal/memory.cpp
+++ b/Zeal/memory.cpp
@@ -139,4 +139,30 @@ namespace mem
 		memcpy((void*)buffer, (const void*)target, size);
 		VirtualProtect((PVOID*)target, size, oldprotect, &oldprotect);
 	}
+	void fill_with_nop(int start_address, int until_address, BYTE* buffer) {
+
+		int size = until_address - start_address;
+		if (size <= 0) {
+			return;
+		}
+
+		int target = start_address;
+		BYTE nop2[] = { 0x66, 0x90 }; // 0x66 0x99 (safe, officially recognized as a 2-byte NOP).
+
+		DWORD oldprotect;
+		VirtualProtect((PVOID*)target, size, PAGE_EXECUTE_READWRITE, &oldprotect);
+		if (buffer)
+			memcpy((void*)buffer, (const void*)target, size);
+
+		while (size >= 2) {
+			memcpy((void*)target, nop2, 2); 
+			size -= 2;
+			target += 2;
+		}
+		if (size == 1) {
+			memcpy((void*)target, &nop2[1], 1);
+		}
+
+		VirtualProtect((PVOID*)target, size, oldprotect, &oldprotect);
+	}
 }

--- a/Zeal/memory.h
+++ b/Zeal/memory.h
@@ -48,6 +48,7 @@ namespace mem
 	void copy(int target, BYTE* source, int size, BYTE* orig_buffer = nullptr);
 	void copy(int target, int source, int size, BYTE* orig_buffer = nullptr);
 	void get(int target, int size, BYTE* buffer = nullptr);
+	void fill_with_nop(int start_address, int until_address, BYTE* buffer = nullptr);
 	void unprotect_memory(PVOID target, size_t size);
 	void reset_memory_protection(PVOID target);
 	extern std::unordered_map<PVOID, mem_protect> protections;


### PR DESCRIPTION
## HelmManager
- Finalized strategy for handling Velious Helms. Using HEAD05 as the "Bald Head" rather than HEAD00. Which avoids all compatibility concerns with non-Zeal clients. So we don't need to modify HEAD00-HEAD03 at all with the distributed global_chr.s3d
- Improved Legacy model detection to consider `AllLuclinPcModelsOff=TRUE/FALSE`.
- Added Tint support for Velious Helms (Custom Cowl of Mortality).
- Added Tint support for Weapons.
- Internal cleanup to use byte patches and general logic upgrades.

Could potentially name this to appearance_manager, but that can be done afterwards when no further edits are needed.

I don't think toggles are needed for the Helm/Weapon tint support, as those are just part of the game. If needed, those will be Quarm features that can be turned on/off/modified via in-game quests, if anything, and the tints will be sent over from the server.