### PR TITLE
Add /outputfile inventory support for bigger bank

### DIFF
--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -253,5 +253,10 @@ namespace Zeal
 			SortType sort_type = SortType::Ascending);
 		short total_spell_affects(Zeal::EqStructures::EQCHARINFO* char_info, BYTE affect_type, BYTE a3, int* per_buff_values);
 		void sit();
+
+		// eqgame.dll patch support that expanded the number of available bank slots.
+		int get_num_personal_bank_slots();
+		int get_num_shared_bank_slots();
+		int get_num_total_bank_slots();
 	}
 }

--- a/Zeal/EqStructures.h
+++ b/Zeal/EqStructures.h
@@ -772,9 +772,20 @@ namespace Zeal
 			/* 0x152C */ BYTE Unknown152C[476];
 			/* 0x1708 */ BYTE AirSupply; // air remaining while swimming underwater
 			/* 0x1709 */ BYTE Unknown1709[2475];
-			/* 0x20B4 */ struct _EQITEMINFO* InventoryBankItem[EQ_NUM_INVENTORY_BANK_SLOTS];
-			/* ...... */
-		};
+
+			// Note: The unmodified client EQCHARINFO has 8 bank slots with the rest of the structure
+			//       effectively unused to the original size of 0x2014. If the Quarm eqgame.dll patch
+			//       is active, the structure is modified to the layout below. The code must check
+			//       for the presence of the patch before accessing beyond EQ_NUM_INVENTORY_BANK_SLOTS.
+			//       Currently this is the get_num_total_bank_slots() which returns 60 if patched.
+			// Original structure:
+			// 0x20B4 */ struct _EQITEMINFO* InventoryBankItem[EQ_NUM_INVENTORY_BANK_SLOTS];
+			// 0x20D4 */ DWORD UnusedSpace[12]; (Index '4' is set to 1 but unused, patched out).
+			// };  /* 0x2104 (total size) */
+			// Patched layout:
+			/* 0x20B4 */ struct _EQITEMINFO* InventoryBankItem[30];
+			/* 0x212C */ struct _EQITEMINFO* SharedBankItem[30];
+		};  /* 0x21A4 (total size) */
 
 		struct Everquest
 		{

--- a/Zeal/commands.cpp
+++ b/Zeal/commands.cpp
@@ -371,6 +371,13 @@ ChatCommands::ChatCommands(ZealService* zeal)
 				Zeal::EqGame::print_chat(ss.str());
 				return true;
 			}
+			if (args.size() == 2 && args[1] == "bank") // Temporary for bank patch testing.
+			{
+				Zeal::EqGame::print_chat("total: %i, personal: %i, shared: %i, size: 0x%x",
+					Zeal::EqGame::get_num_total_bank_slots(), Zeal::EqGame::get_num_personal_bank_slots(),
+					Zeal::EqGame::get_num_shared_bank_slots(), sizeof(Zeal::EqStructures::EQCHARINFO));
+				return true;
+			}
 			if (args.size() == 2 && args[1] == "check")  // Report state and do basic debug integrity checks.
 			{
 				ZealService::get_instance()->entity_manager.get()->Dump();

--- a/Zeal/outputfile.cpp
+++ b/Zeal/outputfile.cpp
@@ -159,30 +159,33 @@ void OutputFile::export_inventory(const std::vector<std::string>& args)
   }
 
   { // Process Bank Items
-    for (size_t i = 0; i < EQ_NUM_INVENTORY_BANK_SLOTS; ++i) {
+    int num_bank_slots = Zeal::EqGame::get_num_personal_bank_slots();
+    for (int i = 0; i < Zeal::EqGame::get_num_total_bank_slots(); ++i) {
       Zeal::EqStructures::EQITEMINFO* item = self->CharInfo->InventoryBankItem[i];
+      const char* label = (i < num_bank_slots) ? "Bank" : "SharedBank";
+      int slot = (i < num_bank_slots) ? (i + 1) : (i + 1 - num_bank_slots);
       if (item) {
         if (ItemIsContainer(item)) {
           int capacity = static_cast<int>(item->Container.Capacity);
-          oss << "Bank" << i + 1 << t << item->Name << t << item->ID << t << 1 << t << capacity << std::endl;
+          oss << label << slot << t << item->Name << t << item->ID << t << 1 << t << capacity << std::endl;
           for (int j = 0; j < capacity; ++j) {
             Zeal::EqStructures::EQITEMINFO* bag_item = item->Container.Item[j];
             if (bag_item) {
               int stack_count = ItemIsStackable(bag_item) ? static_cast<int>(bag_item->Common.StackCount) : 1;
-              oss << "Bank" << i + 1 << "-Slot" << j + 1 << t << bag_item->Name << t << bag_item->ID << t << stack_count << t << 0 << std::endl;
+              oss << label << slot << "-Slot" << j + 1 << t << bag_item->Name << t << bag_item->ID << t << stack_count << t << 0 << std::endl;
             }
             else {
-              oss << "Bank" << i + 1 << "-Slot" << j + 1 << t << "Empty" << t << 0 << t << 0 << t << 0 << std::endl;
+              oss << label << slot << "-Slot" << j + 1 << t << "Empty" << t << 0 << t << 0 << t << 0 << std::endl;
             }
           }
         }
         else {
           int stack_count = ItemIsStackable(item) ? static_cast<int>(item->Common.StackCount) : 1;
-          oss << "Bank" << i + 1 << t << item->Name << t << item->ID << t << stack_count << t << 0 << std::endl;
+          oss << label << slot << t << item->Name << t << item->ID << t << stack_count << t << 0 << std::endl;
         }
       }
       else {
-        oss << "Bank" << i + 1 << t << "Empty" << t << 0 << t << 0 << t << 0 << std::endl;
+        oss << label << slot << t << "Empty" << t << 0 << t << 0 << t << 0 << std::endl;
       }
     }
     ULONGLONG coin = 0;


### PR DESCRIPTION
- Added some utility functions for checking the number of available bank slots based on whether the eqgame.dll patch is active
- Updated the inventory output to export 30 personal and 30 shared bank slots when the patch is active