### PR TITLE
Fix singleclick issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,12 @@ ___
   - **Description:** Shows you your current loot lockouts on Quarm.
 
 - `/singleclick`
-  - **Description:** Toggles on and off the single click auto-transfer of stackable items to open give, trade, or crafting windows.
+  - **Arguments:** none, `bag #` where 0 disables and 1-8 sets inventory bag #
+  - **Description:** Toggles on and off the single click auto-transfer of stackable items to open
+    give, trade, or crafting windows. It only activates when either ctrl or shift are held down.
+    The `bag #` sets the target tradeskill inventory target if no world trade/tradeskill windows
+    are open. Set # to zero to disable (default). The # is not a persistent setting (clears on camp).
+  - **Example:** `/singleclick bag 2` will set inventory slot bag 2 (1-8) as the target.
 
 - `/zealcam`
   - **Aliases:** `/smoothing`

--- a/Zeal/EqStructures.h
+++ b/Zeal/EqStructures.h
@@ -299,15 +299,15 @@ namespace Zeal
 			/* 0x0164 */ WORD BardValue;  // Bard Skill Amount (instrument modifier)
 			/* 0x0166 */ BYTE Unknown0166[18];  // Total item struct size looks like 0x178.
 		} EQITEMCOMMONINFO, * PEQITEMCOMMONINFO;
-		typedef struct _EQITEMCONTAINERINFO
+		typedef struct _EQITEMCONTAINERINFO  // EQ_Container class.
 		{
 			/* 0x00E4 */ struct _EQITEMINFO* Item[EQ_NUM_CONTAINER_SLOTS];
-			/* 0x010C */ BYTE Combine;
+			/* 0x010C */ BYTE Combine;  // Type. 0-7 are bags, 9+ support combines.
 			/* 0x010D */ BYTE Capacity; // num slots
 			/* 0x010E */ BYTE IsOpen;
 			/* 0x010F */ BYTE SizeCapacity;
 			/* 0x0110 */ BYTE WeightReduction; // percent
-			/* ...... */
+			/* 0x0111 */ BYTE Unknown0111[3];  // Operator new of 0x114 bytes.
 		} EQITEMCONTAINERINFO, * PEQITEMCONTAINERINFO;
 		typedef struct _EQITEMBOOKINFO
 		{

--- a/Zeal/EqUI.h
+++ b/Zeal/EqUI.h
@@ -641,8 +641,22 @@ namespace Zeal
 		};
 		struct TradeWnd : public EQWND
 		{
-			/* 0x0134 */ DWORD Unk1[39];
-			/* 0x01D0 */ Zeal::EqStructures::_EQITEMINFO* Item[8];
+			/* 0x0134 */ BYTE Activated;
+			/* 0x0135 */ BYTE Unknown0135[0xb];
+			/* 0x0140 */ EQWND* HisMoneyButtons[4];
+			/* 0x0150 */ EQWND* MyMoneyButtons[4];
+			/* 0x0160 */ EQWND* TradeButton;
+			/* 0x0164 */ EQWND* CancelButton;
+			/* 0x0168 */ EQWND* HisNameLabel;
+			/* 0x016C */ EQWND* MyNameLabel;
+			/* 0x0170 */ InvSlotWnd* TradeSlots[0x10];
+			/* 0x01B0 */ DWORD  Unknown01b0[0x4];  // Probably My or Their Money slots.
+			/* 0x01C0 */ DWORD  Unknown01c0[0x4];  // Probably My or Their money slots.
+			/* 0x01D0 */ Zeal::EqStructures::_EQITEMINFO* GiveItems[8];  // My item giving array.
+			/* 0x01F0 */ Zeal::EqStructures::_EQITEMINFO* ReceiveItems[8];  // Probably their item array.
+			/* 0x0210 */ BYTE Unknown0210;  // Set to 0 in constructor. Possibly accept status.
+			/* 0x0211 */ BYTE Unknown0211;  // Set to 0 in constructor. Possibly accept status.
+			/* 0x0212 */ BYTE Unknown0212[2];  // Operator new of 0x214 bytes.
 		};
 		struct LootWnd : public EQWND
 		{
@@ -719,7 +733,7 @@ namespace Zeal
 		public:
 			/*0x000*/   DWORD pvfTable; // NOT based on CXWnd.  Contains only destructor
 			/*0x004*/   ContainerWnd* pPCContainers[0x11];  // All open containers, including World, in order of opening...
-			/*0x048**/  DWORD*   pWorldItems;            // Pointer to the contents of the world   If NULL, world container isn't open;
+			/*0x048**/  Zeal::EqStructures::EQITEMINFO* pWorldItems;  // Only EQITEMCONTAINERINFO section is valid. Pointer to world bags, crafting stations. Null if none open.
 			/*0x04c*/   DWORD Unknown0x04c;            // in the future this is ID of container in zone, starts at one (zero?) and goes up.
 			/*0x050*/   DWORD dwTimeSpentWithWorldContainerOpen;  // Cumulative counter?
 			/*0x054*/

--- a/Zeal/NPCGive.h
+++ b/Zeal/NPCGive.h
@@ -15,6 +15,7 @@ public:
 
 private:
 	bool wait_cursor_item=false;
+	int bag_index = 0;  // /singleclick bag <#> with 1-8 valid values. 0 disables.
 	void tick();
 };
 

--- a/Zeal/commands.cpp
+++ b/Zeal/commands.cpp
@@ -197,20 +197,10 @@ ChatCommands::ChatCommands(ZealService* zeal)
 		[](std::vector<std::string>& args) {
 			if (args.size() == 1)
 			{
-				if ((Zeal::EqGame::Windows->Trade->IsVisible || Zeal::EqGame::Windows->Give->IsVisible) && Zeal::EqGame::get_char_info()->CursorItem)
+				if (Zeal::EqGame::Windows->Trade->IsVisible || Zeal::EqGame::Windows->Give->IsVisible)
 				{
-					int trade_size = 4;
-					int ptr1 = *(int*)0x7f94c8;
-					if (*(BYTE*)(ptr1 + 0xa8) == 0)
-						trade_size = 8;
-					for (int i = 0; i < trade_size; i++) //look for an empty slot
-					{
-						if (!Zeal::EqGame::Windows->Trade->Item[i])
-						{
-							Zeal::EqGame::move_item(0, i + 0xbb8, 0, 1); //move item
-							break;
-						}
-					}
+					// Disabled the auto-drop from the cursor since it needs more work (see /singlegive notes).
+					Zeal::EqGame::print_chat("Trade window already open");
 				}
 				else
 				{

--- a/Zeal/looting.cpp
+++ b/Zeal/looting.cpp
@@ -389,7 +389,7 @@ bool looting::is_trade_protected(Zeal::EqUI::TradeWnd* wnd) const
 	// Then just check all items versus the protected list (also checks for non-empty bags).
 	const int kNpcTradeSize = 4;
 	for (int i = 0; i < kNpcTradeSize; ++i)  {
-		const auto item_info = wnd->Item[i];
+		const auto item_info = wnd->GiveItems[i];
 		if (item_info && is_item_protected_from_selling(item_info))
 			return true;  // The call above emits the blocked message.
 	}


### PR DESCRIPTION
- Added a simple block to prevent the singleclick transfer of nodrop items
- Disabled singleclick transfers into trade windows since it needs some more logic and testing and is a rare use case (npc give still works for quest turn-ins, etc)
- Added a non-persistent /singleclick bag # command to support transfers to inventory tradeskill kits. A value of 0 (default) disables it.
- Narrowed singleclick so it only activates if ctrl or shift are held down, so you can always just do normal transfers if needed (like removing items from an inventory target bag)