### PR TITLE
Fix special hits logging, stamina bars, log off

### DIFF
--- a/Zeal/EqAddresses.h
+++ b/Zeal/EqAddresses.h
@@ -51,6 +51,7 @@ namespace Zeal
 		static EqStructures::KeyboardInput* KeyInput = (EqStructures::KeyboardInput*)0x7ce058;
 		static char* in_game = (char*)0x798550;
 		static int* attack_on_assist = (int*)0x007cf204;  // 1 = attack on assist
+		static int* is_logging_enabled = (int*)0x007cf1e0;  // 0 = disabled, 1 = enabled
 
 		//Vec3* camera_position = *(Vec3**)0x9c08128;
 	}

--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -449,6 +449,10 @@ namespace Zeal
 		{
 			return reinterpret_cast<Zeal::EqStructures::Entity * (__cdecl*)(const char* name)>(0x0050820e)(name);
 		}
+		void log(const char* data)
+		{
+			reinterpret_cast<void(__cdecl*)(const char* data)>(0x005240dc)(data);
+		}
 		void log(std::string& data)
 		{
 			reinterpret_cast<void(__cdecl*)(const char* data)>(0x5240dc)(data.c_str());
@@ -1653,15 +1657,13 @@ namespace Zeal
 			}
 			std::vector<std::string> vd = splitStringByNewLine(data);
 			for (auto& d : vd)
-				EqGameInternal::print_chat(*(int*)0x809478, 0, d.c_str(), 0, true);
+				print_chat(d.c_str());
 		}
 		void print_chat(const char* format, ...)
 		{
-
 			va_list argptr;
 			char buffer[512];
 			va_start(argptr, format);
-			//printf()
 			vsnprintf(buffer, 511, format, argptr);
 			va_end(argptr);
 			if (!is_in_game())
@@ -1670,23 +1672,6 @@ namespace Zeal
 				return;
 			}			
 			EqGameInternal::print_chat(*(int*)0x809478, 0, buffer, 0, true);
-		}
-		void __fastcall PrintChat(int t, int unused, const char* data, short color_index, bool u) {};
-
-		void print_chat_hook(const char* format, ...)
-		{
-			va_list argptr;
-			char buffer[512];
-			va_start(argptr, format);
-			//printf()
-			vsnprintf(buffer, 511, format, argptr);
-			va_end(argptr);
-			if (!is_in_game())
-			{
-				ZealService::get_instance()->print_buffer.push_back(buffer);
-				return;
-			}
-			ZealService::get_instance()->hooks->hook_map["PrintChat"]->original(PrintChat)(*(int*)0x809478, 0, buffer, 0, true);
 		}
 		void print_debug(const char* format, ...)
 		{

--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -46,8 +46,9 @@ namespace Zeal
 			/*inline int fn_loadoptions = 0x536CE0;*/
 			static int fn_KeyboardPageHandleKeyboardMsg = 0x42c4fb;
 
-			static mem::function<void __fastcall(int t, int unused, const char* data, short color, bool un)> print_chat = 0x537f99;
-			//static mem::function<void __stdcall(const char* data)> log = 0x5240dc;
+			static mem::function<void __fastcall(int t, int unused, char* data, short color, bool un)> print_chat = 0x537f99;
+			static mem::function<void __fastcall(int t, int unused, char* data, int unknown)> DoPercentConvert = 0x00538110;
+			static mem::function<void __cdecl(const char* data)> eqlog = 0x005240dc;
 			static mem::function<char __stdcall(Zeal::EqStructures::Entity* viewer, Zeal::EqStructures::Entity* target)> is_invisible = 0x4afa90;  // can_target
 			static mem::function<char __fastcall(int, int, int, int, float*, float, UINT32)> get_world_visible_actor_list = 0x7f9850;
 			static mem::function<char __fastcall(int, int, int, int, float*, float, UINT32)> get_camera_location = 0x7f99d4;
@@ -169,7 +170,6 @@ namespace Zeal
 		Zeal::EqStructures::ActorLocation get_actor_location(int actor);
 		float get_target_blink_fade_factor(float speed_factor, bool auto_attack_only);  // Returns 0 to 1.0f.
 		bool is_view_actor_me();
-		void print_chat_hook(const char* format, ...);
 		void print_chat(std::string data);
 		void print_chat(const char* format, ...);
 		void print_chat(short color, const char* format, ...);
@@ -181,6 +181,7 @@ namespace Zeal
 		void set_attack_on_assist(bool enable);
 		bool can_move();
 		bool is_on_ground(Zeal::EqStructures::Entity* ent);
+		void log(const char* data);
 		void log(std::string& data);
 		Zeal::EqStructures::EQCHARINFO* get_char_info();
 		Zeal::EqStructures::Entity* get_active_corpse();

--- a/Zeal/chatfilter.cpp
+++ b/Zeal/chatfilter.cpp
@@ -276,7 +276,7 @@ void __fastcall PrintAutoSplit(int t, int unused, const char* data, short color_
     ZealService::get_instance()->hooks->hook_map["PrintAutoSplit"]->original(PrintAutoSplit)(t, unused, data, USERCOLOR_ECHO_AUTOSPLIT, u);
 }
 
-static void HandleMyHitsMode(const char* buffer, const char* s1, const char* s2, const char* s3, int damage)
+static void HandleMyHitsMode(char* buffer, const char* s1, const char* s2, const char* s3, int damage)
 {
     // Support re-routing special melee attacks to the special chat color index.
     if (Zeal::EqGame::is_new_ui() && 
@@ -284,7 +284,7 @@ static void HandleMyHitsMode(const char* buffer, const char* s1, const char* s2,
         strcmp(s1, "kick") == 0 ||
         strcmp(s1, "strike") == 0))
     {
-        const char* output = buffer;
+        char* output = buffer;
         char new_buffer[512];
         int hitmode = Zeal::EqGame::Windows->ChatManager->MyHitsMode;
         if (hitmode == 1) {
@@ -295,13 +295,13 @@ static void HandleMyHitsMode(const char* buffer, const char* s1, const char* s2,
             snprintf(new_buffer, sizeof(new_buffer), "%d", damage);
             output = new_buffer;
         }
-        else if (hitmode != 0) {
-            if (*(int*)0x007cf1e0 == 1 && damage > -0x29)  // Straight from client code.
-                reinterpret_cast<void(__cdecl*)(const char* data)>(0x5240dc)(buffer); // eqlog().
-            return;
-        }
 
-        Zeal::EqGame::print_chat(CHANNEL_MYMELEESPECIAL, output);  // Also handles add to log.
+        if (hitmode >= 0 && hitmode <= 2)  // Print with logging disabled (for abbreviated cases).
+            Zeal::EqGame::EqGameInternal::print_chat(*(int*)0x809478, 0, output, CHANNEL_MYMELEESPECIAL, false);
+
+        if (*Zeal::EqGame::is_logging_enabled && damage > -0x29)  // Comparison copied from client code.
+            Zeal::EqGame::log(buffer);
+
         return;
     }
 
@@ -316,7 +316,7 @@ void HandleOtherHitsOtherMode(char* buffer, const char* s1, const char* s2, cons
             strcmp(s1, "kicks") == 0 ||
             strcmp(s1, "strikes") == 0))
     {
-        const char* output = buffer;
+        char* output = buffer;
         char new_buffer[512];
         int hitmode = Zeal::EqGame::Windows->ChatManager->OthersHitsMode;
         if (hitmode == 1) {
@@ -327,13 +327,13 @@ void HandleOtherHitsOtherMode(char* buffer, const char* s1, const char* s2, cons
             snprintf(new_buffer, sizeof(new_buffer), "%d", damage);
             output = new_buffer;
         }
-        else if (hitmode != 0) {
-            if (*(int*)0x007cf1e0 == 1 && damage > -0x29)  // Straight from client code.
-                reinterpret_cast<void(__cdecl*)(const char* data)>(0x5240dc)(buffer); // eqlog().
-            return;
-        }
 
-        Zeal::EqGame::print_chat(CHANNEL_OTHERMELEESPECIAL, output);  // Also handles add to log.
+        if (hitmode >= 0 && hitmode <= 2)  // Print with logging disabled (for abbreviated cases).
+            Zeal::EqGame::EqGameInternal::print_chat(*(int*)0x809478, 0, output, CHANNEL_OTHERMELEESPECIAL, false);
+
+        if (*Zeal::EqGame::is_logging_enabled && damage > -0x29)  // Comparison copied from client code.
+            Zeal::EqGame::log(buffer);
+
         return;
     }
 

--- a/Zeal/nameplate.h
+++ b/Zeal/nameplate.h
@@ -56,7 +56,7 @@ public:
 	// Advanced fonts
 	ZealSetting<bool> setting_health_bars = { false, "Zeal", "NameplateHealthBars", false };
 	ZealSetting<bool> setting_mana_bars = { false, "Zeal", "NameplateManaBars", false };
-	ZealSetting<bool> setting_stamina_bars = { false, "Zeal", "NameplateManaBars", false };
+	ZealSetting<bool> setting_stamina_bars = { false, "Zeal", "NameplateStaminaBars", false };
 	ZealSetting<bool> setting_zeal_fonts = { false, "Zeal", "NamePlateZealFonts", false,
 		[this](bool val) { clean_ui(); } };
 	ZealSetting<bool> setting_drop_shadow = { false, "Zeal", "NamePlateDropShadow", false,


### PR DESCRIPTION
- The special hits (backstab, kick, strike) chat filtering was writing the abbreviated hitsmode to the log instead of the full message (impacting parsers).  Fixed.
- The nameplate stamina bar ini setting was cross-wired to the health bar setting, causing the last one set to impact both.
- The /log off command has not been working properly since the print_chat hook for timestamping was added. Setting /log off will now disable logging.