### PR TITLE
Add heap check ignore and retry dialog options

### DIFF
--- a/Zeal/Zeal.h
+++ b/Zeal/Zeal.h
@@ -63,6 +63,7 @@ public:
 	static ZealService* ptr_service;
 	//static data/functions to get a base ptr since some hook callbacks don't have the information required
 	static ZealService* get_instance();
+	static int get_heap_check_fail_linenumber();  // Non-zero if heap check failed during boot.
 	void configuration_check();
 
 	bool exit = false;

--- a/Zeal/crash_handler.cpp
+++ b/Zeal/crash_handler.cpp
@@ -198,6 +198,7 @@ void WriteMiniDump(EXCEPTION_POINTERS* pep, const std::string& reason, bool extr
                         reasonFile << "Zone ID: " << zone_id << std::endl;
                         reasonFile << "Game state: " << Zeal::EqGame::get_gamestate() << std::endl;
                         reasonFile << "ShowSpellEffects: " << *reinterpret_cast<unsigned int*>(0x007cf290) << std::endl;
+                        reasonFile << "BootHeapCheck: " << ZealService::get_heap_check_fail_linenumber() << std::endl;
                         if (ZealService::get_instance() && ZealService::get_instance()->callbacks)
                             reasonFile << "Callbacks: " << ZealService::get_instance()->callbacks->get_trace();
                     }
@@ -258,7 +259,7 @@ void WriteMiniDump(EXCEPTION_POINTERS* pep, const std::string& reason, bool extr
 LONG CALLBACK VectoredExceptionHandler(PEXCEPTION_POINTERS pExceptionInfo) {
     static int crashes = 0;
     crashes++;
-    if (crashes > 1)
+    if (crashes == 2)
     {
         WriteMiniDump(pExceptionInfo, "Multiple Crashes", false);
     }


### PR DESCRIPTION
- Updated the heap check dialog box to allow users to also retry the checks or to ignore the failure and continue into the game
- Added the line number of the first heap check failure to crash reasons log
- Fixed a logic issue in the crash handler's recent change to protect against crash looping