### PR TITLE
Add option to require ctrl for right click loot

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,8 +159,12 @@ ___
 - `/lootall`
   - **Description:** loots all items from a corpse if looting window is open.
 
+- `/lootctrl`
+  - **Arguments:** none (toggles), `on`, `off`
+  - **Description:** controls the requirement to hold ctrl down to enable right click looting
+
 - `/lootlast`
-  - **Arguments:** `item_id_#`, `item_link`, or `0` to disable_
+  - **Arguments:** `item_id_#`, `item_link`, or `0` to disable.
   - **Description:** specifies an item ID that will be left as the last item when using /lootall on your corpse 
  
 - `/melody`

--- a/Zeal/looting.h
+++ b/Zeal/looting.h
@@ -19,6 +19,7 @@ public:
 	~looting();
 
 	ZealSetting<bool> setting_alt_delimiter = { false, "Zeal", "LinkAllAltDelimiter", false };
+	ZealSetting<bool> setting_ctrl_rightclick_loot = { false, "Zeal", "CtrlRightClickLoot", true };
 
 	// /protect functionality.  Command line-only for now.
 	bool is_cursor_protected(const Zeal::EqStructures::EQCHARINFO* char_info) const;

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -386,6 +386,7 @@ void ui_options::InitGeneral()
 	ui->AddCheckboxCallback(wnd, "Zeal_SingleClickGiveEnable",  [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->give->setting_enable_give.set(wnd->Checked); });
 
 	ui->AddCheckboxCallback(wnd, "Zeal_LinkAllAltDelimiter",    [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->looting_hook->setting_alt_delimiter.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_CtrlRightClickCorpse",   [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->looting_hook->setting_ctrl_rightclick_loot.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_EnableContainerLock",    [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->ui->options->setting_enable_container_lock.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_ExportOnCamp",           [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->outputfile->setting_export_on_camp.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_SelfClickThru",          [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->camera_mods->setting_selfclickthru.set(wnd->Checked); });
@@ -704,6 +705,7 @@ void ui_options::UpdateOptionsGeneral()
 	ui->SetChecked("Zeal_TellWindows", ZealService::get_instance()->tells->enabled);
 	ui->SetChecked("Zeal_TellWindowsHist", ZealService::get_instance()->tells->hist_enabled);
 	ui->SetChecked("Zeal_LinkAllAltDelimiter", ZealService::get_instance()->looting_hook->setting_alt_delimiter.get());
+	ui->SetChecked("Zeal_CtrlRightClickCorpse", ZealService::get_instance()->looting_hook->setting_ctrl_rightclick_loot.get());
 	ui->SetChecked("Zeal_EnableContainerLock", ZealService::get_instance()->ui->options->setting_enable_container_lock.get());
 	ui->SetChecked("Zeal_ExportOnCamp", ZealService::get_instance()->outputfile->setting_export_on_camp.get());
 	ui->SetChecked("Zeal_SelfClickThru", ZealService::get_instance()->camera_mods->setting_selfclickthru.get());

--- a/Zeal/uifiles/zeal/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_General.xml
@@ -776,6 +776,36 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
+  <Button item="Zeal_CtrlRightClickCorpse">
+    <ScreenID>Zeal_CtrlRightClickCorpse</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>442</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Require Ctrl with right click to loot corpse</TooltipReference>
+    <Text>Ctrl Right Click Loot</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>  
   <Button item="Zeal_CastAutoStand">
     <ScreenID>Zeal_CastAutoStand</ScreenID>
     <RelativePosition>true</RelativePosition>
@@ -1111,6 +1141,7 @@
     <Pieces>Zeal_BuffTimers</Pieces>
     <Pieces>Zeal_RecastTimers</Pieces>
     <Pieces>Zeal_RecastTimersLeftAlign</Pieces>
+    <Pieces>Zeal_CtrlRightClickCorpse</Pieces>
     <Pieces>Zeal_CastAutoStand</Pieces>
     <Pieces>Zeal_BrownSkeletons</Pieces>
     <Pieces>Zeal_ClassicMusic</Pieces>


### PR DESCRIPTION
- New Zeal general option and /lootctrl command that controls a requirement to hold the ctrl key down while right click looting (to prevent inadvertent looting in 3rd person)