### PR TITLE
Add /map ring on and off options

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,11 +699,13 @@ are colored orange.
 #### Map ring
 A simple distance ring around the current position is available. The distance can be auto-set
 based on the tracking skill for rangers, druids, and bards, so they can simply toggle the ring
-on and off with `/map ring`.
+on and off with `/map ring` (or explicitly on or off with `ring on` or `ring off`).
 
 * Command examples:
   - `/map ring` if visible or a non-tracker, turns ring off
   - `/map ring` if not visible, sets the ring at max tracking distance per skill level
+  - `/map ring on` sets the ring at max tracking distance per skill level
+  - `/map ring off` turns ring off
   - `/map ring 500` sets the ring around the player at a distance of 500 (all classes)
 
 #### Showing group and raid members


### PR DESCRIPTION
- Added additional 'on' and 'off' parameters to the /map ring command
  - 'on' works like '/map ring' when it is toggling on and sets the radius at the player's max tracking distance
  - 'off' turns off the map ring