### PR TITLE
Sort the /linkall list (and > 10 item support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,19 @@ from the repo using github actions, providing full transparency on the contents.
 
 ### Features
 - Camera motion improvements (major improvements to third person view)
-- Additional key binds (tab targeting, strafe, pet)
-- Additional commands (melody, useitem, autoinventory)
-- Additional ui support (new gauges, bag control & locking, looting, spellsets, targetrings, nameplates, right click to equip)
-- Enhanced chat (additional filters and colors, tell windows, tab completion)
-- Third party tool support (silent log messages, direct ZealPipes)
+- Additional key binds (tab targeting, corpse cycling, strafe, pet, map,
+  autoinventory, autofire, buy/sell stacks)
+- Additional commands (melody, autofire, useitem, autoinventory, autobank,
+  link all, loot all, raid survey, singleclick, show loot lockouts, etc)
 - Integrated map (see In-game Map section below)
-- Various client bug fixes and patches (fix crashes and helm graphical glitches, skill window sorting, etc)
-- Autosit on camp (with option to export inventory and spellbook files)
+- Additional ui support (new gauges, bag control & locking, looting, spellsets, targetrings,
+  nameplates, right click to equip, skill window sorting, etc)
+- Autostand on move/cast, autosit on camp with export inventory/spellbook option
+- Enhanced chat (% replacements, additional filters and colors, tell windows,
+  tab completion, copy and paste)
+- Notification sounds (tells, group invites)
+- Third party tool support (silent log messages, direct ZealPipes)
+- Various client bug fixes and patches (crashe fixes, helm graphical glitches, etc)
 
 ### Installation
 #### The easy way


### PR DESCRIPTION
- The printed linkall list is now sorted alphabetically
- The previous code exited early if more than 10 links were in the active chat window (or queued for the channel)
- This update will:
  - Active chat window: Add active links until there are 10 and then it will just add remaining item as text names
  - /linkall <channel>: Split the item links across multiple channel messages to stay below the limit.