### PR TITLE
Add /singleclick command (replaced /npcgive)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,9 @@ ___
   - **Aliases:** `/showlootlockout`, `/showlockout`, `/sll`
   - **Description:** Shows you your current loot lockouts on Quarm.
 
+- `/singleclick`
+  - **Description:** Toggles on and off the single click auto-transfer of stackable items to open give, trade, or crafting windows.
+
 - `/zealcam`
   - **Aliases:** `/smoothing`
   - **Arguments:** `x y 3rdperson_x 3rdperson_y`

--- a/Zeal/EqUI.h
+++ b/Zeal/EqUI.h
@@ -675,8 +675,8 @@ namespace Zeal
 		class  ContainerWnd : public EQWND {
 		public:
 			/*0x134*/ DWORD   something;     // dont know maybe type or a counter/ID?;
-			/*0x138*/ DWORD* pIteminfo;     // Pointer to the contents of the container;// Matches the pointer in CHARINFO.Inventory/Bank/World
-			/*0x13c*/ EQWND* pSlots[0x0a];
+			/*0x138*/ Zeal::EqStructures::EQITEMINFO* pContainerInfo;  // Type, capacity, etc.
+			/*0x13c*/ InvSlotWnd* pSlotWnds[0x0a];
 			/*0x164*/ EQWND* pCombine;
 			/*0x168*/ EQWND* pDone;
 			/*0x16c*/ EQWND* pIcon;

--- a/Zeal/NPCGive.cpp
+++ b/Zeal/NPCGive.cpp
@@ -11,39 +11,104 @@ void __fastcall QtyPickupItem(int cquantitywnd, int unused)
     ZealService::get_instance()->hooks->hook_map["QtyPickupItem"]->original(QtyPickupItem)(cquantitywnd, unused);
 }
 
+static bool is_give_or_trade_window_active()
+{
+    return (Zeal::EqGame::Windows->Give && Zeal::EqGame::Windows->Give->IsVisible) ||
+        (Zeal::EqGame::Windows->Trade && Zeal::EqGame::Windows->Trade->IsVisible);
+}
+
+static Zeal::EqUI::ContainerWnd* get_active_tradeskill_container()
+{
+    // Tradeskill combine containers are just a differently labeled "worldbag". To detect if one
+    // is open, we just search the titles of all active tables to see if it contains any of
+    // the substrings below.
+    // Note: The EQITEMCONTAINERINFO::Combine field maps to the EqPacket::Combine_Struct::worldobjecttype
+    // field, and that field is used to check versus race and class so it is another possible check.
+    static std::vector<std::string> craftbags = { "Pottery Wheel", "Medicine Bag", "Mixing Bowl",
+            "Oven", "Sewing Kit", "Forge", "Fletching Kit", "Brew Barrel", "Jeweler's Kit", "Kiln" };
+
+    auto container_mgr = Zeal::EqGame::Windows->ContainerMgr;
+    if (!container_mgr)
+        return nullptr;
+
+    for (int i = 0; i < 0x11; ++i)
+    {
+        auto wnd = container_mgr->pPCContainers[i];
+        if (!wnd || !wnd->IsVisible || !wnd->pContainerInfo)  // Note: ItemInfo.Type != 1 for some reason.
+            continue;
+        const char* name = wnd->pLabel->Text.CastToCharPtr();
+        if (!name)
+            continue;
+        if (std::find_if(craftbags.begin(), craftbags.end(),
+            [name](const std::string& craft) {return std::string(name).find(craft) != std::string::npos; })
+            != craftbags.end())
+            return wnd;
+    }
+    return nullptr;
+}
+
 void NPCGive::HandleItemPickup()
 {
-    if (Zeal::EqGame::Windows && Zeal::EqGame::Windows->Give && Zeal::EqGame::Windows->Give->IsVisible)
+    if (setting_enable_give.get() &&
+        (is_give_or_trade_window_active() || get_active_tradeskill_container()))
         wait_cursor_item = true;
 }
 
 void NPCGive::tick()
 {
-    if (!Zeal::EqGame::is_in_game())
+    if (!wait_cursor_item)
+        return;
+
+    wait_cursor_item = false;  // Only make a single attempt whenever set.
+
+    // Must be a non-container item on the cursor and still be in the game.
+    if (!Zeal::EqGame::get_char_info() ||
+        !Zeal::EqGame::get_char_info()->CursorItem || 
+        Zeal::EqGame::get_char_info()->CursorItem->Type != 0 ||
+        !Zeal::EqGame::is_in_game())
+        return;
+
+    if (ZealService::get_instance()->looting_hook->is_item_protected_from_selling(
+        Zeal::EqGame::get_char_info()->CursorItem))
     {
-        wait_cursor_item = false;
+        Zeal::EqGame::print_chat("Zeal disabled the single click move to trade or craft");
         return;
     }
-    if (!Zeal::EqGame::Windows || !Zeal::EqGame::Windows->Give || !Zeal::EqGame::Windows->Give->IsVisible)
+
+    // First check for the NPC give and trade windows as highest priority.
+    if (is_give_or_trade_window_active())
     {
-        wait_cursor_item = false;
-        return;
-    }
-    if (wait_cursor_item && Zeal::EqGame::get_char_info()->CursorItem)
-    {
-        int trade_size = 4;
-        int ptr1 = *(int*)0x7f94c8;
-        if (*(BYTE*)(ptr1 + 0xa8) == 0)
-            trade_size = 8;
-        for (int i = 0; i < trade_size; i++) //look for an empty slot
+        auto trade_target = *reinterpret_cast<Zeal::EqStructures::Entity**>(0x007f94c8);
+        if (!trade_target || !Zeal::EqGame::Windows->Trade)
+            return;   // Should have one, but just bail if not.
+
+        const int trade_size = (trade_target->Type == Zeal::EqEnums::Player) ? 8 : 4;
+        for (int i = 0; i < trade_size; i++) // Look for an empty slot.
         {
             if (!Zeal::EqGame::Windows->Trade->Item[i])
             {
-                Zeal::EqGame::move_item(0, i + 0xbb8, 0, 1); //move item
+                Zeal::EqGame::move_item(0, i + 0xbb8, 0, 1);  // Put in first free slot.
                 break;
             }
         }
-        wait_cursor_item = false;
+        return;
+    }
+
+    // Next check if there is a tradeskill container window open that can accept the item.
+    auto wnd = get_active_tradeskill_container();
+    if (!wnd || !wnd->pContainerInfo ||  // Note: Trade station ItemInfo.Type != 1 for some reason.
+        wnd->pContainerInfo->Container.SizeCapacity < Zeal::EqGame::get_char_info()->CursorItem->Size)
+        return;
+
+    const int num_slots = wnd->pContainerInfo->Container.Capacity;
+    for (int i = 0; i < num_slots; ++i)
+    {
+        auto invslot = wnd->pSlotWnds[i];
+        if (invslot->invSlot && !invslot->invSlot->Item)
+        {
+            Zeal::EqGame::move_item(0, i + 4000, 0, 1);  // Put in free slot of world bag (4000).
+            break;
+        }
     }
 }
 
@@ -51,9 +116,11 @@ NPCGive::NPCGive(ZealService* zeal, IO_ini* ini)
 {
     zeal->callbacks->AddGeneric([this]() { tick();  });
     zeal->hooks->Add("QtyPickupItem", 0x42F65A, QtyPickupItem, hook_type_detour); //Hook in to end melody as well.
-    zeal->commands_hook->Add("/npcgive", { "/ngv" }, "Toggles on and off the ctrl+click item picking up going directly to your give window if its open.",
+    zeal->commands_hook->Add("/singleclick", {},
+        "Toggles on and off the single click auto-transfer of stackable items to open give, trade, or crafting windows.",
         [this](std::vector<std::string>& args) {
-
+            setting_enable_give.set(!setting_enable_give.get());
+            Zeal::EqGame::print_chat("Single click give: %s", setting_enable_give.get() ? "ON" : "OFF");
             return true; //return true to stop the game from processing any further on this command, false if you want to just add features to an existing cmd
         });
 }

--- a/Zeal/NPCGive.h
+++ b/Zeal/NPCGive.h
@@ -2,13 +2,17 @@
 #include "hook_wrapper.h"
 #include "memory.h"
 #include "EqUI.h"
+#include "ZealSettings.h"
+
 class NPCGive
 {
 public:
 	NPCGive(class ZealService* pHookWrapper, class IO_ini* ini);
 	~NPCGive();
-	bool enabled = true;
-	void HandleItemPickup();
+	void HandleItemPickup();  // For internal callback use only.
+
+	ZealSetting<bool> setting_enable_give = { false, "SingleClick", "EnableGive", false };
+
 private:
 	bool wait_cursor_item=false;
 	void tick();

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -332,6 +332,7 @@ void ui_options::InitGeneral()
 	ui->AddCheckboxCallback(wnd, "Zeal_SuppressOtherFizzles",	[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->chatfilter_hook->setting_suppress_other_fizzles.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_UseZealAssistOn",		[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->assist->setting_use_zeal_assist_on.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_DetectAssistFailure",	[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->assist->setting_detect_assist_failure.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_SingleClickGiveEnable",  [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->give->setting_enable_give.set(wnd->Checked); });
 
 	ui->AddCheckboxCallback(wnd, "Zeal_LinkAllAltDelimiter",    [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->looting_hook->setting_alt_delimiter.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_EnableContainerLock",    [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->ui->options->setting_enable_container_lock.set(wnd->Checked); });
@@ -625,6 +626,7 @@ void ui_options::UpdateOptionsGeneral()
 	ui->SetChecked("Zeal_SuppressOtherFizzles", ZealService::get_instance()->chatfilter_hook->setting_suppress_other_fizzles.get());
 	ui->SetChecked("Zeal_UseZealAssistOn", ZealService::get_instance()->assist->setting_use_zeal_assist_on.get());
 	ui->SetChecked("Zeal_DetectAssistFailure", ZealService::get_instance()->assist->setting_detect_assist_failure.get());
+	ui->SetChecked("Zeal_SingleClickGiveEnable", ZealService::get_instance()->give->setting_enable_give.get());
 }
 void ui_options::UpdateOptionsCamera()
 {

--- a/Zeal/uifiles/zeal/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_General.xml
@@ -842,6 +842,36 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
+  <Button item="Zeal_SingleClickGiveEnable">
+    <ScreenID>Zeal_SingleClickGiveEnable</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>552</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Enables the single click auto-transfer of stackable items to open give, trade, or crafting windows</TooltipReference>
+    <Text>Single click give</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
   <!-- end -->
     
   <Page item="Tab_General">
@@ -896,6 +926,7 @@
     <Pieces>Zeal_SuppressOtherFizzles</Pieces>
     <Pieces>Zeal_UseZealAssistOn</Pieces>
     <Pieces>Zeal_DetectAssistFailure</Pieces>
+    <Pieces>Zeal_SingleClickGiveEnable</Pieces>
     <Location>
       <X>0</X>
       <Y>22</Y>

--- a/Zeal/zone_map.cpp
+++ b/Zeal/zone_map.cpp
@@ -1414,7 +1414,7 @@ void ZoneMap::add_non_ally_position_vertices(std::vector<MapVertex>&vertices,
             else
                 add_non_ally_player_marker_vertices(entity->Position, size, color, vertices);
         else
-            add_npc_marker_vertices(entity->Position, size, color, vertices);
+            add_npc_marker_vertices(entity->Position, size * 0.5, color, vertices);
         if ((vertices.size() - start) > kVertexLimit)
             break;  // Note: Dropping markers, but names will still show up.
     }


### PR DESCRIPTION
- Added a new /singleclick command that toggles the single click automatic transfer of stacked items to an open give, trade, or crafting station container window as unstacked items
  - If ctrl+left click, transfers 1 item from stack over
  - If shift+left click, transfers entire stack
  - If left click, quantity window comes up then transfers result
- Removed the /npcgive command which was a no-op (didn't change the enable state, the logic was always on for give windows)
- Also added the corresponding control to zeal general options