### PR TITLE
Add map option to show raid member headings

### DIFF
--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -421,6 +421,7 @@ void ui_options::InitMap()
 	ui->AddCheckboxCallback(wnd, "Zeal_MapShowRaid", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->zone_map->set_show_raid(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_MapShowGrid", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->zone_map->set_show_grid(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_MapAddLocText", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->zone_map->setting_add_loc_text.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_MapShowPlayerHeadings", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->zone_map->setting_show_all_player_headings.set(wnd->Checked); });
 	ui->AddComboCallback(wnd, "Zeal_MapShowGroup_Combobox", [this](Zeal::EqUI::BasicWnd* wnd, int value) { ZealService::get_instance()->zone_map->set_show_group_mode(value); });
 	ui->AddComboCallback(wnd, "Zeal_MapBackground_Combobox", [this](Zeal::EqUI::BasicWnd* wnd, int value) { ZealService::get_instance()->zone_map->set_background(value); });
 	ui->AddComboCallback(wnd, "Zeal_MapAlignment_Combobox", [this](Zeal::EqUI::BasicWnd* wnd, int value) { ZealService::get_instance()->zone_map->set_alignment(value); });
@@ -732,6 +733,7 @@ void ui_options::UpdateOptionsMap()
 	ui->SetChecked("Zeal_MapShowRaid", ZealService::get_instance()->zone_map->is_show_raid_enabled());
 	ui->SetChecked("Zeal_MapShowGrid", ZealService::get_instance()->zone_map->is_show_grid_enabled());
 	ui->SetChecked("Zeal_MapAddLocText", ZealService::get_instance()->zone_map->setting_add_loc_text.get());
+	ui->SetChecked("Zeal_MapShowPlayerHeadings", ZealService::get_instance()->zone_map->setting_show_all_player_headings.get());
 	ui->SetComboValue("Zeal_MapShowGroup_Combobox", ZealService::get_instance()->zone_map->get_show_group_mode());
 	ui->SetComboValue("Zeal_MapBackground_Combobox", ZealService::get_instance()->zone_map->get_background());
 	ui->SetComboValue("Zeal_MapAlignment_Combobox", ZealService::get_instance()->zone_map->get_alignment());

--- a/Zeal/uifiles/zeal/EQUI_Tab_Map.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_Map.xml
@@ -388,13 +388,44 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
+  <!-- Zeal Map Show Player Headings-->
+  <Button item="Zeal_MapShowPlayerHeadings">
+    <ScreenID>Zeal_MapShowPlayerHeadings</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>401</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Shows all player headings</TooltipReference>
+    <Text>Show Headings</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
   <!-- Zeal Map Names Length -->
   <Label item="Zeal_MapNamesLength_Label">
     <ScreenID>Zeal_MapNamesLength_Label</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>409</Y>
+      <Y>431</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -415,7 +446,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>429</Y>
+      <Y>451</Y>
     </Location>
     <Size>
       <CX>100</CX>
@@ -428,7 +459,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>110</X>
-      <Y>429</Y>
+      <Y>451</Y>
     </Location>
     <Size>
       <CX>40</CX>
@@ -450,7 +481,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>452</Y>
+      <Y>474</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -481,7 +512,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>482</Y>
+      <Y>504</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -502,7 +533,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>502</Y>
+      <Y>524</Y>
     </Location>
     <Size>
       <CX>100</CX>
@@ -515,7 +546,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>110</X>
-      <Y>502</Y>
+      <Y>524</Y>
     </Location>
     <Size>
       <CX>40</CX>
@@ -991,6 +1022,7 @@
     <Style_Sizable>true</Style_Sizable>
     <Pieces>Zeal_Map</Pieces>
     <Pieces>Zeal_MapShowRaid</Pieces>
+    <Pieces>Zeal_MapShowPlayerHeadings</Pieces>
     <Pieces>Zeal_MapShowGrid</Pieces>
     <Pieces>Zeal_MapInteractiveEnable</Pieces>
     <Pieces>Zeal_MapExternalWindow</Pieces>

--- a/Zeal/zone_map.h
+++ b/Zeal/zone_map.h
@@ -68,6 +68,7 @@ public:
 	bool set_font(std::string font_name, bool update_default = true);
 	void set_marauders_map(bool enable) { map_show_all = enable; }  // Resets to false on zone.
 	ZealSetting<bool> setting_add_loc_text = { false, "Zeal", "MapAddLocText", false };
+	ZealSetting<bool> setting_show_all_player_headings = { false, "Zeal", "MapShowPlayerHeadings", false };
 
 	bool is_external_enabled() const { return external_enabled; }
 	bool is_show_raid_enabled() const { return map_show_raid; }


### PR DESCRIPTION
- New option in zeal map ("show headings") beneath the show raid button that will display small direction-indicating position markers for raid members instead of the simple triangle