### PR TITLE
Add 'PVP Ally' nameplate color

### DIFF
--- a/Zeal/nameplate.h
+++ b/Zeal/nameplate.h
@@ -28,7 +28,7 @@ public:
 		NpcCorpse = 10,
 		PlayerCorpse = 11,
 		Target = 18,
-		PvpAlly = 40,
+		PvpAlly = 31,
 	};
 
 	NamePlate(class ZealService* zeal, class IO_ini* ini);

--- a/Zeal/nameplate.h
+++ b/Zeal/nameplate.h
@@ -28,6 +28,7 @@ public:
 		NpcCorpse = 10,
 		PlayerCorpse = 11,
 		Target = 18,
+		PvpAlly = 40,
 	};
 
 	NamePlate(class ZealService* zeal, class IO_ini* ini);
@@ -91,6 +92,8 @@ private:
 	std::string generate_nameplate_text(const Zeal::EqStructures::Entity& entity, int show) const;
 	std::string generate_target_postamble(const Zeal::EqStructures::Entity& entity) const;
 	bool is_nameplate_hidden_by_race(const Zeal::EqStructures::Entity& entity) const;
+	bool is_group_member(const Zeal::EqStructures::Entity& entity) const;
+	bool is_raid_member(const Zeal::EqStructures::Entity& entity) const;
 
 	void clean_ui();
 	void render_ui();

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -231,6 +231,11 @@ void ui_options::LoadColors()
 		if (color_buttons.count(39))
 			color_buttons[39]->TextColor.ARGB = D3DCOLOR_XRGB(0xf0, 0xf0, 0xf0);  // White
 	}
+	if (!ini->exists("ZealColors", "Color40")) // Nameplate: PvP Ally
+	{
+		if (color_buttons.count(40))
+			color_buttons[40]->TextColor.ARGB = 0xFF3D6BDC; // Default Blue
+	}
 
 	for (auto& [index, btn] : color_buttons)
 	{

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -191,6 +191,17 @@ void ui_options::LoadColors()
 		if (color_buttons.count(24))
 			color_buttons[24]->TextColor.ARGB = D3DCOLOR_ARGB(0xff, 0xf0, 0xf0, 0xf0); //Default White
 	}
+	// Color25: Unused
+	// Color26: Unused
+	// Color27: Unused
+	// Color28: Unused
+	// Color29: Unused
+	// Color30: Unused
+	if (!ini->exists("ZealColors", "Color31")) // Nameplate: PvP Ally
+	{
+		if (color_buttons.count(31))
+			color_buttons[31]->TextColor.ARGB = 0xFF3D6BDC; // Default Blue
+	}
 	if (!ini->exists("ZealColors", "Color32")) // FCD: My melee damage
 	{
 		if (color_buttons.count(32))
@@ -230,11 +241,6 @@ void ui_options::LoadColors()
 	{
 		if (color_buttons.count(39))
 			color_buttons[39]->TextColor.ARGB = D3DCOLOR_XRGB(0xf0, 0xf0, 0xf0);  // White
-	}
-	if (!ini->exists("ZealColors", "Color40")) // Nameplate: PvP Ally
-	{
-		if (color_buttons.count(40))
-			color_buttons[40]->TextColor.ARGB = 0xFF3D6BDC; // Default Blue
 	}
 
 	for (auto& [index, btn] : color_buttons)

--- a/Zeal/uifiles/zeal/EQUI_Tab_Colors.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_Colors.xml
@@ -402,8 +402,8 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
-  <Button item="Zeal_Color40">
-    <ScreenID>Zeal_Color40</ScreenID>
+  <Button item="Zeal_Color31">
+    <ScreenID>Zeal_Color31</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
@@ -417,7 +417,7 @@
     <Style_HScroll>false</Style_HScroll>
     <Style_Transparent>false</Style_Transparent>
     <Style_Checkbox>false</Style_Checkbox>
-    <Text>41 - PVP Ally</Text>
+    <Text>32 - PVP Ally</Text>
     <TextColor>
       <R>255</R>
       <G>255</G>
@@ -1245,6 +1245,7 @@
 	<Pieces>Zeal_Color24</Pieces>
     <Pieces>Section_FloatingCombat</Pieces>
     <Pieces>Zeal_BtnDividerFloating</Pieces>
+    <Pieces>Zeal_Color31</Pieces>
     <Pieces>Zeal_Color32</Pieces>
     <Pieces>Zeal_Color33</Pieces>
     <Pieces>Zeal_Color34</Pieces>
@@ -1253,7 +1254,6 @@
     <Pieces>Zeal_Color37</Pieces>
     <Pieces>Zeal_Color38</Pieces>
     <Pieces>Zeal_Color39</Pieces>
-    <Pieces>Zeal_Color40</Pieces>
 
     <Location>
       <X>0</X>

--- a/Zeal/uifiles/zeal/EQUI_Tab_Colors.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_Colors.xml
@@ -402,6 +402,35 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
+  <Button item="Zeal_Color40">
+    <ScreenID>Zeal_Color40</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>164</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>41 - PVP Ally</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
   <Label item="Section_NameplateNPC">
     <ScreenID>Section_NameplateNPC</ScreenID>
     <RelativePosition>true</RelativePosition>
@@ -1224,6 +1253,7 @@
     <Pieces>Zeal_Color37</Pieces>
     <Pieces>Zeal_Color38</Pieces>
     <Pieces>Zeal_Color39</Pieces>
+    <Pieces>Zeal_Color40</Pieces>
 
     <Location>
       <X>0</X>


### PR DESCRIPTION
New nameplate color for friendly PVP targets (same Group, Raid, or Guild)
- (ignore my weird colors. Part of colorblind gang)

![image](https://github.com/user-attachments/assets/34101dca-8224-4d51-a5e7-1f660ad5a373)
