### PR TITLE
Add 'npc' option to /hidecorpse

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,10 +190,10 @@ ___
           `./<character_name>_protected.ini` file.
 
 - `/hidecorpse`
-  - **Arguments:** `looted` (hides after looting), `showlast` (unhides last hidden corpse)
+  - **Arguments:** `looted` (hides after looting), `npc` (hides npcs only), `showlast` (unhides last hidden corpse)
   - **Aliases:** `/hideco`, `/hidec`, `/hc`
   - **Example:** `/hidecorpse looted`
-  - **Description:** `looted` Hides a corpse after you have looted it., `none` reveals all hidden corpses
+  - **Description:** Adds extra arguments and aliases to built in /hidecorpses command.
 
 - `/spellset`
   - **Arguments:** `save`, `load`, `delete`

--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -1917,7 +1917,7 @@ namespace Zeal
 		Zeal::EqStructures::Entity* get_entity_by_parent_id(short parent_id)
 		{
 			Zeal::EqStructures::Entity* current_ent = get_entity_list();
-			while (current_ent->Next)
+			while (current_ent)
 			{
 				if (current_ent->PetOwnerSpawnId == parent_id)
 					return current_ent;

--- a/Zeal/looting.h
+++ b/Zeal/looting.h
@@ -13,6 +13,7 @@ public:
 	bool loot_all=false;
 	ULONGLONG loot_next_item_time = 0;
 	void looted_item();
+	void handle_hide_looted();
 	void set_last_hidden_corpse(Zeal::EqStructures::Entity* corpse);
 	looting(class ZealService* zeal);
 	~looting();


### PR DESCRIPTION
- The command '/hidecorpse npc' will now hide all existing NPC corpses (subset of '/hidecorpse all' which also does players)