### PR TITLE
ServerTick - UI Gauge and Pipe Event added

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,8 @@ ___
   - **Arguments:** `colors`, `concolors`, `targetcolor`, `charselect`, `hideself`, `x`, `hideraidpets`, `showpetownername`, `targetmarker`, `targethealth`, `inlineguild`
   - **Description:** toggles nameplate modes for adjusting colors (tints) and text
 
+- `/tickreverse`
+  - **Description:** Swaps the direction of the server tick gauge.
 ___
 ### Binds
 - Cycle through nearest NPCs
@@ -358,6 +360,7 @@ ___
 ### UI
 - **Gauge EqType's**
   - `23` EXP Per Hour
+  - `24` Server tick timer
 
 - **Label EqType's**
   - `80` Mana/Max Mana
@@ -365,6 +368,12 @@ ___
   - `124` Current Mana
   - `125` Max Mana
   - `134` Spell being casted
+  - `135` Song Window Buff 1
+  - `136` Song Window Buff 2
+  - `137` Song Window Buff 3
+  - `138` Song Window Buff 4
+  - `139` Song Window Buff 5
+  - `140` Song Window Buff 6
 
 - **LootAllButton**
 - **LinkAllButton** (w/option to select either `, ` or ` | ` delimiter)
@@ -377,6 +386,16 @@ ___
 ### Zeal pipes
 - Zeal supports creating a namedpipe for streaming game updates to third party applications
 - C# example: https://github.com/OkieDan/ZealPipes
+
+---
+### Tick Timer
+
+Adds a Gauge (EQType 24) that supports drawing a server tick timer natively in the EQUI.
+
+The gauge drain/fill style can be swapped using `/tickreverse`.
+
+The tick event is also logged to the Zeal Pipe, in addition to the gauge value:
+- `{ "type": 0, "text": "Tick" }`
 
 ---
 ### Building

--- a/Zeal/EqPackets.h
+++ b/Zeal/EqPackets.h
@@ -18,6 +18,7 @@ namespace Zeal
             WearChange = 0x4092,
             Illusion = 0x4091,
             Assist = 0x4200,
+            Stamina = 0x4157,
         };
         struct TradeRequest_Struct {
             /*000*/	UINT16 to_id;
@@ -110,6 +111,12 @@ namespace Zeal
             /*014*/ short   unknown_void;
             /*016*/ int     size;
             /*020*/
+        };
+        struct Stamina_Struct
+        {
+            /*00*/ INT16 food;    // clamped to 0 - 32000
+            /*02*/ INT16 water;   // clamped to 0 - 32000
+            /*04*/ INT8 fatigue;  // clamped to 0 - 100
         };
     }
 }

--- a/Zeal/EqStructures.h
+++ b/Zeal/EqStructures.h
@@ -444,8 +444,8 @@ namespace Zeal
 			/* 0x0050 */ PVOID Unknown0050; // EqMobileEmitter*
 			/* 0x0054 */ DWORD Unknown0054;
 			/* 0x0058 */ DWORD PhysicsTimer;
-			/* 0x005C */ DWORD LastTick;
-			/* 0x0060 */ DWORD UnknownTimer3;
+			/* 0x005C */ DWORD LastTick; // Last 1000ms Tick
+			/* 0x0060 */ DWORD Last6000msTick;
 			/* 0x0064 */ DWORD UnknownTimer4;
 			/* 0x0068 */ DWORD AttackTimer;
 			/* 0x006C */ DWORD DeathTimer;

--- a/Zeal/Zeal.cpp
+++ b/Zeal/Zeal.cpp
@@ -74,6 +74,7 @@ ZealService::ZealService()
 	physics = std::make_shared<Physics>(this, ini.get());
 	target_ring = std::make_shared<TargetRing>(this, ini.get());
 	zone_map = std::make_shared<ZoneMap>(this, ini.get());
+	tick = std::make_shared<Tick>(this);
 
 	callbacks->AddGeneric([this]() {
 		if (Zeal::EqGame::is_in_game() && print_buffer.size())
@@ -278,6 +279,7 @@ ZealService::~ZealService()
 	binds_hook.reset();
 	labels_hook.reset();
 	looting_hook.reset();
+	tick.reset();
 	callbacks.reset();
 	helm.reset();
 	commands_hook.reset();

--- a/Zeal/Zeal.h
+++ b/Zeal/Zeal.h
@@ -35,6 +35,7 @@ public:
 	std::shared_ptr<TellWindows> tells = nullptr;
 	std::shared_ptr<HelmManager> helm = nullptr;
 	std::shared_ptr<MusicManager> music = nullptr;
+	std::shared_ptr<Tick> tick = nullptr;
 
 	//other features
 	std::shared_ptr<OutputFile> outputfile = nullptr;

--- a/Zeal/Zeal.vcxproj
+++ b/Zeal/Zeal.vcxproj
@@ -173,6 +173,7 @@
     <ClInclude Include="json.hpp" />
     <ClInclude Include="helm_manager.h" />
     <ClInclude Include="music.h" />
+    <ClInclude Include="tick.h" />
     <ClInclude Include="ui_buff.h" />
     <ClInclude Include="ui_group.h" />
     <ClInclude Include="ui_inputdialog.h" />
@@ -245,6 +246,7 @@
     <ClCompile Include="floating_damage.cpp" />
     <ClCompile Include="helm_manager.cpp" />
     <ClCompile Include="music.cpp" />
+    <ClCompile Include="tick.cpp" />
     <ClCompile Include="ui_buff.cpp" />
     <ClCompile Include="ui_group.cpp" />
     <ClCompile Include="ui_inputdialog.cpp" />

--- a/Zeal/Zeal.vcxproj.filters
+++ b/Zeal/Zeal.vcxproj.filters
@@ -261,6 +261,9 @@
     <ClInclude Include="assist.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="tick.h">
+      <Filter>Header Files\hooks</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
@@ -445,6 +448,9 @@
     </ClCompile>
     <ClCompile Include="assist.cpp">
       <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="tick.cpp">
+      <Filter>Source Files\hooks</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Zeal/framework.h
+++ b/Zeal/framework.h
@@ -26,6 +26,7 @@
 #include "tellwindows.h"
 #include "helm_manager.h"
 #include "music.h"
+#include "tick.h"
 // other features
 #include "NPCGive.h"
 #include "cycle_target.h"

--- a/Zeal/labels.cpp
+++ b/Zeal/labels.cpp
@@ -127,6 +127,12 @@ int GetGaugeFromEq(int EqType, Zeal::EqUI::CXSTR* str)
 			float fpct = zeal->experience->exp_per_hour_pct_tot / 100.f;
 			return (int)(1000.f * fpct);
 		}
+		case 24: // Server Tick
+		{
+			if (zeal->tick)
+				return zeal->tick->GetTickGauge(str);
+			return 0;
+		}
 		default:
 			break;
 	}

--- a/Zeal/named_pipe.cpp
+++ b/Zeal/named_pipe.cpp
@@ -91,6 +91,12 @@ const std::map<int, std::string> LabelNames = {
 	{124, "Mana"},
 	{125, "MaxMana"},
 	{134, "CastingName"},
+	{135, "Buff15"},
+	{136, "Buff16"},
+	{137, "Buff17"},
+	{138, "Buff18"},
+	{139, "Buff19"},
+	{140, "Buff20"},
 };
 const std::map<int, std::string> GaugeNames = {
    {1, "HP"},
@@ -114,7 +120,8 @@ const std::map<int, std::string> GaugeNames = {
    {19, "Group3PetHP"},
    {20, "Group4PetHP"},
    {21, "Group5PetHP"},
-   {23, "ExpPerHR"}
+   {23, "ExpPerHR"},
+   {24, "ServerTick"},
 };
 
 

--- a/Zeal/tick.cpp
+++ b/Zeal/tick.cpp
@@ -1,0 +1,78 @@
+#include "tick.h"
+#include "Zeal.h"
+#include "EqStructures.h"
+#include "EqPackets.h"
+
+constexpr DWORD kAverageTickDuration = 6010;
+constexpr DWORD kGaugeScale = 1000;
+
+constexpr const char* TICK_MESSAGE = "Tick";
+
+UINT64 LastKnownServerTick = 0;
+
+DWORD Tick::GetTimeUntilTick()
+{
+	if (LastKnownServerTick != 0) // Don't calculate until tick is known
+	{
+		DWORD now_point = GetTickCount64() % kAverageTickDuration;
+		DWORD tick_point = LastKnownServerTick % kAverageTickDuration;
+		DWORD millis_until_tick = tick_point >= now_point
+			? tick_point - now_point
+			: kAverageTickDuration - (now_point - tick_point);
+		return millis_until_tick;
+	}
+	return 0;
+}
+
+DWORD Tick::GetTickGauge(Zeal::EqUI::CXSTR* str)
+{
+	DWORD value = GetTimeUntilTick();
+
+	// The seconds remaining (1-6)
+	DWORD seconds_display = (value / 1000) + 1;
+	if (seconds_display > 6)
+		seconds_display = 6;
+	Zeal::EqGame::CXStr_PrintString(str, "%u", seconds_display);
+
+	// Scales the gauge from 0-1000
+	value = value * kGaugeScale / kAverageTickDuration;
+
+	// Toggle can reverse the gauge display (drain / fill)
+	if (ReverseDirection.get())
+		value = kGaugeScale - value;
+
+	return value;
+}
+
+void OnServerTick()
+{
+	LastKnownServerTick = GetTickCount64();
+	ZealService::get_instance()->pipe->chat_msg(TICK_MESSAGE, 0); // Send 'Tick' to ZealPipe
+}
+
+void __cdecl Handle_OP_Stamina(Zeal::Packets::Stamina_Struct* packet)
+{
+	Zeal::EqStructures::EQCHARINFO* char_info = Zeal::EqGame::get_char_info();
+
+	// Fatigue packet is the first thing sent on a Server Tick. If Food/Water are unchanged, then we know this is sent via Server Tick.
+	if (char_info && char_info->Hunger == packet->food && char_info->Thirst == packet->water)
+		OnServerTick();
+
+	ZealService::get_instance()->hooks->hook_map["Handle_OP_Stamina"]->original(Handle_OP_Stamina)(packet);
+}
+
+Tick::Tick(ZealService* zeal)
+{
+	zeal->hooks->Add("Handle_OP_Stamina", 0x4E47A2, Handle_OP_Stamina, hook_type_detour);
+	zeal->callbacks->AddGeneric([]() { LastKnownServerTick = 0; }, callback_type::Zone);
+
+	zeal->commands_hook->Add("/tickreverse", {}, "Swaps the direction of the tick progress.", [this](std::vector<std::string>& args) {
+		ReverseDirection.toggle();
+		Zeal::EqGame::print_chat("Server Tick direction swapped.");
+		return true;
+	});
+}
+
+Tick::~Tick()
+{
+}

--- a/Zeal/tick.h
+++ b/Zeal/tick.h
@@ -1,0 +1,19 @@
+#pragma once
+#include "hook_wrapper.h"
+#include "EqUI.h"
+#include "ZealSettings.h"
+#include <stdint.h>
+
+class Tick
+{
+public:
+	DWORD GetTimeUntilTick();
+	DWORD GetTickGauge(struct Zeal::EqUI::CXSTR* str);
+	Tick(class ZealService* zeal);
+	~Tick();
+
+	ZealSetting<bool> ReverseDirection = { false, "ServerTick", "ReverseDirection", false };
+
+private:
+};
+


### PR DESCRIPTION
- Added basic Tick support natively for the UI, and a `"Tick"` message logged to Zeal Pipes.
- Updated README (as well as a couple readme updates for the song window labels).

### UI / Pipe Gauge
- type: 24
- value: 0-1000 (progress bar)
- text: 1-6 (seconds until tick)

### Pipe Events
- `{ "type": 0, "text": "Tick" }` - Emitted on server tick.

### Commands
- `/tickreverse` - Swaps the direction/value of the progress bar.

## Example

https://github.com/user-attachments/assets/3590ce09-a74a-41b1-8e71-dee1360bc0b5

## Context

![image](https://github.com/user-attachments/assets/0a17bc87-1a25-4623-ba7a-46d15d5ccd9d)
