### PR TITLE
Cleanup use of CXSTR to fix some leaks

### DIFF
--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -1719,9 +1719,9 @@ namespace Zeal
 				return;
 			}
 			//eal::EqUI::ChatWnd* wnd, int u, Zeal::EqUI::CXSTR msg, short channel)
-			Zeal::EqUI::CXSTR cxBuff = Zeal::EqUI::CXSTR(buffer);
+			Zeal::EqUI::CXSTR cxBuff(buffer);  // Callers of AddOutputText() must FreeRep().
 			reinterpret_cast<void(__thiscall*)(Zeal::EqUI::ChatWnd*, Zeal::EqUI::CXSTR msg, short channel)>(ZealService::get_instance()->hooks->hook_map["AddOutputText"]->trampoline)(wnd, cxBuff, color);
-			cxBuff.FreeRep();
+			cxBuff.FreeRep();  // Required here to match client behavior calling AddOutputText.
 		}
 		void destroy_held()
 		{
@@ -2478,7 +2478,6 @@ namespace Zeal
 
 			// Copy data into a standard 2-D structure for sorting.
 			std::vector<std::vector<std::string>> data;
-			Zeal::EqUI::CXSTR temp;
 			for (int r = 0; r < num_rows; ++r)
 			{
 				// Temporary logging / sanity check that there are equal number of columns for each row.
@@ -2489,12 +2488,8 @@ namespace Zeal
 				}
 				data.push_back(std::vector<std::string>());
 				for (int c = 0; c < num_cols; ++c)
-				{
-					list_wnd->GetItemText(&temp, r, c);
-					data[r].push_back(std::string(temp));
-				}
+					data[r].push_back(list_wnd->GetItemText(r, c));
 			}
-			temp.FreeRep();  // Need to release the temporary reference count.
 
 			bool ascending = (sort_type == SortType::Ascending) ||
 				(sort_type == SortType::Toggle &&

--- a/Zeal/callbacks.cpp
+++ b/Zeal/callbacks.cpp
@@ -271,10 +271,10 @@ void __fastcall OutputText(Zeal::EqUI::ChatWnd* wnd, int u, Zeal::EqUI::CXSTR ms
 		if (!wnd)
 			wnd = Zeal::EqGame::Windows->ChatManager->ChatWindows[0];
 
-		msg.FreeRep();
-		msg = Zeal::EqUI::CXSTR(msg_data);
+		msg.Set(msg_data);
 	}
-	zeal->hooks->hook_map["AddOutputText"]->original(OutputText)(wnd, u, msg, new_channel); //msg is freed in this function so no need to free it after
+	// Note: The top-level caller of OutputText will handle FreeRep() of msg (unlike in print_chat_wnd).
+	zeal->hooks->hook_map["AddOutputText"]->original(OutputText)(wnd, u, msg, new_channel);
 }
 
 ///*000*/	UINT16	target;

--- a/Zeal/chat.cpp
+++ b/Zeal/chat.cpp
@@ -361,8 +361,7 @@ static bool handle_tell_tab_completion(Zeal::EqUI::EditWnd* active_edit, int mod
         {
             const char* end_space = strcmp(prefix, "/consent") ? " " : "";
             std::string updated_text = prefix_with_space + matches.front() + end_space;
-            active_edit->InputText.FreeRep();
-            active_edit->InputText = Zeal::EqUI::CXSTR(updated_text);
+            active_edit->InputText.Set(updated_text);
             active_edit->Caret_End = active_edit->GetInputLength();
             active_edit->Caret_Start = active_edit->Caret_End;
         }
@@ -433,8 +432,7 @@ static bool handle_command_tab_completion(Zeal::EqUI::EditWnd* active_edit, int 
     else  // Update the text with the first match in the list.
     {
         std::string updated_text = prefix.empty() ? matches.front() : prefix;
-        active_edit->InputText.FreeRep();
-        active_edit->InputText = Zeal::EqUI::CXSTR(updated_text);
+        active_edit->InputText.Set(updated_text);
         active_edit->Caret_End = active_edit->GetInputLength();
         active_edit->Caret_Start = active_edit->Caret_End;
     }

--- a/Zeal/chatfilter.cpp
+++ b/Zeal/chatfilter.cpp
@@ -150,10 +150,7 @@ int32_t __fastcall AddMenu(int this_, int u, Zeal::EqUI::ContextMenu* menu)
     cf->ZealMenu = InitializeMenu();
 
     for (auto& ec : cf->Extended_ChannelMaps)
-    {
-        Zeal::EqUI::CXSTR cstr(ec.name);
-        cf->ZealMenu->AddMenuItem(cstr, ec.channelMap);
-    }
+        cf->ZealMenu->AddMenuItem(ec.name, ec.channelMap);
     cf->menuIndex = Zeal::EqGame::Windows->ContextMenuManager->AddMenu(cf->ZealMenu);
 
     menu->AddMenuItem("Zeal", cf->menuIndex, true, true);

--- a/Zeal/commands.cpp
+++ b/Zeal/commands.cpp
@@ -388,6 +388,14 @@ ChatCommands::ChatCommands(ZealService* zeal)
 				Zeal::EqGame::print_chat("Process HeapValidate: %s", heap_valid1 ? "Pass" : "Fail");
 				int heap_valid2 = HeapValidate(*Zeal::EqGame::Heap, 0, NULL);
 				Zeal::EqGame::print_chat("Game HeapValidate: %s", heap_valid2 ? "Pass" : "Fail");
+
+				HEAP_SUMMARY heap_summary;
+				memset(&heap_summary, 0, sizeof(heap_summary));
+				heap_summary.cb = sizeof(heap_summary);
+				HeapSummary(*Zeal::EqGame::Heap, 0, &heap_summary);
+				Zeal::EqGame::print_chat("Game Heap: Alloc: 0x%08x, Commit: 0x%08x",
+					heap_summary.cbAllocated, heap_summary.cbCommitted);
+
 				return true;
 			}
 			if (args.size() == 3 && args[1] == "get_command")

--- a/Zeal/item_display.cpp
+++ b/Zeal/item_display.cpp
@@ -35,7 +35,7 @@ void ItemDisplay::InitUI()
 
 		// Set up independent ini settings for these new windows and reload using the new name.
 		new_wnd->EnableINIStorage = 0x19;  // Magic value to use the INIStorageName.
-		new_wnd->INIStorageName = Zeal::EqUI::CXSTR(std::format("ZealItemDisplay{}", i).c_str());
+		new_wnd->INIStorageName.Set(std::format("ZealItemDisplay{}", i));
 		auto vtable = static_cast<Zeal::EqUI::ItemDisplayVTable*>(new_wnd->vtbl);
 		auto load_ini = reinterpret_cast<void(__fastcall*)(Zeal::EqUI::ItemDisplayWnd*, int unused)>(vtable->LoadIniInfo);
 		load_ini(new_wnd, 0);
@@ -127,8 +127,7 @@ static void UpdateSetItemText(Zeal::EqUI::ItemDisplayWnd* wnd, Zeal::EqStructure
 	// Split the existing text into separate lines, release it, and then update line by line.
 	const std::string stml_line_break = "<BR>";
 	auto strings = Zeal::String::split_text(std::string(wnd->DisplayText), stml_line_break);
-	wnd->DisplayText.FreeRep();
-	wnd->DisplayText = Zeal::EqUI::CXSTR("");
+	wnd->DisplayText.Set("");
 	for (auto& s : strings) {
 		// Perform partial iteminfo filtering in combination with substrings.
 		if (item->Type == 0 && item->Common.Skill != 0x14 && item->Common.IsStackable > 1 &&

--- a/Zeal/labels.cpp
+++ b/Zeal/labels.cpp
@@ -139,7 +139,8 @@ static int get_recast_time_gauge(int index, Zeal::EqUI::CXSTR* str)
 	auto char_info = Zeal::EqGame::get_char_info();
 	int* this_display = *(int**)Zeal::EqGame::Display;
 	if (invalid_index || !self || !actor_info || !char_info || !this_display) {
-		if (str) *str = Zeal::EqUI::CXSTR("0");
+		if (str)
+			str->Set("0");
 		return 0;
 	}
 
@@ -150,7 +151,8 @@ static int get_recast_time_gauge(int index, Zeal::EqUI::CXSTR* str)
 		actor_info->CastingSpellId == spell_id ||
 		actor_info->RecastTimeout[index] <= game_time ||
 		actor_info->RecastTimeout[index] <= actor_info->FizzleTimeout) {
-		if (str) *str = Zeal::EqUI::CXSTR("0");
+		if (str)
+			str->Set("0");
 		return 0;
 	}
 
@@ -219,8 +221,7 @@ int GetGaugeFromEq(int EqType, Zeal::EqUI::CXSTR* str)
 			if (group_info->is_in_group() && strcmp(str->CastToCharPtr(), group_info->LeaderName) == 0)
 			{
 				std::string name = std::string(*str) + "*";
-				str->FreeRep();
-				*str = Zeal::EqUI::CXSTR(name.c_str());
+				str->Set(name.c_str());
 			}
 		}
 		break;
@@ -296,8 +297,10 @@ labels::labels(ZealService* zeal)
 				bool override = false;
 				ULONG color = 0;
 				GetLabelFromEq(i, (Zeal::EqUI::CXSTR*)&tmp, &override, &color);
-				if (tmp.Data)
+				if (tmp.Data) {
 					Zeal::EqGame::print_chat("label: %i value: %s", i, tmp.CastToCharPtr());
+					tmp.FreeRep();
+				}
 			}
 			return true; //return true to stop the game from processing any further on this command, false if you want to just add features to an existing cmd
 		});

--- a/Zeal/ui_guild.cpp
+++ b/Zeal/ui_guild.cpp
@@ -22,7 +22,8 @@ void ui_guild::InitUI()
 {
 	guild = new Zeal::EqUI::BasicWnd();
 	guild->vtbl = (Zeal::EqUI::BaseVTable*)0x5e60f0;
-	reinterpret_cast<int* (__thiscall*)(Zeal::EqUI::BasicWnd*, Zeal::EqUI::BasicWnd*, Zeal::EqUI::CXSTR name, int, int)>(0x56e1e0)(guild, 0, Zeal::EqUI::CXSTR("GuildManagementWnd"), -1, 0);
+	Zeal::EqUI::CXSTR name_cxstr("GuildManagementWnd");  // Constructor calls FreeRep() internally.
+	reinterpret_cast<int* (__thiscall*)(Zeal::EqUI::BasicWnd*, Zeal::EqUI::BasicWnd*, Zeal::EqUI::CXSTR name, int, int)>(0x56e1e0)(guild, 0, name_cxstr, -1, 0);
 	guild->CreateChildren();
 	members = (Zeal::EqUI::ListWnd*)guild->GetChildItem("MemberList");
 }
@@ -40,13 +41,10 @@ ui_guild::ui_guild(ZealService* zeal, IO_ini* ini, ui_manager* mgr)
 
 					for (int i = 1; i < members->ItemCount; i++)
 					{
-						Zeal::EqUI::CXSTR name;
-						Zeal::EqUI::CXSTR level;
-						Zeal::EqUI::CXSTR _class;
-						members->GetItemText(&name, i, 0);
-						members->GetItemText(&level, i, 1);
-						members->GetItemText(&_class, i, 2);
-						Zeal::EqGame::print_chat("%s %s %s", name.CastToCharPtr(), level.CastToCharPtr(), _class.CastToCharPtr());
+						auto name = members->GetItemText(i, 0);
+						auto level = members->GetItemText(i, 1);
+						auto _class = members->GetItemText(i, 2);
+						Zeal::EqGame::print_chat("%s %s %s", name.c_str(), level.c_str(), _class.c_str());
 					}
 				}
 				return true;

--- a/Zeal/ui_inputdialog.cpp
+++ b/Zeal/ui_inputdialog.cpp
@@ -23,13 +23,13 @@ bool ui_inputdialog::show(const std::string& title, const std::string& message, 
 		return false;
 	button_callbacks = { button1_callback, button2_callback };
 	if (button1)
-		button1->Text = button1_name;
+		button1->Text.Set(button1_name);
 	if (button2)
-		button2->Text = button2_name;
+		button2->Text.Set(button2_name);
 	if (label)
-		label->Text = message;
+		label->Text.Set(message);
 	if (wnd)
-		wnd->Text = title;
+		wnd->Text.Set(title);
 	if (input)
 	{
 		input->IsVisible = show_input_field;

--- a/Zeal/ui_manager.cpp
+++ b/Zeal/ui_manager.cpp
@@ -9,8 +9,8 @@ Zeal::EqUI::EQWND* ui_manager::CreateSidlScreenWnd(const std::string& name)
 {
 	Zeal::EqUI::EQWND* wnd = (Zeal::EqUI::EQWND*)HeapAlloc(*Zeal::EqGame::Heap, 0, sizeof(Zeal::EqUI::EQWND));
 	mem::set((int)wnd, 0, sizeof(Zeal::EqUI::EQWND));
-	Zeal::EqGame::EqGameInternal::CSidlScreenWndConstructor(wnd, 0, nullptr, Zeal::EqUI::CXSTR(name));
-	//reinterpret_cast<int* (__thiscall*)(Zeal::EqUI::EQWND*, Zeal::EqUI::EQWND*, Zeal::EqUI::CXSTR name, int, int)>(0x56e1e0)(wnd, 0, Zeal::EqUI::CXSTR(name), -1, 0);
+	Zeal::EqUI::CXSTR name_cxstr(name);  // Constructor calls FreeRep() internally.
+	Zeal::EqGame::EqGameInternal::CSidlScreenWndConstructor(wnd, 0, nullptr, name_cxstr);
 	wnd->SetupCustomVTable();
 	wnd->CreateChildren();
 	return wnd;
@@ -176,11 +176,8 @@ void ui_manager::AddListItems(Zeal::EqUI::ListWnd* wnd, const std::vector<std::s
 }
 void ui_manager::AddListItems(Zeal::EqUI::ComboWnd* wnd, const std::vector<std::string> data)
 {
-
 	for (auto & current_row : data)
-	{
 		wnd->InsertChoice(current_row);
-	}
 }
 void ui_manager::AddListItems(Zeal::EqUI::ListWnd* wnd, const std::vector<std::vector<std::string>>data)
 {
@@ -368,7 +365,7 @@ void __fastcall LoadSidlHk(void* t, int unused, Zeal::EqUI::CXSTR path1, Zeal::E
 			file_path = default_file;
 
 		ui->WriteTemporaryUI(file_path, path1);
-		filename = Zeal::EqUI::CXSTR("EQUI_Zeal.xml");
+		filename.Set("EQUI_Zeal.xml");
 	}
 	ZealService::get_instance()->hooks->hook_map["LoadSidl"]->original(LoadSidlHk)(t, unused, path1, path2, filename);
 
@@ -412,14 +409,14 @@ int __fastcall XMLRead(void* t, int unused, Zeal::EqUI::CXSTR path1, Zeal::EqUI:
 	std::string str_filename = filename;
 	std::string file = ui_manager::ui_path + str_filename;
 	if (std::filesystem::exists(file))
-		path1 = Zeal::EqUI::CXSTR(ui_manager::ui_path);
+		path1.Set(ui_manager::ui_path);
 	else
-		path1 = Zeal::EqUI::CXSTR((char*)0x63D3C0);
+		path1.Set((char*)0x63D3C0);
 
 	if (ui->AlreadyLoadedXml(filename))
 	{
-		path1 = Zeal::EqUI::CXSTR(ui_manager::ui_path);
-		filename = "EQUI_TMP.xml";
+		path1.Set(ui_manager::ui_path);
+		filename.Set("EQUI_TMP.xml");
 	}
 
 	return ZealService::get_instance()->hooks->hook_map["XMLRead"]->original(XMLRead)(t, unused, path1, path2, filename);
@@ -430,14 +427,14 @@ int __fastcall XMLReadNoValidate(void* t, int unused, Zeal::EqUI::CXSTR path1, Z
 	std::string str_filename = filename;
 	std::string file = ui_manager::ui_path + str_filename;
 	if (std::filesystem::exists(file))
-		path1 = Zeal::EqUI::CXSTR(ui_manager::ui_path);
+		path1.Set(ui_manager::ui_path);
 	else
-		path1 = Zeal::EqUI::CXSTR((char*)0x63D3C0);
+		path1.Set((char*)0x63D3C0);
 
 	if (ui->AlreadyLoadedXml(filename))
 	{
-		path1 = Zeal::EqUI::CXSTR(ui_manager::ui_path);
-		filename = "EQUI_TMP.xml";
+		path1.Set(ui_manager::ui_path);
+		filename.Set("EQUI_TMP.xml");
 	}
 
 	return ZealService::get_instance()->hooks->hook_map["XMLReadNoValidate"]->original(XMLReadNoValidate)(t, unused, path1, path2, filename);

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -362,14 +362,8 @@ void ui_options::InitFloatingDamage()
 		});
 	ui->AddComboCallback(wnd, "Zeal_FloatingFont_Combobox", [this](Zeal::EqUI::BasicWnd* wnd, int value) {
 		std::string font_name("");
-		if (value >= 0) {
-			Zeal::EqUI::CXSTR selected_name;
-			wnd->CmbListWnd->GetItemText(&selected_name, value, 0);
-			if (selected_name.Data) {
-				font_name = std::string(selected_name);
-				selected_name.FreeRep();
-			}
-		}
+		if (value >= 0)
+			font_name = wnd->CmbListWnd->GetItemText(value, 0);
 		ZealService::get_instance()->floating_damage->bitmap_font_filename.set(font_name);
 		});
 }
@@ -433,14 +427,8 @@ void ui_options::InitMap()
 
 	ui->AddComboCallback(wnd, "Zeal_MapFont_Combobox", [this](Zeal::EqUI::BasicWnd* wnd, int value) {
 		std::string font_name("");
-		if (value > 0) {  // Note: Assuming first value is the default, which "" selects anyways.
-			Zeal::EqUI::CXSTR selected_name;
-			wnd->CmbListWnd->GetItemText(&selected_name, value, 0);
-			if (selected_name.Data) {
-				font_name = std::string(selected_name);
-				selected_name.FreeRep();
-			}
-		}
+		if (value > 0)  // Note: Assuming first value is the default, which "" selects anyways.
+			font_name = wnd->CmbListWnd->GetItemText(value, 0);
     	ZealService::get_instance()->zone_map->set_font(font_name);
 		});
 
@@ -492,20 +480,11 @@ void ui_options::InitTargetRing()
 	ui->AddCheckboxCallback(wnd, "Zeal_TargetRingColor", [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->target_ring->target_color.set(wnd->Checked); });
 	
 	ui->AddComboCallback(wnd, "Zeal_TargetRingTexture_Combobox", [this](Zeal::EqUI::BasicWnd* wnd, int value) {
+		std::string texture_name("None");
 		if (value >= 0)
-		{
-			Zeal::EqUI::CXSTR texture_name;
-			wnd->CmbListWnd->GetItemText(&texture_name, value, 0);
-			if (texture_name.Data)
-			{
-				ZealService::get_instance()->target_ring->texture_name.set(std::string(texture_name));
-				texture_name.FreeRep();
-			}
-		}
-		else
-		{
-			ZealService::get_instance()->target_ring->texture_name.set("None");
-		}
+			texture_name = wnd->CmbListWnd->GetItemText(value, 0);
+
+		ZealService::get_instance()->target_ring->texture_name.set(texture_name);
 	});
 	
 	ui->AddSliderCallback(wnd, "Zeal_TargetRingFlash_Slider", [this](Zeal::EqUI::SliderWnd* wnd, int value) {
@@ -569,14 +548,8 @@ void ui_options::InitNameplate()
 
 	ui->AddComboCallback(wnd, "Zeal_NameplateFont_Combobox", [this](Zeal::EqUI::BasicWnd* wnd, int value) {
 		std::string font_name("");
-		if (value >= 0) {
-			Zeal::EqUI::CXSTR selected_name;
-			wnd->CmbListWnd->GetItemText(&selected_name, value, 0);
-			if (selected_name.Data) {
-				font_name = std::string(selected_name);
-				selected_name.FreeRep();
-			}
-		}
+		if (value >= 0)
+			font_name = wnd->CmbListWnd->GetItemText(value, 0);
 		ZealService::get_instance()->nameplate->setting_fontname.set(font_name);
 		});
 }
@@ -787,13 +760,9 @@ int ui_options::FindComboIndex(std::string combobox, std::string text_value) {
 
 	int value = 0;
 	for (int value = 0; value < kMaxComboBoxItems; ++value) {
-		Zeal::EqUI::CXSTR selected_name;
-		cmb->CmbListWnd->GetItemText(&selected_name, value, 0);  // Assumption: value > rows is safe.
-		if (!selected_name.Data)
+		auto value_label = cmb->CmbListWnd->GetItemText(value, 0);  // Assumption: value > rows is safe.
+		if (value_label.empty())
 			return -1;  // End of list.
-
-		std::string value_label = std::string(selected_name);
-		selected_name.FreeRep();
 		if (Zeal::String::compare_insensitive(value_label, text_value))
 			return value;
 	}

--- a/Zeal/zone_map.cpp
+++ b/Zeal/zone_map.cpp
@@ -3172,7 +3172,7 @@ void ZoneMap::callback_zone() {
 void ZoneMap::set_window_title(const char* title) {
     title = title ? title : "Zeal Map";
     if (wnd)
-        wnd->Text = Zeal::EqUI::CXSTR(title); // Reset to default name until loaded.
+        wnd->Text.Set(title);
     if (external_hwnd)
         SetWindowTextA(external_hwnd, title);
 }


### PR DESCRIPTION
- Audited usage of CXSTR in codebase to try and locate any potential sources of leakage by dropped references
- Fixed locations where implicit construction of CXSTR was getting assigned to existing CXSTR without checking for the need to FreeRep (usually updated with Set())
- Pushed CXSTR constructors back into EqUI where possible and added comments about FreeRep() handling
- Made the CXSTR char* and string constructors explicit to identify implicit conversions
- Added a CXSTR::operator= that will correctly release resources upon assignment