### PR TITLE
Add instruction cache flushes when modifying code

### DIFF
--- a/Zeal/Zeal.cpp
+++ b/Zeal/Zeal.cpp
@@ -16,8 +16,8 @@ static void mem_check(int line_number = 0) {
 	int result1 = HeapValidate(GetProcessHeap(), 0, NULL);
 	int result2 = HeapValidate(*Zeal::EqGame::Heap, 0, NULL);
 	if (!result1 || !result2) {
-		std::string message = std::format("Zeal {0} ({1}) detected heap corruption ({2}). EqGame will terminate.",
-			ZEAL_VERSION, ZEAL_BUILD_VERSION, line_number);
+		std::string message = std::format("Zeal {0} ({1}) detected heap corruption ({2}:{3}). EqGame will terminate.",
+			ZEAL_VERSION, ZEAL_BUILD_VERSION, line_number, result1 * 2 + result2);
 		MessageBoxA(NULL, message.c_str(),
 			"Zeal heap monitor", MB_OK | MB_ICONERROR);
 		throw std::bad_alloc();  // Will crash out the program.
@@ -47,6 +47,7 @@ ZealService::ZealService()
 	spell_sets = std::make_shared<SpellSets>(this);
 	item_displays = std::make_shared<ItemDisplay>(this, ini.get());
 	tooltips = std::make_shared<tooltip>(this, ini.get());
+	mem_check(__LINE__);
 	floating_damage = std::make_shared<FloatingDamage>(this, ini.get());
 	give = std::make_shared<NPCGive>(this, ini.get());
 	game_patches = std::make_shared<patches>();
@@ -59,6 +60,7 @@ ZealService::ZealService()
 	cycle_target = std::make_shared<CycleTarget>(this);
 	assist = std::make_shared<Assist>(this);
 	experience = std::make_shared<Experience>(this);
+	mem_check(__LINE__);
 	chat_hook = std::make_shared<chat>(this, ini.get());
 	chatfilter_hook = std::make_shared<chatfilter>(this, ini.get());
 	outputfile = std::make_shared<OutputFile>(this);

--- a/Zeal/commands.cpp
+++ b/Zeal/commands.cpp
@@ -399,6 +399,13 @@ ChatCommands::ChatCommands(ZealService* zeal)
 
 				return true;
 			}
+			if (args.size() == 2 && args[1] == "list_keybinds")  // Just a utility to check native keybind mapping.
+			{
+				const char** cmd = reinterpret_cast<const char**>(0x00611220);
+				for (int i = 0; cmd[i] != nullptr; ++i)
+					Zeal::EqGame::print_chat("[%d]: %s", i, cmd[i]);
+				return true;
+			}
 			if (args.size() == 2 && args[1] == "target_name")  // Report name parsing of current target.
 			{
 				Zeal::EqStructures::Entity* target = Zeal::EqGame::get_target();

--- a/Zeal/hook_wrapper.cpp
+++ b/Zeal/hook_wrapper.cpp
@@ -20,6 +20,7 @@ void hook::replace(int addr, int dest)
 		memcpy(original_bytes, (LPVOID)addr, 5);
 		*(DWORD*)(addr + 1) = dest - addr - 5;
 		VirtualProtect((LPVOID)addr, 0x5, old, NULL);
+		FlushInstructionCache(GetCurrentProcess(), (LPVOID)addr, 0x5);
 	}
 }
 

--- a/Zeal/memory.cpp
+++ b/Zeal/memory.cpp
@@ -100,8 +100,10 @@ namespace mem
 	}
 	void reset_memory_protection(PVOID target)
 	{
-		if (protections[target].size)
+		if (protections[target].size) {
 			VirtualProtect((PVOID*)target, protections[target].size, protections[target].orig, nullptr);
+			FlushInstructionCache(GetCurrentProcess(), (PVOID*)target, protections[target].size);
+		}
 	}
 	void set(int target, int val, int size, BYTE* buffer)
 	{
@@ -111,6 +113,7 @@ namespace mem
 			memcpy(buffer, (void*)target, size);
 		memset((void*)target, val, size);
 		VirtualProtect((PVOID*)target, size, oldprotect, &oldprotect);
+		FlushInstructionCache(GetCurrentProcess(), (PVOID*)target, size);
 	}
 	void copy(int target, int source, int size, BYTE* buffer)
 	{
@@ -120,6 +123,7 @@ namespace mem
 			memcpy((void*)buffer, (const void*)target, size);
 		memcpy((void*)target, (const void*)source, size);
 		VirtualProtect((PVOID*)target, size, oldprotect, &oldprotect);
+		FlushInstructionCache(GetCurrentProcess(), (PVOID*)target, size);
 	}
 	void copy(int target, BYTE* source, int size, BYTE* buffer)
 	{
@@ -129,6 +133,7 @@ namespace mem
 			memcpy((void*)buffer, (const void*)target, size);
 		memcpy((void*)target, (const void*)source, size);
 		VirtualProtect((PVOID*)target, size, oldprotect, &oldprotect);
+		FlushInstructionCache(GetCurrentProcess(), (PVOID*)target, size);
 	}
 	void get(int target, int size, BYTE* buffer)
 	{

--- a/Zeal/memory.h
+++ b/Zeal/memory.h
@@ -32,6 +32,7 @@ namespace mem
 		VirtualProtect(reinterpret_cast<PVOID*>(target), size, PAGE_EXECUTE_READWRITE, &oldprotect);
 		memcpy(reinterpret_cast<T*>(target), &value, size);
 		VirtualProtect(reinterpret_cast<PVOID*>(target), size, oldprotect, &oldprotect);
+		FlushInstructionCache(GetCurrentProcess(), reinterpret_cast<PVOID*>(target), size);
 	}
 
 	template<typename T, size_t N>
@@ -42,6 +43,7 @@ namespace mem
 		VirtualProtect(reinterpret_cast<PVOID*>(target), size, PAGE_EXECUTE_READWRITE, &oldprotect);
 		memcpy(reinterpret_cast<T*>(target), value, size);
 		VirtualProtect(reinterpret_cast<PVOID*>(target), size, oldprotect, &oldprotect);
+		FlushInstructionCache(GetCurrentProcess(), reinterpret_cast<PVOID*>(target), size);
 	}
 
 	void set(int target, int val, int size, BYTE* orig_buffer = nullptr);

--- a/Zeal/patches.cpp
+++ b/Zeal/patches.cpp
@@ -111,9 +111,6 @@ patches::patches()
 	//the following does not work entirely needs more effort
 	//mem::write<byte>(0x4A594B, 15); //load font sizes 1 to 14 (default is 6)
 	//mem::write<byte>(0X4FDB6A, 15); //allow /chatfontsize to be larger than 5
-	
-
-	ZealService::get_instance()->callbacks->AddGeneric([this]() { ; }, callback_type::InitUI);
 
 	mem::write<BYTE>(0x4A14CF, 0xEB); //don't print Your XML files are not compatible with current EverQuest files, certain windows may not perform correctly.  Use "/loadskin Default 1" to load the EverQuest default skin.
 

--- a/Zeal/ui_group.cpp
+++ b/Zeal/ui_group.cpp
@@ -73,7 +73,7 @@ ui_group::~ui_group()
 ui_group::ui_group(ZealService* zeal, IO_ini* ini, ui_manager* mgr)
 {
 	ui = mgr;
-	zeal->callbacks->AddGeneric([this]() { InitUI(); }, callback_type::InitUI);
+	//zeal->callbacks->AddGeneric([this]() { InitUI(); }, callback_type::InitUI);
 	zeal->commands_hook->Add("/sortgroup", {"/sg"}, "Sort your group members example usages: /sg or /sg 1 2 where /sg alpha sorts the group and /sg 1 2 switches players 1 and 2 in your group window ",
 		[this](std::vector<std::string>& args) 
 		{
@@ -85,5 +85,5 @@ ui_group::ui_group(ZealService* zeal, IO_ini* ini, ui_manager* mgr)
 				sort();
 			return true;
 		});
-	if (Zeal::EqGame::is_in_game()) InitUI();
+	//if (Zeal::EqGame::is_in_game()) InitUI();
 }


### PR DESCRIPTION
- Added calls to flush the instruction cache wherever code is modified. Practically this seems unlikely to make a difference.
- Removed a few lambda callbacks that were empty functions
- Added two additional heapvalidate calls to see if the current reported heap corruption is consistent on location
- Added a utility command that reports the keybind mapping to execute command code numbers (/zeal list_keybinds)