### PR TITLE
Add option to link hiding fcd/ring with GUI

### DIFF
--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -377,6 +377,9 @@ namespace Zeal
 		{
 			return *(EqUI::CXWndManager**)0x809db4;
 		}
+		bool is_gui_visible() {
+			return *(reinterpret_cast<int*>(0x0063b918)) != 3;  // ScreenMode == 3 when F10 is pressed.
+		}
 		bool is_game_ui_window_hovered()
 		{
 			EqUI::CXWndManager* mgr = *(EqUI::CXWndManager**)0x809db4;

--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -222,6 +222,7 @@ namespace Zeal
 		std::string get_class_desc(int class_id);  // CEverQuest::GetClassDesc()
 		std::string get_title_desc(int class_id, int aa_rank, int gender);  // CEverQuest::GetTitleDesc()
 		std::string get_player_guild_name(short guild_id); // GetPlayerGuildName()
+		bool is_gui_visible();  // Returns true if DrawWindows() will be called.
 		bool is_game_ui_window_hovered();
 		bool is_targetable(Zeal::EqStructures::Entity* ent);
 		bool is_in_game();

--- a/Zeal/floating_damage.h
+++ b/Zeal/floating_damage.h
@@ -38,6 +38,7 @@ public:
 	void callback_deferred();
 	void callback_render();
 	ZealSetting<bool> enabled = { true, "FloatingDamage", "Enabled", true };
+	ZealSetting<bool> hide_with_gui = { false, "FloatingDamage", "HideWithGui", true };
 	ZealSetting<bool> spell_icons = { true, "FloatingDamage", "Icons", true };
 	ZealSetting<bool> show_spells = { true, "FloatingDamage", "Spells", true };
 	ZealSetting<bool> show_melee = { true, "FloatingDamage", "Melee", true };
@@ -56,6 +57,7 @@ public:
 	~FloatingDamage();
 private:
 
+	bool is_visible() const;
 	bool add_texture(std::string path);
 	std::vector<IDirect3DTexture8*> textures;
 	IDirect3DTexture8* load_texture(std::string path);

--- a/Zeal/target_ring.cpp
+++ b/Zeal/target_ring.cpp
@@ -385,7 +385,7 @@ void TargetRing::render_ring(Vec3 pos, float radius, DWORD color, IDirect3DTextu
 }
 
 void TargetRing::callback_render() {
-	if (!enabled.get())
+	if (!enabled.get() || (hide_with_gui.get() && !Zeal::EqGame::is_gui_visible()))
 		return;
 	Zeal::EqStructures::Entity* target = Zeal::EqGame::get_target();
 	if (!target || !target->ActorInfo || !target->ActorInfo->ViewActor_)

--- a/Zeal/target_ring.h
+++ b/Zeal/target_ring.h
@@ -59,6 +59,7 @@ public:
 	~TargetRing();
 
 	ZealSetting<bool> enabled = { false, "TargetRing", "Enabled", true, [](bool val) { Zeal::EqGame::print_chat("Target ring is %s", val ? "Enabled" : "Disabled"); } };
+	ZealSetting<bool> hide_with_gui = { false, "TargetRing", "HideWithGui", true };
 	ZealSetting<bool> disable_for_self = { false, "TargetRing", "DisableForSelf", true };
 	ZealSetting<bool> attack_indicator = { false, "TargetRing", "AttackIndicator", true };
 	ZealSetting<bool> rotate_match_heading = { false, "TargetRing", "MatchHeading", true };

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -443,6 +443,7 @@ void ui_options::InitFloatingDamage()
 	if (!wnd)
 		return;
 	ui->AddCheckboxCallback(wnd, "Zeal_FloatingDamage", [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->floating_damage->enabled.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_FloatingHideWithGui", [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->floating_damage->hide_with_gui.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_FloatingSelf", [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->floating_damage->show_self.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_FloatingPets", [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->floating_damage->show_pets.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_FloatingOthers", [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->floating_damage->show_others.set(wnd->Checked); });
@@ -567,6 +568,7 @@ void ui_options::InitTargetRing()
 	ui->AddLabel(wnd, "Zeal_TargetRingTransparency_Value");
 
 	ui->AddCheckboxCallback(wnd, "Zeal_TargetRing", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->target_ring->enabled.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_TargetRingHideWithGui", [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->target_ring->hide_with_gui.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_TargetRingDisableForSelf", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->target_ring->disable_for_self.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_TargetRingAttackIndicator", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->target_ring->attack_indicator.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_TargetRingForward", [](Zeal::EqUI::BasicWnd* wnd) {ZealService::get_instance()->target_ring->rotate_match_heading.set(wnd->Checked); });

--- a/Zeal/uifiles/zeal/EQUI_Tab_FloatingDamage.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_FloatingDamage.xml
@@ -213,6 +213,37 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
+  <Button item="Zeal_FloatingHideWithGui">
+    <ScreenID>Zeal_FloatingHideWithGui</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>178</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Hides FCD when GUI is hidden (Default fonts are always hidden)</TooltipReference>
+    <Text>Hide with GUI</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+
   <!-- Font Combobox -->
   <Label item="Zeal_FloatingFont_Label">
     <ScreenID>Zeal_FloatingFont_Label</ScreenID>
@@ -339,6 +370,7 @@
     <Pieces>Zeal_FloatingMelee</Pieces>
     <Pieces>Zeal_FloatingSpells</Pieces>
     <Pieces>Zeal_FloatingSpellIcons</Pieces>
+    <Pieces>Zeal_FloatingHideWithGui</Pieces>
     <Pieces>Zeal_FloatingBigHit_Label</Pieces>
     <Pieces>Zeal_FloatingBigHit_Slider</Pieces>
     <Pieces>Zeal_FloatingBigHit_Value</Pieces>

--- a/Zeal/uifiles/zeal/EQUI_Tab_TargetRing.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_TargetRing.xml
@@ -182,7 +182,37 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
-   <!-- Zeal Target Ring Fill slider -->
+  <Button item="Zeal_TargetRingHideWithGui">
+    <ScreenID>Zeal_TargetRingHideWithGui</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>11</X>
+      <Y>142</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Hides target ring when GUI is hidden</TooltipReference>
+    <Text>Hide with Gui</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <!-- Zeal Target Ring Fill slider -->
   <Label item="Zeal_TargetRingFill_Label">
     <ScreenID>Zeal_TargetRingFill_Label</ScreenID>
     <RelativePosition>true</RelativePosition>
@@ -607,6 +637,7 @@
     <Pieces>Zeal_TargetRingTexture_Combobox</Pieces>
     <Pieces>Zeal_TargetRingCone</Pieces>
     <Pieces>Zeal_TargetRingColor</Pieces>
+    <Pieces>Zeal_TargetRingHideWithGui</Pieces>
     <Location>
       <X>0</X>
       <Y>22</Y>


### PR DESCRIPTION
- Added option checkboxes to enable linking the visibility of the target ring or the floating combat damage with the F10 UI visibility toggle
- Fixed an issue with FCD where the spell icons remained visible but the text were hidden with the GUI