### PR TITLE
Bump to 0.6.5-alpha0: Add /assist failure detection, /uilock, /lootlast, and extend /protect to trades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ Nameplates
   - Due to client data limitations, only applies to self, group, pet, target
 
 Targetring:
-* Add target_color option that uses targer color instead of con color
+* Add target_color option that uses target color instead of con color
+* Add option to disable self target ring
 
 Map:
 * Added a small dull yellow position marker for self-pet if show group members is enabled

--- a/README.md
+++ b/README.md
@@ -238,6 +238,10 @@ ___
   - **Arguments:** `on`, `off`
   - **Description:** Disables (on) click on self in third person and allows 'u' to activate doors.
 
+- `/uilock`
+  - **Arguments:** `on`, `off`
+  - **Description:** Sets (on) or clears (off) the UI Lock value on primary game windows. Bag windows must be open to take effect.
+
 - `/useitem`
   - **Arguments:** `slot_#` (+ optional `quiet` that suppresses warnings if no click effect)
   - **Description:** Activates a click effect on item in slot_#.

--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ ___
 - `/lootall`
   - **Description:** loots all items from a corpse if looting window is open.
 
+- `/lootlast`
+  - **Arguments:** `item_id_#`, `item_link`, or `0` to disable_
+  - **Description:** specifies an item ID that will be left as the last item when using /lootall on your corpse 
+ 
 - `/melody`
   - **Arguments:** `song gem #'s (maximum of 5)`
   - **Aliases:** `/mel`

--- a/README.md
+++ b/README.md
@@ -178,8 +178,10 @@ ___
           upon as the primary method of protection and you will not be reimbursed if it doesn't protect
           you from your own mistake.  Zeal intercepts the client calls to sell, destroy, or drop cursor
           contents and blocks the action if it is a non-empty container, the item_value is >= value (not
-          checked for sell), or the item is on the protect list. The enable, value, and protected list
-          are stored per character with the list stored in the `./<character_name>_protected.ini` file.
+          checked for sell), or the item is on the protect list. It also protects against all trades to
+          banker NPCs and trades of protected items or non-empty bags to NPCs (including pets). The
+          enable, value, and protected list are stored per character with the list stored in the
+          `./<character_name>_protected.ini` file.
 
 - `/hidecorpse`
   - **Arguments:** `looted`, `none`

--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -444,6 +444,10 @@ namespace Zeal
 			reinterpret_cast<void(__thiscall*)(int everquest, const char* name, int len)>(0x538110)(*(int*)0x809478, temp_buffer, 1);
 			data = temp_buffer;
 		}
+		Zeal::EqStructures::Entity* get_player_partial_name(const char* name)
+		{
+			return reinterpret_cast<Zeal::EqStructures::Entity * (__cdecl*)(const char* name)>(0x0050820e)(name);
+		}
 		void log(std::string& data)
 		{
 			reinterpret_cast<void(__cdecl*)(const char* data)>(0x5240dc)(data.c_str());
@@ -1839,7 +1843,7 @@ namespace Zeal
 		void set_target(Zeal::EqStructures::Entity* target)
 		{
 			auto old_target = Zeal::EqGame::get_target();
-			if (!target)
+			if (old_target && !target)
 				print_chat(get_string(0x3057)); //you no longer have a target
 			*(Zeal::EqStructures::Entity**)Zeal::EqGame::Target = target;
 

--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -125,6 +125,7 @@ namespace Zeal
 		float CalcZOffset(Zeal::EqStructures::Entity* ent);
 		float CalcBoundingRadius(Zeal::EqStructures::Entity* ent);
 		void DoPercentConvert(std::string& str);
+		Zeal::EqStructures::Entity* get_player_partial_name(const char* name);
 		void move_item(int a1, int slot, int a2, int a3);
 		bool can_inventory_item(Zeal::EqStructures::EQITEMINFO* item);
 		// Checks if the race/class/deity etc can equip this item

--- a/Zeal/EqPackets.h
+++ b/Zeal/EqPackets.h
@@ -16,7 +16,8 @@ namespace Zeal
             HPUpdate = 0x40b2, // Note: Shared with MobHealth.
             RequestTrade = 0x40D1,
             WearChange = 0x4092,
-            Illusion = 0x4091
+            Illusion = 0x4091,
+            Assist = 0x4200,
         };
         struct TradeRequest_Struct {
             /*000*/	UINT16 to_id;
@@ -56,6 +57,11 @@ namespace Zeal
             /*016*/	UINT8   is_PC;
             /*017*/	UINT8   unknown015[3];
             /*020*/
+        };
+        struct EntityId_Struct
+        {
+            /*000*/	INT16 entity_id;
+            /*002*/
         };
         struct ClientTarget_Struct
         {

--- a/Zeal/EqStructures.h
+++ b/Zeal/EqStructures.h
@@ -785,8 +785,8 @@ namespace Zeal
 			/* 0x0090 */ FLOAT ModelHeightOffset;
 			/* 0x0094 */ WORD SpawnId;
 			/* 0x0096 */ WORD PetOwnerSpawnId; // spawn id of the owner of this pet spawn
-			/* 0x0098 */ DWORD HpMax;
-			/* 0x009C */ DWORD HpCurrent;
+			/* 0x0098 */ INT HpMax;
+			/* 0x009C */ INT HpCurrent;  // Can go negative (unconscious).
 			/* 0x00A0 */ short GuildId;  // -1 is unguilded
 			/* 0x00A2 */ BYTE Unknown00A2[6];
 			/* 0x00A8 */ BYTE Type; // EQ_SPAWN_TYPE_x

--- a/Zeal/EqUI.h
+++ b/Zeal/EqUI.h
@@ -672,11 +672,11 @@ namespace Zeal
 			/*0x17c*/
 		};
 
-		// Actual Size 0x54  eqmac fixed
+		// Actual Size 0x54 in eqgame.
 		class ContainerMgr {
 		public:
 			/*0x000*/   DWORD pvfTable; // NOT based on CXWnd.  Contains only destructor
-			/*0x004*/   ContainerWnd pPCContainers[0x11];  // All open containers, including World, in order of opening...
+			/*0x004*/   ContainerWnd* pPCContainers[0x11];  // All open containers, including World, in order of opening...
 			/*0x048**/  DWORD*   pWorldItems;            // Pointer to the contents of the world   If NULL, world container isn't open;
 			/*0x04c*/   DWORD Unknown0x04c;            // in the future this is ID of container in zone, starts at one (zero?) and goes up.
 			/*0x050*/   DWORD dwTimeSpentWithWorldContainerOpen;  // Cumulative counter?

--- a/Zeal/Zeal.cpp
+++ b/Zeal/Zeal.cpp
@@ -57,6 +57,7 @@ ZealService::ZealService()
 	entity_manager = std::make_shared<EntityManager>(this, ini.get());
 	camera_mods = std::make_shared<CameraMods>(this, ini.get());
 	cycle_target = std::make_shared<CycleTarget>(this);
+	assist = std::make_shared<Assist>(this);
 	experience = std::make_shared<Experience>(this);
 	chat_hook = std::make_shared<chat>(this, ini.get());
 	chatfilter_hook = std::make_shared<chatfilter>(this, ini.get());
@@ -259,6 +260,9 @@ ZealService::~ZealService()
 	hooks.reset();
 	autofire.reset();
 	melody.reset();
+	nameplate.reset();
+	target_ring.reset();
+	zone_map.reset();
 	ui.reset();
 	netstat.reset();
 	alarm.reset();
@@ -269,6 +273,7 @@ ZealService::~ZealService()
 	chatfilter_hook.reset();
 	experience.reset();
 	cycle_target.reset();
+	assist.reset();
 	camera_mods.reset();
 	item_displays.reset();
 	spell_sets.reset();
@@ -282,5 +287,5 @@ ZealService::~ZealService()
 	helm.reset();
 	commands_hook.reset();
 	ini.reset();
-	
+
 }

--- a/Zeal/Zeal.h
+++ b/Zeal/Zeal.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "framework.h"
-#define ZEAL_VERSION "0.6.4"
+#define ZEAL_VERSION "0.6.5-alpha0"
 #ifndef ZEAL_BUILD_VERSION  // Set by github actions
 #define ZEAL_BUILD_VERSION "UNOFFICIAL"  // Local build
 #endif
@@ -40,6 +40,7 @@ public:
 	std::shared_ptr<OutputFile> outputfile = nullptr;
 	std::shared_ptr<Experience> experience = nullptr;
 	std::shared_ptr<CycleTarget> cycle_target = nullptr;
+	std::shared_ptr<Assist> assist = nullptr;
 	std::shared_ptr<BuffTimers> buff_timers = nullptr;
 	std::shared_ptr<PlayerMovement> movement = nullptr;
 	std::shared_ptr<Alarm> alarm = nullptr;

--- a/Zeal/Zeal.vcxproj
+++ b/Zeal/Zeal.vcxproj
@@ -160,6 +160,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="alarm.h" />
+    <ClInclude Include="assist.h" />
     <ClInclude Include="autofire.h" />
     <ClInclude Include="bitmap_font.h" />
     <ClInclude Include="chatfilter.h" />
@@ -232,6 +233,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="alarm.cpp" />
+    <ClCompile Include="assist.cpp" />
     <ClCompile Include="autofire.cpp" />
     <ClCompile Include="bitmap_font.cpp" />
     <ClCompile Include="chatfilter.cpp" />

--- a/Zeal/Zeal.vcxproj.filters
+++ b/Zeal/Zeal.vcxproj.filters
@@ -258,6 +258,9 @@
     <ClInclude Include="music.h">
       <Filter>Header Files\hooks</Filter>
     </ClInclude>
+    <ClInclude Include="assist.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
@@ -439,6 +442,9 @@
     </ClCompile>
     <ClCompile Include="music.cpp">
       <Filter>Source Files\hooks</Filter>
+    </ClCompile>
+    <ClCompile Include="assist.cpp">
+      <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Zeal/assist.cpp
+++ b/Zeal/assist.cpp
@@ -1,0 +1,77 @@
+#include "assist.h"
+#include "Zeal.h"
+#include "EqFunctions.h"
+#include "string_util.h"
+
+
+Assist::Assist(ZealService* zeal)
+{
+	zeal->commands_hook->Add("/assist", {}, "Supports optional per character settings for /assist on/off.",
+		[this](std::vector<std::string>& args) { return handle_assist_command(args); });
+
+	zeal->callbacks->AddPacket([this](UINT opcode, char* buffer, UINT len) {
+		if (opcode == Zeal::Packets::Assist && len == sizeof(Zeal::Packets::EntityId_Struct))
+			return handle_assist_response(reinterpret_cast<Zeal::Packets::EntityId_Struct*>(buffer));
+		return false; // continue processing
+		}, callback_type::WorldMessage);
+}
+
+Assist::~Assist()
+{
+}
+
+bool Assist::handle_assist_command(const std::vector<std::string>& args)
+{
+	if (!setting_use_zeal_assist_on.get() && !setting_detect_assist_failure.get())
+		return false;  // Disabled, use /normal assist.
+
+	// If no target param, either there's a target and the OP_Assist will be sent or the client's
+	// /assist handler will print out a usage format message.
+	if (args.size() == 1)
+		return false;
+
+	// The default client ignores parameters beyond args[1], so we'll do the same.
+	bool turn_on = Zeal::String::compare_insensitive(args[1], "on");
+	bool turn_off = !turn_on && Zeal::String::compare_insensitive(args[1], "off");
+	if (turn_on || turn_off) {
+		if (setting_use_zeal_assist_on.get()) {
+			setting_assist_on.set(turn_on);
+			Zeal::EqGame::set_attack_on_assist(turn_on);
+			Zeal::EqGame::print_chat("Per character attack on assist: %s",
+				turn_on ? "ON" : "OFF");
+			return true;  // Skip normal /assist processing.
+		}
+		return false;  // Let normal /assist handle the on or off.
+	}
+
+	if (setting_detect_assist_failure.get()) {
+		// Duplicate the /assist command code to check that an OP_Assist message will go out that
+		// can be monitored for success.
+		std::string name = args[1];
+		Zeal::EqGame::DoPercentConvert(name);
+		if (!Zeal::EqGame::get_player_partial_name(name.c_str())) {
+			Zeal::EqGame::print_chat(USERCOLOR_SHOUT, "Assistee %s not found!", name.c_str());
+			Zeal::EqGame::set_target(nullptr);  // Will emit message if had a target.
+			return true;
+		}
+	}
+
+	return false;  // Let normal /assist process the args.
+}
+
+bool Assist::handle_assist_response(const Zeal::Packets::EntityId_Struct* packet) {
+	// If the assist request failed, the response will contain either -1 or self->SpawnId depending on
+	// RuleB(Combat, AssistNoTargetSelf). The latter is difficult to be 100% sure if it is a failure
+	// or a desired result (like assisting a mob for heals that is targeting you now), and since it is
+	// a server flag we just emit a warning.
+	if (setting_detect_assist_failure.get() && packet) {
+		if (packet->entity_id == -1) {
+			Zeal::EqGame::print_chat(USERCOLOR_SHOUT, "Assist failed! (Out of range or no assistee target)");
+			Zeal::EqGame::set_target(nullptr);  // Will emit message if had a target.
+			return true;  // Skip downstream response handling.
+		}
+		else if (Zeal::EqGame::get_self() && Zeal::EqGame::get_self()->SpawnId == packet->entity_id)
+			Zeal::EqGame::print_chat(USERCOLOR_SHOUT, "Assist targeting self.");  // Just warn.
+	}
+	return false;
+}

--- a/Zeal/assist.h
+++ b/Zeal/assist.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "EqStructures.h"
+#include "ZealSettings.h"
+
+// Enhancements for the /assist command. Separate class since commands.cpp can't use settings.
+class Assist
+{
+public:
+	Assist(class ZealService* zeal);
+	~Assist();
+
+	// Assist on/off per character support.
+	ZealSetting<bool> setting_assist_on = { false, "Zeal", "AssistOn", true };
+	ZealSetting<bool> setting_use_zeal_assist_on = { false, "Zeal", "UseZealAssistOn", true,
+		[this](bool val) {if (val) Zeal::EqGame::set_attack_on_assist(setting_assist_on.get()); },
+		true };
+
+	// Support for detecting / reporting that /assist failed to update to a new target.
+	ZealSetting<bool> setting_detect_assist_failure = { false, "Zeal", "DetectAssistFailure", true };
+
+protected:
+	bool handle_assist_command(const std::vector<std::string>& args);
+	bool handle_assist_response(const Zeal::Packets::EntityId_Struct* packet);
+};
+

--- a/Zeal/cycle_target.cpp
+++ b/Zeal/cycle_target.cpp
@@ -114,20 +114,4 @@ CycleTarget::CycleTarget(ZealService* zeal)
 {
 	//originally this used a hook and replaced target nearest but now uses a bind
 	//	hook = zeal->hooks->Add("NearestEnt", Zeal::EqGame::EqGameInternal::fn_targetnearestnpc, get_nearest_ent, hook_type_detour, 6);
-
-	zeal->commands_hook->Add("/assist", {}, "Supports optional per character settings for /assist on/off.",
-		[this](std::vector<std::string>& args) {
-			if (setting_use_zeal_assist_on.get() && args.size() == 2) {
-				bool turn_on = Zeal::String::compare_insensitive(args[1], "on");
-				bool turn_off = !turn_on && Zeal::String::compare_insensitive(args[1], "off");
-				if (turn_on || turn_off) {
-					setting_assist_on.set(turn_on);
-					Zeal::EqGame::set_attack_on_assist(turn_on);
-					Zeal::EqGame::print_chat("Per character attack on assist: %s",
-						turn_on ? "ON" : "OFF");
-					return true;  // Skip normal /assist processing.
-				}
-			}
-			return false;  // Let normal /assist handle things.
-		});
 }

--- a/Zeal/cycle_target.h
+++ b/Zeal/cycle_target.h
@@ -2,7 +2,7 @@
 #include "hook_wrapper.h"
 #include "memory.h"
 #include "EqStructures.h"
-#include "ZealSettings.h"
+
 class CycleTarget
 {
 public:
@@ -11,12 +11,6 @@ public:
 	Zeal::EqStructures::Entity* get_next_ent(float dist, BYTE type);
 	Zeal::EqStructures::Entity* get_nearest_ent(float dist, BYTE type);
 
-	// Assist on/off placed here since commands.cpp can't use settings and it is target related.
-	ZealSetting<bool> setting_assist_on = { false, "Zeal", "AssistOn", true };
-
-	ZealSetting<bool> setting_use_zeal_assist_on = { false, "Zeal", "UseZealAssistOn", true,
-		[this](bool val) {if (val) Zeal::EqGame::set_attack_on_assist(setting_assist_on.get()); },
-		true };
 private:
-	hook* hook;
+	//hook* hook;
 };

--- a/Zeal/floating_damage.cpp
+++ b/Zeal/floating_damage.cpp
@@ -253,12 +253,13 @@ void FloatingDamage::handle_hp_update_packet(const Zeal::Packets::SpawnHPUpdate_
 	auto color = D3DCOLOR_XRGB(0x00, 0xff, 0x00);
 	// Self hp updates are in hitpoints.
 	if (entity == Zeal::EqGame::get_self()) {
-		int delta_hps = packet->cur_hp - entity->HpCurrent;
-		if (delta_hps > 0)
-			damage_numbers[entity].push_back(DamageData(-delta_hps, false, nullptr, color, false));
+		// Disabling since the cur_hp does not include various HP modifications (like armor)
+		// and the client updates itself from spells and buffs.
+		// int delta_hps = packet->cur_hp - entity->HpCurrent;
+		// if (delta_hps > 0)
+		//	damage_numbers[entity].push_back(DamageData(-delta_hps, false, nullptr, color, false));
 		return;
 	}
-
 
 	// NPCs are sent in percent.
 	const int kMinPercent = 5;  // Do not report HP updates < 5% since those can be normal tick regens.

--- a/Zeal/framework.h
+++ b/Zeal/framework.h
@@ -29,6 +29,7 @@
 // other features
 #include "NPCGive.h"
 #include "cycle_target.h"
+#include "assist.h"
 #include "outputfile.h"
 #include "experience.h"
 #include "buff_timers.h"

--- a/Zeal/item_display.h
+++ b/Zeal/item_display.h
@@ -10,6 +10,7 @@ public:
 	ItemDisplay(class ZealService* pHookWrapper, class IO_ini* ini);
 	~ItemDisplay();
 	Zeal::EqUI::ItemDisplayWnd* get_available_window(Zeal::EqStructures::EQITEMINFOBASE* item = nullptr);
+	std::vector<Zeal::EqUI::ItemDisplayWnd*> get_windows() { return windows; }  // For short-term use only.
 	bool close_latest_window();
 private:
 	void InitUI();

--- a/Zeal/looting.h
+++ b/Zeal/looting.h
@@ -21,6 +21,7 @@ public:
 	// /protect functionality.  Command line-only for now.
 	bool is_cursor_protected(const Zeal::EqStructures::EQCHARINFO* char_info) const;
 	bool is_item_protected_from_selling(const Zeal::EqStructures::EQITEMINFO* item_info) const;
+	bool is_trade_protected(struct Zeal::EqUI::TradeWnd* wnd) const;
 
 protected:
 	ZealSetting<bool> setting_protect_enable = { false, "Protect", "Enabled", true };

--- a/Zeal/looting.h
+++ b/Zeal/looting.h
@@ -25,11 +25,13 @@ public:
 protected:
 	ZealSetting<bool> setting_protect_enable = { false, "Protect", "Enabled", true };
 	ZealSetting<int> setting_protect_value = { 10, "Protect", "Value", true };
+	ZealSetting<int> setting_loot_last_item = { 0, "Zeal", "LootLastItem", true };
 
 	struct ProtectedItem {
 		int id;
 		std::string name;
 	};
+	bool parse_loot_last(const std::vector<std::string>& args);
 	bool parse_protect(const std::vector<std::string>& args);
 	void update_protected_item(int item_id, const std::string& name);
 	void load_protected_items();

--- a/Zeal/ui_manager.h
+++ b/Zeal/ui_manager.h
@@ -61,6 +61,8 @@ public:
 	void CreateTmpXML();
 
 private:
+	bool handle_uilock(const std::vector<std::string>& args);
+
 	std::vector<std::string> XMLIncludes;
 	std::unordered_map<std::string, Zeal::EqUI::BasicWnd*> checkbox_names;
 	std::unordered_map<std::string, Zeal::EqUI::BasicWnd*> button_names;

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -319,9 +319,9 @@ void ui_options::InitGeneral()
 	ui->AddCheckboxCallback(wnd, "Zeal_BrownSkeletons",			[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->game_patches->BrownSkeletons.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_ClassicMusic",			[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->music->ClassicMusic.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_SuppressMissedNotes",	[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->chatfilter_hook->setting_suppress_missed_notes.set(wnd->Checked); });
-	ui->AddCheckboxCallback(wnd, "Zeal_UseZealAssistOn",		[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->cycle_target->setting_use_zeal_assist_on.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_UseZealAssistOn",		[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->assist->setting_use_zeal_assist_on.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_DetectAssistFailure",	[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->assist->setting_detect_assist_failure.set(wnd->Checked); });
 
-	
 	ui->AddCheckboxCallback(wnd, "Zeal_LinkAllAltDelimiter",    [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->looting_hook->setting_alt_delimiter.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_EnableContainerLock",    [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->ui->options->setting_enable_container_lock.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_ExportOnCamp",           [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->outputfile->setting_export_on_camp.set(wnd->Checked); });
@@ -608,7 +608,8 @@ void ui_options::UpdateOptionsGeneral()
 	ui->SetChecked("Zeal_BrownSkeletons", ZealService::get_instance()->game_patches->BrownSkeletons.get());
 	ui->SetChecked("Zeal_ClassicMusic", ZealService::get_instance()->music->ClassicMusic.get());
 	ui->SetChecked("Zeal_SuppressMissedNotes", ZealService::get_instance()->chatfilter_hook->setting_suppress_missed_notes.get());
-	ui->SetChecked("Zeal_UseZealAssistOn", ZealService::get_instance()->cycle_target->setting_use_zeal_assist_on.get());
+	ui->SetChecked("Zeal_UseZealAssistOn", ZealService::get_instance()->assist->setting_use_zeal_assist_on.get());
+	ui->SetChecked("Zeal_DetectAssistFailure", ZealService::get_instance()->assist->setting_detect_assist_failure.get());
 }
 void ui_options::UpdateOptionsCamera()
 {

--- a/Zeal/ui_options.h
+++ b/Zeal/ui_options.h
@@ -17,10 +17,12 @@ public:
 	void SaveColors() const;
 	void LoadColors();
 	DWORD GetColor(int index) const;
+	Zeal::EqUI::EQWND* GetZealOptionsWindow() { return wnd; }  // Only use for short-term access.
 	ui_options(class ZealService* zeal, class IO_ini* ini, class ui_manager* mgr);
 	~ui_options();
 
 	ZealSetting<bool> setting_enable_container_lock = { false, "Zeal", "EnableContainerLock", false };
+
 
 private:
 	void InitUI();

--- a/Zeal/uifiles/zeal/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_General.xml
@@ -782,6 +782,36 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
+  <Button item="Zeal_DetectAssistFailure">
+    <ScreenID>Zeal_DetectAssistFailure</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>508</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Emits a message and clears target if /assist fails</TooltipReference>
+    <Text>Detect assist failure</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
   <!-- end -->
     
   <Page item="Tab_General">
@@ -834,6 +864,7 @@
     <Pieces>Zeal_ClassicMusic</Pieces>
     <Pieces>Zeal_SuppressMissedNotes</Pieces>
     <Pieces>Zeal_UseZealAssistOn</Pieces>
+    <Pieces>Zeal_DetectAssistFailure</Pieces>
     <Location>
       <X>0</X>
       <Y>22</Y>

--- a/Zeal/zone_map.h
+++ b/Zeal/zone_map.h
@@ -102,6 +102,8 @@ public:
 	void add_dynamic_label(const std::string& label, int loc_y, int loc_x,
 		unsigned int duration_ms = 0, D3DCOLOR font_color = D3DCOLOR_XRGB(250, 250, 51));
 
+	Zeal::EqUI::EQWND* get_internal_window() { return wnd; }  // For short-term use only.
+
 	// Private methods exposed for callback use only.
 	void process_mouse_wheel(int16_t mouse_delta, uint16_t flags, int16_t x, int16_t y);
 	void process_left_mouse_button_down(int16_t x, int16_t y);


### PR DESCRIPTION
- Bumped version to 0.6.5-alpha0

- Added a new zeal general tab option to detect /assist failures
    - clears target and emits warning

- Added a new /uilock command that supports on and off toggling
      of the UI Lock state for primary game windows
  - Bags must be open to take effect

- Added a /lootlast command that specifies an item ID (either
      by a direct number or using an item link) that will be looted
      last during /lootall of your own corpse (and thus not looted
      since /lootall leaves an item on your own corpse)

- General /protect on now blocks all trades to bankers (money, items)
  - Item and non-empty bag protection now applies to trades to NPCs
      and pets (value is not checked)

 - Also fixed a health calc wraparound issue for health bars caused
      by an incorrect unsigned variable definition in the entity struct
      and disabled the FCD self heals since they are currently inaccurate