### PR TITLE
Item Display - Clickies now show "Level" and "Can Equip"

### DIFF
--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -1763,6 +1763,25 @@ namespace Zeal
 			oss << std::put_time(&timeinfo, "%Y-%m-%d_%H-%M-%S");
 			return oss.str();
 		}
+		int get_effect_required_level(Zeal::EqStructures::EQITEMINFO* item)
+		{
+			if (!item || item->Type != 0)
+				return 0;
+			if (item->Common.Skill == 21 || item->Common.Skill == 42 || item->Common.Skill == 20) // potion, poison, scroll
+				return 0;
+			if (item->Common.SpellIdEx < 1 || item->Common.SpellIdEx >= 4000)
+				return 0;
+			switch (item->Common.IsStackableEx) {
+			case Zeal::EqEnums::ItemEffectCombatProc:
+			case Zeal::EqEnums::ItemEffectMustEquipClick:
+			case Zeal::EqEnums::ItemEffectCanEquipClick:
+				return item->Common.CastingLevelEx;
+			case Zeal::EqEnums::ItemEffectClick:
+			case Zeal::EqEnums::ItemEffectExpendable:
+				return 0;
+			}
+			return 0;
+		}
 		bool use_item(int item_index, bool quiet)
 		{
 			Zeal::EqStructures::EQCHARINFO* chr = Zeal::EqGame::get_char_info();
@@ -1798,8 +1817,8 @@ namespace Zeal
 			// List of checks copied from eqemu/zone/client_packet.cpp:
 			if ((item->Common.EffectType != Zeal::EqEnums::ItemEffect::ItemEffectClick) &&
 				(item->Common.EffectType != Zeal::EqEnums::ItemEffect::ItemEffectExpendable) &&
-				(item->Common.EffectType != Zeal::EqEnums::ItemEffect::ItemEffectEquipClick) &&
-				(item->Common.EffectType != Zeal::EqEnums::ItemEffect::ItemEffectClick2))
+				(item->Common.EffectType != Zeal::EqEnums::ItemEffect::ItemEffectMustEquipClick) &&
+				(item->Common.EffectType != Zeal::EqEnums::ItemEffect::ItemEffectCanEquipClick))
 			{
 				if (!quiet)
 					Zeal::EqGame::print_chat("Item %s does not have a click effect.", item->Name);

--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -243,6 +243,7 @@ namespace Zeal
 		void print_raid_ungrouped();
 		void dump_raid_state();
 		std::string generateTimestamp();
+		int get_effect_required_level(Zeal::EqStructures::EQITEMINFO* item);
 		bool use_item(int item_index, bool quiet = false);
 		enum class SortType {Ascending, Descending, Toggle};
 		void sort_list_wnd(Zeal::EqUI::ListWnd* list_wnd, int sort_column,

--- a/Zeal/EqStructures.h
+++ b/Zeal/EqStructures.h
@@ -221,8 +221,8 @@ namespace Zeal
 			ItemEffectClick,
 			ItemEffectWorn,
 			ItemEffectExpendable,
-			ItemEffectEquipClick,
-			ItemEffectClick2, //5		//name unknown
+			ItemEffectMustEquipClick,
+			ItemEffectCanEquipClick,
 			ItemEffectFocus,
 			ItemEffectScroll,
 			ItemEffectCount
@@ -268,9 +268,9 @@ namespace Zeal
 			/* 0x00F8 */ BYTE Light;
 			/* 0x00F9 */ BYTE AttackDelay;    // Atk Delay
 			/* 0x00FA */ BYTE Damage;         // DMG
-			/* 0x00FB */ BYTE IsStackableEx;
+			/* 0x00FB */ BYTE IsStackableEx;  // Effect Type: 0=Combat 1=ClickyAny 2=Worn 3=Expendable 4=ClickyMustEquip 5=ClickyCanEquip
 			/* 0x00FC */ BYTE Range;
-			/* 0x00FD */ BYTE Skill;
+			/* 0x00FD */ BYTE Skill;          // 21 = Expendable Potion
 			/* 0x00FE */ BYTE Magic;
 			/* 0x00FF */ BYTE CastingLevelEx;
 			/* 0x0100 */ BYTE Material; // 0=None, 1=Leather, 2=Chain, 3=Plate, 4=Silk, etc
@@ -292,9 +292,18 @@ namespace Zeal
 			/* 0x0117 */ BYTE EffectType;
 			/* 0x0118 */ WORD SpellId;
 			/* 0x011A */ BYTE Unknown0123[10];
-			/* 0x0124 */ WORD SkillModId;
-			/* 0x0126 */ INT8 SkillModPercent;
-			/* 0x0127 */ BYTE Unknown0127[59];
+			/* 0x0124 */ union
+			{
+				struct {
+					/* 0x0124 */ WORD SkillModId;
+					/* 0x0126 */ INT8 SkillModPercent;
+					/* 0x0127 */ BYTE Unknown0127;
+				} SkillMod;
+				/* 0x0124 */ int CastTime;
+			};
+			/* 0x0128 */ BYTE Unknown0128[52];
+			/* 0x015C */ DWORD Deity;
+			/* 0x0160 */ short RequiredLevel;
 			/* 0x0162 */ WORD BardType;   // Bard Skill Type (instrument type)
 			/* 0x0164 */ WORD BardValue;  // Bard Skill Amount (instrument modifier)
 			/* 0x0166 */ BYTE Unknown0166[18];  // Total item struct size looks like 0x178.


### PR DESCRIPTION
- Added a standard `Level: N` text to all Clickies/Procs.
- Added `Can Equip.` to Type5 clickies.
![image](https://github.com/user-attachments/assets/99acc186-d56a-419c-be30-98847db08fe7)
