### PR TITLE
Add run command and option to suppress non-grouped caster fizzle messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,10 @@ ___
   - **Aliases:** `/cleartarget`
   - **Description:** acts as normal /target unless you provide no argument in which case it will clear your target.
 
+- `/run`
+  - **Arguments:** none (toggles), `on` (run), `off` (walk)
+  - **Description:** Controls run versus walk mode.
+
 - `/sit`
   - **Description:** The /sit command now accepts "on" as an argument. Using "/sit on" will always make you sit, even if you are currently sitting. This matches the game's native "/sit off" which always makes you stand even if you are currently standing. The "/sit" command will continue to toggle sit/stand state if no argument is provided or if the argument provided is not on or off. Additionally, "/sit down" now works as well and will always make you sit, even if already sitting.
 

--- a/Zeal/chatfilter.h
+++ b/Zeal/chatfilter.h
@@ -47,8 +47,10 @@ class chatfilter
 	void LoadSettings(Zeal::EqUI::CChatManager* cm);
 	void callback_clean_ui();
 	ZealSetting<bool> setting_suppress_missed_notes = { false, "Zeal", "SuppressMissedNotes", false };
+	ZealSetting<bool> setting_suppress_other_fizzles = { false, "Zeal", "SupressOtherFizzles", false };
 	bool isExtendedCM(int channelMap, int applyOffset = 0);
 	bool isStandardCM(int channelMap, int applyOffset = 0);
+	int current_string_id = 0;
 	bool isDamage=false;
 	bool isMyPetSay=false;
 	bool isPetMessage=false;

--- a/Zeal/commands.cpp
+++ b/Zeal/commands.cpp
@@ -323,6 +323,21 @@ ChatCommands::ChatCommands(ZealService* zeal)
 			}
 			return false;
 		});
+	Add("/run", {}, "Sets run mode (toggle, on, off (walk)).",
+		[](const std::vector<std::string>& args) {
+			BYTE* run_mode = reinterpret_cast<BYTE*>(0x0079856d);
+			if (args.size() == 2 && Zeal::String::compare_insensitive(args[1], "on"))
+				*run_mode = 1;
+			else if (args.size() == 2 && Zeal::String::compare_insensitive(args[1], "off"))
+				*run_mode = 0;
+			else if (args.size() == 1) {
+				*run_mode = (*run_mode == 0);
+				Zeal::EqGame::print_chat("%s", *run_mode ? "Run on" : "Walk on");
+			}
+			else
+				Zeal::EqGame::print_chat("Usage: /run (toggles), /run on, /run off");
+			return true;
+		});
 	Add("/showhelm", { "/helm" }, "Toggles your show helm setting on/off.",
 		[](std::vector<std::string>& args) {
 			if (args.size() == 1) {

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -319,6 +319,7 @@ void ui_options::InitGeneral()
 	ui->AddCheckboxCallback(wnd, "Zeal_BrownSkeletons",			[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->game_patches->BrownSkeletons.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_ClassicMusic",			[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->music->ClassicMusic.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_SuppressMissedNotes",	[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->chatfilter_hook->setting_suppress_missed_notes.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_SuppressOtherFizzles",	[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->chatfilter_hook->setting_suppress_other_fizzles.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_UseZealAssistOn",		[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->assist->setting_use_zeal_assist_on.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_DetectAssistFailure",	[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->assist->setting_detect_assist_failure.set(wnd->Checked); });
 
@@ -608,6 +609,7 @@ void ui_options::UpdateOptionsGeneral()
 	ui->SetChecked("Zeal_BrownSkeletons", ZealService::get_instance()->game_patches->BrownSkeletons.get());
 	ui->SetChecked("Zeal_ClassicMusic", ZealService::get_instance()->music->ClassicMusic.get());
 	ui->SetChecked("Zeal_SuppressMissedNotes", ZealService::get_instance()->chatfilter_hook->setting_suppress_missed_notes.get());
+	ui->SetChecked("Zeal_SuppressOtherFizzles", ZealService::get_instance()->chatfilter_hook->setting_suppress_other_fizzles.get());
 	ui->SetChecked("Zeal_UseZealAssistOn", ZealService::get_instance()->assist->setting_use_zeal_assist_on.get());
 	ui->SetChecked("Zeal_DetectAssistFailure", ZealService::get_instance()->assist->setting_detect_assist_failure.get());
 }

--- a/Zeal/uifiles/zeal/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_General.xml
@@ -752,12 +752,42 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
+  <Button item="Zeal_SuppressOtherFizzles">
+    <ScreenID>Zeal_SuppressOtherFizzles</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>486</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Suppress fizzle messages from non-grouped casters</TooltipReference>
+    <Text>Reduce fizzles</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>  
   <Button item="Zeal_UseZealAssistOn">
     <ScreenID>Zeal_UseZealAssistOn</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>486</Y>
+      <Y>508</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -787,7 +817,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>508</Y>
+      <Y>530</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -863,6 +893,7 @@
     <Pieces>Zeal_BrownSkeletons</Pieces>
     <Pieces>Zeal_ClassicMusic</Pieces>
     <Pieces>Zeal_SuppressMissedNotes</Pieces>
+    <Pieces>Zeal_SuppressOtherFizzles</Pieces>
     <Pieces>Zeal_UseZealAssistOn</Pieces>
     <Pieces>Zeal_DetectAssistFailure</Pieces>
     <Location>


### PR DESCRIPTION
* Add /run command
    - New command that controls run versus walk mode
      - /run (toggles), /run on, /run off (walk)
     
*  Add option to suppress fizzles msgs from non-group
    - Added a zeal general tab option to suppress fizzle messages
      from non-grouped casters