### PR TITLE
Add spell global cooldown and recast EqType gauges

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,8 @@ ___
 - **Gauge EqType's**
   - `23` EXP Per Hour
   - `24` Server tick timer
+  - `25` Global cast recovery countdown timer
+  - `26` to `33` Recast recovery countdown timers for spell0 - spell7
 
 - **Label EqType's**
   - `80` Mana/Max Mana

--- a/Zeal/named_pipe.cpp
+++ b/Zeal/named_pipe.cpp
@@ -122,6 +122,15 @@ const std::map<int, std::string> GaugeNames = {
    {21, "Group5PetHP"},
    {23, "ExpPerHR"},
    {24, "ServerTick"},
+   {25, "SpellCooldown"},
+   {26, "Spell0Recast"},
+   {27, "Spell1Recast"},
+   {28, "Spell2Recast"},
+   {29, "Spell3Recast"},
+   {30, "Spell4Recast"},
+   {31, "Spell5Recast"},
+   {32, "Spell6Recast"},
+   {33, "Spell6Recast"},
 };
 
 

--- a/Zeal/ui_buff.cpp
+++ b/Zeal/ui_buff.cpp
@@ -145,7 +145,7 @@ int __fastcall CastSpellWnd_PostDraw(Zeal::EqUI::CastSpellWnd* this_ptr, void* n
 	for (size_t i = 0; i < EQ_NUM_SPELL_GEMS; i++)
 	{
 		if (!Zeal::EqGame::Spells::IsValidSpellIndex(char_info->MemorizedSpell[i]) ||
-			actor_info->CastingSpellGemNumber == i)
+			actor_info->CastingSpellId == char_info->MemorizedSpell[i])
 			continue;
 		if (actor_info->RecastTimeout[i] <= game_time)
 			continue;


### PR DESCRIPTION
- Added new gauge eqtypes (25, 26-33) for reporting the current status of the spell global recovery cooldown and the individual spell recast recovery countdowns