### PR TITLE
Add default zone select button to char select

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ ___
 - **LootAllButton**
 - **LinkAllButton** (w/option to select either `, ` or ` | ` delimiter)
 
+- Option to select background zone at character select w/explore mode.
 
 ### Options UI 
 - Separate Zeal options window that opens in parallel with the client window

--- a/Zeal/character_select.cpp
+++ b/Zeal/character_select.cpp
@@ -79,6 +79,10 @@ static void __fastcall SelectCharacter(DWORD t, DWORD unused, DWORD character_sl
 	else
 		*Zeal::EqGame::camera_view = Zeal::EqEnums::CameraView::CharacterSelect;
 
+	if (Zeal::EqGame::Windows && Zeal::EqGame::Windows->CharacterSelect && !Zeal::EqGame::Windows->CharacterSelect->Explore &&
+					ZealService::get_instance()->ui->zoneselect)
+		ZealService::get_instance()->ui->zoneselect->ShowButton();  // Put dynamic button (if present) on top.
+
 	Zeal::EqStructures::Entity* self = Zeal::EqGame::get_self();
 	if (self)
 	{

--- a/Zeal/ui_zoneselect.h
+++ b/Zeal/ui_zoneselect.h
@@ -7,11 +7,14 @@ class ui_zoneselect
 public:
 	void Show();
 	void Hide();
+	void ShowButton();
+	void HideButton();
 	std::unordered_map<std::string, int> zones;
 	ui_zoneselect(class ZealService* zeal, class ui_manager* mgr);
 	~ui_zoneselect();
 private:
 	Zeal::EqUI::EQWND* wnd = nullptr;
+	Zeal::EqUI::EQWND* btn_wnd = nullptr;  // Optional button if not in xml.
 	void InitUI();  // Called in InitCharSelectUI().
 	void Deactivate();
 	void CleanUI();

--- a/Zeal/uifiles/zeal/EQUI_ZealButtonWnd.xml
+++ b/Zeal/uifiles/zeal/EQUI_ZealButtonWnd.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="us-ascii"?>
+<XML ID="EQInterfaceDefinitionLanguage">
+  <Schema xmlns="EverQuestData" xmlns:dt="EverQuestDataTypes" />
+  <Button item="Zeal_Button">
+    <ScreenID>Zeal_Button</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>1</X>
+      <Y>1</Y>
+    </Location>
+    <Size>
+      <CX>98</CX>
+      <CY>24</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>Button</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+    <AutoStretch>false</AutoStretch>
+    <TopAnchorToTop>false</TopAnchorToTop>
+    <RightAnchorToLeft>false</RightAnchorToLeft>
+    <LeftAnchorToLeft>false</LeftAnchorToLeft>
+    <BottomAnchorToTop>false</BottomAnchorToTop>
+    <BottomAnchorOffset>1</BottomAnchorOffset>
+  </Button>
+  <Screen item="ZealButtonWnd">
+    <RelativePosition>false</RelativePosition>
+    <Location>
+      <X>2</X>
+      <Y>2</Y>
+    </Location>
+    <Size>
+      <CX>100</CX>
+      <CY>26</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <DrawTemplate>WDT_Def</DrawTemplate>
+    <Style_Titlebar>false</Style_Titlebar>
+    <Style_Closebox>false</Style_Closebox>
+    <Style_Minimizebox>false</Style_Minimizebox>
+    <Style_Border>false</Style_Border>
+    <Style_Sizable>false</Style_Sizable>
+    <Pieces>Zeal_Button</Pieces>
+  </Screen>
+</XML>

--- a/Zeal/uifiles/zeal/optional/README.md
+++ b/Zeal/uifiles/zeal/optional/README.md
@@ -5,10 +5,16 @@ Extra xml files that can be used to update the default or custom UI skins.
 ## EQUI_CharacterSelect.xml
 
 - Adds the "Zone Select" button for setting the background and explore mode
+  in a XML controlled location (if the default simple button location is undesirable)
   - UI label: "Zeal_ZoneSelect"
+- The code adds a default simple button if the character select xml does have
+  this child button specifying the location.
 
 ### Installation if using this file
 - Can copy to the uifiles/zeal directory or to the custom or default skin
+  - If not copied to ufiles/default directory, the xml does not take affect until 
+    returning (camping) to character select
+  - Note this is the same behavior for all custom character select skins.
 - Based on the default xml file
 - If using a custom skin, it requires that the active EQUI_Animations.xml include
   the Ui2DAnimations from following section in the default EQUI_Animations.xml:


### PR DESCRIPTION
- Added a simple zone select button in the upper left if the EQUI_CharacterSelect.xml is missing the Zeal_ZoneSelect button.
- Allows setting the background zone w/out any xml mods.