### PR TITLE
Support autosit and inv/spell export on btn camp

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ from the repo using github actions, providing full transparency on the contents.
 - Third party tool support (silent log messages, direct ZealPipes)
 - Integrated map (see In-game Map section below)
 - Various client bug fixes and patches (fix crashes and helm graphical glitches, skill window sorting, etc)
+- Autosit on camp (with option to export inventory and spellbook files)
 
 ### Installation
 #### The easy way
@@ -243,9 +244,6 @@ ___
 
 - `/sit`
   - **Description:** The /sit command now accepts "on" as an argument. Using "/sit on" will always make you sit, even if you are currently sitting. This matches the game's native "/sit off" which always makes you stand even if you are currently standing. The "/sit" command will continue to toggle sit/stand state if no argument is provided or if the argument provided is not on or off. Additionally, "/sit down" now works as well and will always make you sit, even if already sitting.
-
-- `/camp`
-  - **Description:** Auto sits before camping.
 
 - `/selfclickthru`
   - **Arguments:** `on`, `off`

--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -229,9 +229,10 @@ namespace Zeal
 			}
 			return false;
 		}
-		void move_item(int a1, int slot, int a2, int a3)
+		// See EQMacEmu/common/patches/mac_limits.h namespace invslot for valid slot numbers. 0 = Cursor.
+		void move_item(int from_slot, int to_slot, int print_error, int a3)
 		{
-			reinterpret_cast<bool (__thiscall*)(int t, int a1, int slot, int a2, int a3)>(0x422b1c)(*(int*)0x63d6b4, a1, slot, a2, a3);
+			reinterpret_cast<bool (__thiscall*)(int t, int a1, int slot, int a2, int a3)>(0x422b1c)(*(int*)0x63d6b4, from_slot, to_slot, print_error, a3);
 		}
 		bool is_on_ground(Zeal::EqStructures::Entity* ent)
 		{


### PR DESCRIPTION
- The /camp command supported auto-sit and the optional export of inventory and spellbook but that path wasn't shared by the camp button or hotkeys. This change hooks the common call so all camp paths (/camp, key bind, camp button, hot keyed camp button) support those features.