### PR TITLE
Adjust default nameplate shadow offset

### DIFF
--- a/Zeal/NPCGive.cpp
+++ b/Zeal/NPCGive.cpp
@@ -119,7 +119,7 @@ NPCGive::NPCGive(ZealService* zeal, IO_ini* ini)
     zeal->commands_hook->Add("/singleclick", {},
         "Toggles on and off the single click auto-transfer of stackable items to open give, trade, or crafting windows.",
         [this](std::vector<std::string>& args) {
-            setting_enable_give.set(!setting_enable_give.get());
+            setting_enable_give.toggle();
             Zeal::EqGame::print_chat("Single click give: %s", setting_enable_give.get() ? "ON" : "OFF");
             return true; //return true to stop the game from processing any further on this command, false if you want to just add features to an existing cmd
         });

--- a/Zeal/bitmap_font.cpp
+++ b/Zeal/bitmap_font.cpp
@@ -137,8 +137,8 @@ std::vector<std::string> BitmapFontBase::get_available_fonts() {
 
 // Calculates the default shadow offset for this font size.
 float BitmapFontBase::calculate_shadow_offset() const {
-    float offset = std::roundf(get_line_spacing() * 0.05f);  // Round to integer offsets.
-    return std::max(1.f, offset);
+    float offset = std::roundf(get_line_spacing() * shadow_offset_factor);
+    return std::max(1.f, offset);  // Rounded, integer offset >= 1.
 }
 
 // Reads a font from files created with the MakeSpriteFont utility.
@@ -243,8 +243,8 @@ BitmapFontBase::~BitmapFontBase() {
 }
 
 void BitmapFontBase::dump() const {
-    Zeal::EqGame::print_chat("drop_shadow: %d, outlined: %d, align_bottom: %d",
-        drop_shadow, outlined, align_bottom);
+    Zeal::EqGame::print_chat("drop_shadow: %d, offset_factor: %.3f, outlined: %d, align_bottom: %d",
+        drop_shadow, shadow_offset_factor, outlined, align_bottom);
     Zeal::EqGame::print_chat("line_spacing: %f, default_character: %c",
         line_spacing, default_character);
 

--- a/Zeal/bitmap_font.h
+++ b/Zeal/bitmap_font.h
@@ -29,6 +29,8 @@ public:
     static constexpr char kManaBarValue = 3;  // ASCII '\x03' draws the mana value
     static constexpr char kStaminaBarValue = 4;  // ASCII '\x04' draws the stamina value.
 
+    static constexpr float kDefaultShadowOffsetFactor = 0.01f;
+
     // Utility method to report the available fonts.
     static std::vector<std::string> get_available_fonts();
 
@@ -48,8 +50,8 @@ public:
     RECT measure_draw_rect(const char* text, const Vec2& position) const;
     float get_line_spacing() const { return line_spacing; }
 
-    // Utilities for drop shadow effects.
-    float calculate_shadow_offset() const;
+    // Drop shadow and alignment configuration.
+    void set_shadow_offset_factor(float factor) { shadow_offset_factor = factor; }
     void set_drop_shadow(bool enable) { drop_shadow = enable; }
     void set_outlined(bool enable) { outlined = enable; }
     void set_align_bottom(bool enable) { align_bottom = enable; }
@@ -115,6 +117,9 @@ protected:
     template<typename TAction>
     void for_each_glyph(const char* text, TAction action) const;
 
+    float calculate_shadow_offset() const;
+
+    float shadow_offset_factor = kDefaultShadowOffsetFactor;
     bool drop_shadow = false;
     bool outlined = false;
     bool align_bottom = false;  // Applies only when text is queued with center flag.

--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -125,6 +125,16 @@ void NamePlate::parse_args(const std::vector<std::string>& args)
 			return;
 		}
 	}
+	else if (args.size() == 3 && args[1] == "shadowfactor") {
+		float factor;
+		if (Zeal::String::tryParse(args[2], &factor)) {
+			factor = max(0.005f, min(0.1f, factor));
+			setting_shadow_offset_factor.set(factor);
+			if (sprite_font)
+				sprite_font->set_shadow_offset_factor(setting_shadow_offset_factor.get());
+			return;
+		}
+	}
 
 	if (args.size() == 2 && command_map.find(args[1]) != command_map.end())
 	{
@@ -141,6 +151,7 @@ void NamePlate::parse_args(const std::vector<std::string>& args)
 	Zeal::EqGame::print_chat("tint:  colors, concolors, targetcolor, targetblink, attackonly, charselect");
 	Zeal::EqGame::print_chat("text:  hideself, x, hideraidpets, showpetownername, targetmarker, targethealth, inlineguild");
 	Zeal::EqGame::print_chat("font:  zealfont, dropshadow, healthbars, manabars, staminabars");
+	Zeal::EqGame::print_chat("shadows: /nameplate shadowfactor <float> (0.005 to 0.1 range)");
 }
 
 std::vector<std::string> NamePlate::get_available_fonts() const {
@@ -165,6 +176,7 @@ void NamePlate::load_sprite_font() {
 		return;  // Let caller deal with the failure.
 	sprite_font->set_drop_shadow(setting_drop_shadow.get());
 	sprite_font->set_align_bottom(true);  // Bottom align for multi-line and font sizes.
+	sprite_font->set_shadow_offset_factor(setting_shadow_offset_factor.get());
 }
 
 void NamePlate::clean_ui()
@@ -177,24 +189,6 @@ void NamePlate::clean_ui()
 static float get_nameplate_z_offset(const Zeal::EqStructures::Entity& entity)
 {
 	return z_position_offset;
-
-#if 0  // Adonis formula (before fix to bottom alignment).
-	const float scale_factor = (entity.ActorInfo && entity.ActorInfo->ViewActor_) ?
-		entity.ActorInfo->ViewActor_->ScaleFactor : 1.f;
-	const float base_offset = entity.Height + entity.ModelHeightOffset;
-
-	if (scale_factor > 3)
-		return base_offset * 0.08f;
-	if (scale_factor > 2)
-		return base_offset * 0.1f;
-	if (scale_factor > 1)
-		return base_offset * 0.11f;
-	if (scale_factor > 0.8)
-		return base_offset * 0.12f;
-
-	return base_offset * 0.14f;
-#endif
-
 }
 
 // The server currently only sends reliable HP updates for target, self, self pet,

--- a/Zeal/nameplate.h
+++ b/Zeal/nameplate.h
@@ -50,7 +50,8 @@ public:
 	ZealSetting<bool> setting_attack_only = { false, "Zeal", "NameplateAttackOnly", false };
 	ZealSetting<bool> setting_inline_guild = { false, "Zeal", "NameplateInlineGuild", false };
 	
-	ZealSetting<bool> setting_extended_nameplate = { true, "Zeal", "NameplateExtended", false, [this](bool& val) { mem::write<BYTE>(0x4B0B3D, val ? 0 : 1); }, true };
+	ZealSetting<bool> setting_extended_nameplate = { true, "Zeal", "NameplateExtended", false,
+		[this](bool& val) { mem::write<BYTE>(0x4B0B3D, val ? 0 : 1); }, true };
 
 	// Advanced fonts
 	ZealSetting<bool> setting_health_bars = { false, "Zeal", "NameplateHealthBars", false };
@@ -60,6 +61,8 @@ public:
 		[this](bool val) { clean_ui(); } };
 	ZealSetting<bool> setting_drop_shadow = { false, "Zeal", "NamePlateDropShadow", false,
 		[this](bool val) { clean_ui(); } };
+	ZealSetting<float> setting_shadow_offset_factor = { BitmapFontBase::kDefaultShadowOffsetFactor,
+		"Zeal", "NamePlateShadowOffsetFactor", false };
 	ZealSetting<std::string> setting_fontname = { std::string(BitmapFont::kDefaultFontName),
 		"Zeal", "NamePlateFontname", false, [this](std::string val) { clean_ui(); } };
 


### PR DESCRIPTION
- Reduced the default shadow factor from 0.05 to 0.01 times the line spacing to make the shadows tighter per feedback
- Added a /nameplate shadowfactor <float> to allow users to adjust the offset