### PR TITLE
Add option for spell gem recast countdown timers

### DIFF
--- a/Zeal/item_display.cpp
+++ b/Zeal/item_display.cpp
@@ -305,8 +305,7 @@ static int __fastcall InvSlotWnd_HandleLButtonUp(Zeal::EqUI::InvSlotWnd* wnd, in
 	return result;
 }
 
-// SpellGemsWnd is known as CastSpellWnd in eqmac.
-static int __fastcall SpellGemsWnd_WndNotification(Zeal::EqUI::SpellGemsWnd* wnd, int unused_edx, Zeal::EqUI::BasicWnd* src_wnd, int param_2, void* param_3) {
+static int __fastcall CastSpellWnd_WndNotification(Zeal::EqUI::CastSpellWnd* wnd, int unused_edx, Zeal::EqUI::BasicWnd* src_wnd, int param_2, void* param_3) {
 	// Forward all messages except for left mouse click messages with the alt key depressed.
 	if (param_2 != 1 || !Zeal::EqGame::get_wnd_manager() || !Zeal::EqGame::get_wnd_manager()->AltKeyState)
 		return wnd->WndNotification(src_wnd, param_2, param_3);
@@ -362,10 +361,10 @@ ItemDisplay::ItemDisplay(ZealService* zeal, IO_ini* ini)
 	inv_slot_wnd_vtable->HandleLButtonUp = InvSlotWnd_HandleLButtonUp;
 	mem::reset_memory_protection(inv_slot_wnd_vtable);
 
-	// Modify the Alt + Left Mouse click SetItem() related callback of SpellGemsWnd (CCastSpell).
-	auto* spell_gems_wnd_vtable = Zeal::EqUI::SpellGemsWnd::default_vtable;
+	// Modify the Alt + Left Mouse click SetItem() related callback of CastSpellWnd.
+	auto* spell_gems_wnd_vtable = Zeal::EqUI::CastSpellWnd::default_vtable;
 	mem::unprotect_memory(spell_gems_wnd_vtable, sizeof(*spell_gems_wnd_vtable));
-	spell_gems_wnd_vtable->WndNotification = SpellGemsWnd_WndNotification;
+	spell_gems_wnd_vtable->WndNotification = CastSpellWnd_WndNotification;
 	mem::reset_memory_protection(spell_gems_wnd_vtable);
 
 	// Modify the Alt + Left Mouse click SetItem() related callback of SpellBookWnd.

--- a/Zeal/labels.cpp
+++ b/Zeal/labels.cpp
@@ -4,7 +4,6 @@
 #include "EqFunctions.h"
 #include "EqUI.h"
 #include "Zeal.h"
-#include "json.hpp"
 
 void default_empty(Zeal::EqUI::CXSTR* str, bool* override_color, ULONG* color)
 {

--- a/Zeal/spellsets.cpp
+++ b/Zeal/spellsets.cpp
@@ -267,7 +267,7 @@ static int __stdcall SpellsMenuNotification(Zeal::EqUI::EQWND* pWnd, unsigned in
 }
 
 
-static int __fastcall SpellGemWnd_HandleRButtonUp(Zeal::EqUI::SpellGem* gem, int unused, Zeal::EqUI::CXPoint pt, unsigned int flag)
+static int __fastcall SpellGemWnd_HandleRButtonUp(Zeal::EqUI::SpellGemWnd* gem, int unused, Zeal::EqUI::CXPoint pt, unsigned int flag)
 {
     ZealService* zeal = ZealService::get_instance();
     if (gem->spellicon == -1)

--- a/Zeal/spellsets.h
+++ b/Zeal/spellsets.h
@@ -38,7 +38,7 @@ public:
 	std::map<int, Zeal::EqUI::ContextMenu*> MenuMap;
 	std::map<int, std::string> spellset_map;
 	std::vector<std::string> spellsets;
-	Zeal::EqUI::SpellGem* last_gem_clicked=0;
+	Zeal::EqUI::SpellGemWnd* last_gem_clicked=0;
 	std::vector<std::pair<int, int>> mem_buffer;
 	void handle_menu_mem(int book_index, int gem_index);
 	SpellSets(class ZealService* zeal);

--- a/Zeal/ui_buff.h
+++ b/Zeal/ui_buff.h
@@ -17,6 +17,7 @@ public:
 	ui_buff(class ZealService* zeal, class IO_ini* ini, class ui_manager* mgr);
 	~ui_buff();
 	ZealSetting<bool> BuffTimers = { true, "Zeal", "Bufftimers", false };
+	ZealSetting<bool> RecastTimers = { false, "Zeal", "Recasttimers", false };
 private:
 
 	void InitUI();

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -326,6 +326,7 @@ void ui_options::InitGeneral()
 	ui->AddCheckboxCallback(wnd, "Zeal_TellWindows",			[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->tells->SetEnabled(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_TellWindowsHist",		[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->tells->SetHist(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_BuffTimers",				[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->ui->buffs->BuffTimers.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_RecastTimers",			[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->ui->buffs->RecastTimers.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_BrownSkeletons",			[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->game_patches->BrownSkeletons.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_ClassicMusic",			[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->music->ClassicMusic.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_SuppressMissedNotes",	[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->chatfilter_hook->setting_suppress_missed_notes.set(wnd->Checked); });
@@ -620,6 +621,7 @@ void ui_options::UpdateOptionsGeneral()
 	ui->SetChecked("Zeal_CastAutoStand", ZealService::get_instance()->movement->CastAutoStand.get());
 	ui->SetChecked("Zeal_RightClickToEquip", ZealService::get_instance()->equip_item_hook->Enabled.get());
 	ui->SetChecked("Zeal_BuffTimers", ZealService::get_instance()->ui->buffs->BuffTimers.get());
+	ui->SetChecked("Zeal_RecastTimers", ZealService::get_instance()->ui->buffs->RecastTimers.get());
 	ui->SetChecked("Zeal_BrownSkeletons", ZealService::get_instance()->game_patches->BrownSkeletons.get());
 	ui->SetChecked("Zeal_ClassicMusic", ZealService::get_instance()->music->ClassicMusic.get());
 	ui->SetChecked("Zeal_SuppressMissedNotes", ZealService::get_instance()->chatfilter_hook->setting_suppress_missed_notes.get());

--- a/Zeal/uifiles/zeal/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_General.xml
@@ -602,7 +602,7 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
-   <Button item="Zeal_BuffTimers">
+  <Button item="Zeal_BuffTimers">
     <ScreenID>Zeal_BuffTimers</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
@@ -632,12 +632,42 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
-   <Button item="Zeal_CastAutoStand">
-    <ScreenID>Zeal_CastAutoStand</ScreenID>
+  <Button item="Zeal_RecastTimers">
+    <ScreenID>Zeal_RecastTimers</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
       <Y>398</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Toggles Recast Timers</TooltipReference>
+    <Text>Recast Timers</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_CastAutoStand">
+    <ScreenID>Zeal_CastAutoStand</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>420</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -667,7 +697,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>420</Y>
+      <Y>442</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -697,7 +727,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>442</Y>
+      <Y>464</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -727,7 +757,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>464</Y>
+      <Y>486</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -757,7 +787,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>486</Y>
+      <Y>508</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -787,7 +817,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>508</Y>
+      <Y>530</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -817,7 +847,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>530</Y>
+      <Y>552</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -847,7 +877,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>552</Y>
+      <Y>574</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -919,6 +949,7 @@
     <Pieces>Zeal_SelfClickThru</Pieces>
     <Pieces>Zeal_Timestamps_Combobox</Pieces>
     <Pieces>Zeal_BuffTimers</Pieces>
+    <Pieces>Zeal_RecastTimers</Pieces>
     <Pieces>Zeal_CastAutoStand</Pieces>
     <Pieces>Zeal_BrownSkeletons</Pieces>
     <Pieces>Zeal_ClassicMusic</Pieces>


### PR DESCRIPTION
- Adds a zeal general option that enables tooltip-like timers similar to the buff icons for the spell recast times
  - Similar display of h, m, s. Does 6 sec ticks until 12 secs and then counts down each second.
- Cleanup:
  - Renamed the previous SpellGemWnd to CastSpellWnd and the SpellGem class to SpellGemWnd for consistency
  - Fleshed out the SpellGemWnd class contents