### PR TITLE
Add key bind that closes all open tell windows

### DIFF
--- a/Zeal/binds.cpp
+++ b/Zeal/binds.cpp
@@ -371,6 +371,10 @@ void Binds::add_binds()
 			}
 		}
 		});
+	add_bind(245, "Close all tell windows", "CloseAllTellWindows", key_category::Chat, [](int key_down) {
+		if (key_down && !Zeal::EqGame::EqGameInternal::UI_ChatInputCheck())
+			ZealService::get_instance()->tells->CloseAllWindows();
+		});
 	add_bind(255, "Auto Inventory", "AutoInventory", key_category::Commands | key_category::Macros, [](int key_down)
 	{
 		if (key_down)

--- a/Zeal/tellwindows.cpp
+++ b/Zeal/tellwindows.cpp
@@ -260,6 +260,18 @@ bool TellWindows::IsTellWindow(Zeal::EqUI::ChatWnd* wnd)
     return false;
 }
 
+void TellWindows::CloseAllWindows()
+{
+    if (!Zeal::EqGame::Windows || !Zeal::EqGame::Windows->ChatManager || !enabled)
+        return;
+    for (int i = 0; i < Zeal::EqGame::Windows->ChatManager->MaxChatWindows; i++)
+    {
+        Zeal::EqUI::ChatWnd* cwnd = Zeal::EqGame::Windows->ChatManager->ChatWindows[i];
+        if (cwnd && cwnd->IsVisible && IsTellWindow(cwnd))
+            reinterpret_cast<void(__thiscall*)(const Zeal::EqUI::ChatWnd*)>(cwnd->vtbl->Deactivate)(cwnd);
+    }
+}
+
 void TellWindows::CleanUI()
 {
     if (!Zeal::EqGame::Windows || !Zeal::EqGame::Windows->ChatManager || !enabled)

--- a/Zeal/tellwindows.h
+++ b/Zeal/tellwindows.h
@@ -16,6 +16,7 @@ public:
 	void SetHist(bool val);
 	Zeal::EqUI::ChatWnd* FindTellWnd(std::string& name);
 	void AddOutputText(Zeal::EqUI::ChatWnd*& wnd, std::string& msg, short channel);
+	void CloseAllWindows();
 	bool enabled = false;
 	bool hist_enabled = true;
 private:


### PR DESCRIPTION
- Keybind 245 is a new Chat keybind that will deactivate all visible tell windows. 
  - Note that if history is enabled, unnoticed messages could be dropped.
  - Sending a new tell to the person or /rt will pop back up the tell window (with history if enabled).