### PR TITLE
Add left align option to recast timer tooltip

### DIFF
--- a/Zeal/ui_buff.cpp
+++ b/Zeal/ui_buff.cpp
@@ -164,7 +164,9 @@ int __fastcall CastSpellWnd_PostDraw(Zeal::EqUI::CastSpellWnd* this_ptr, void* n
 		std::string orig = gem_wnd->ToolTipText.Data->Text;
 		gem_wnd->ToolTipText.Set(time_text);
 		Zeal::EqUI::CXRect relativeRect = gem_wnd->GetScreenRect();
-		gem_wnd->DrawTooltipAtPoint(relativeRect.Right + 2, relativeRect.Top + 2);  // Match alt tip.
+		int x = ZealService::get_instance()->ui->buffs->RecastTimersLeftAlign.get() ?
+			relativeRect.Left : relativeRect.Right;
+		gem_wnd->DrawTooltipAtPoint(x + 2, relativeRect.Top + 2);  // Match alt tip.
 		gem_wnd->ToolTipText.Set(orig);
 	}
 

--- a/Zeal/ui_buff.h
+++ b/Zeal/ui_buff.h
@@ -18,6 +18,7 @@ public:
 	~ui_buff();
 	ZealSetting<bool> BuffTimers = { true, "Zeal", "Bufftimers", false };
 	ZealSetting<bool> RecastTimers = { false, "Zeal", "Recasttimers", false };
+	ZealSetting<bool> RecastTimersLeftAlign = { false, "Zeal", "RecasttimersLeftAlign", false };
 private:
 
 	void InitUI();

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -327,6 +327,7 @@ void ui_options::InitGeneral()
 	ui->AddCheckboxCallback(wnd, "Zeal_TellWindowsHist",		[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->tells->SetHist(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_BuffTimers",				[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->ui->buffs->BuffTimers.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_RecastTimers",			[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->ui->buffs->RecastTimers.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_RecastTimersLeftAlign",	[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->ui->buffs->RecastTimersLeftAlign.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_BrownSkeletons",			[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->game_patches->BrownSkeletons.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_ClassicMusic",			[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->music->ClassicMusic.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_SuppressMissedNotes",	[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->chatfilter_hook->setting_suppress_missed_notes.set(wnd->Checked); });
@@ -595,6 +596,7 @@ void ui_options::UpdateOptionsGeneral()
 	ui->SetChecked("Zeal_RightClickToEquip", ZealService::get_instance()->equip_item_hook->Enabled.get());
 	ui->SetChecked("Zeal_BuffTimers", ZealService::get_instance()->ui->buffs->BuffTimers.get());
 	ui->SetChecked("Zeal_RecastTimers", ZealService::get_instance()->ui->buffs->RecastTimers.get());
+	ui->SetChecked("Zeal_RecastTimersLeftAlign", ZealService::get_instance()->ui->buffs->RecastTimersLeftAlign.get());
 	ui->SetChecked("Zeal_BrownSkeletons", ZealService::get_instance()->game_patches->BrownSkeletons.get());
 	ui->SetChecked("Zeal_ClassicMusic", ZealService::get_instance()->music->ClassicMusic.get());
 	ui->SetChecked("Zeal_SuppressMissedNotes", ZealService::get_instance()->chatfilter_hook->setting_suppress_missed_notes.get());

--- a/Zeal/uifiles/zeal/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_General.xml
@@ -662,12 +662,42 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
-  <Button item="Zeal_CastAutoStand">
-    <ScreenID>Zeal_CastAutoStand</ScreenID>
+  <Button item="Zeal_RecastTimersLeftAlign">
+    <ScreenID>Zeal_RecastTimersLeftAlign</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
       <Y>420</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Left align recast timer tooltip</TooltipReference>
+    <Text>Left Align Recast</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_CastAutoStand">
+    <ScreenID>Zeal_CastAutoStand</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>194</X>
+      <Y>178</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -696,8 +726,8 @@
     <ScreenID>Zeal_BrownSkeletons</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
-      <X>10</X>
-      <Y>442</Y>
+      <X>194</X>
+      <Y>200</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -726,8 +756,8 @@
     <ScreenID>Zeal_ClassicMusic</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
-      <X>10</X>
-      <Y>464</Y>
+      <X>194</X>
+      <Y>222</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -756,8 +786,8 @@
     <ScreenID>Zeal_SuppressMissedNotes</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
-      <X>10</X>
-      <Y>486</Y>
+      <X>194</X>
+      <Y>244</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -786,8 +816,8 @@
     <ScreenID>Zeal_SuppressOtherFizzles</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
-      <X>10</X>
-      <Y>508</Y>
+      <X>194</X>
+      <Y>266</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -816,8 +846,8 @@
     <ScreenID>Zeal_UseZealAssistOn</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
-      <X>10</X>
-      <Y>530</Y>
+      <X>194</X>
+      <Y>288</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -846,8 +876,8 @@
     <ScreenID>Zeal_DetectAssistFailure</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
-      <X>10</X>
-      <Y>552</Y>
+      <X>194</X>
+      <Y>310</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -876,8 +906,8 @@
     <ScreenID>Zeal_SingleClickGiveEnable</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
-      <X>10</X>
-      <Y>574</Y>
+      <X>194</X>
+      <Y>332</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -950,6 +980,7 @@
     <Pieces>Zeal_Timestamps_Combobox</Pieces>
     <Pieces>Zeal_BuffTimers</Pieces>
     <Pieces>Zeal_RecastTimers</Pieces>
+    <Pieces>Zeal_RecastTimersLeftAlign</Pieces>
     <Pieces>Zeal_CastAutoStand</Pieces>
     <Pieces>Zeal_BrownSkeletons</Pieces>
     <Pieces>Zeal_ClassicMusic</Pieces>


### PR DESCRIPTION
- Added a zeal general option that will draw the recast timer tooltip left aligned instead of the normal off the right edge