### PR TITLE
Fix a variable lifetime issue in LoadSidlHk

### DIFF
--- a/Zeal/ui_manager.cpp
+++ b/Zeal/ui_manager.cpp
@@ -334,8 +334,8 @@ bool ui_manager::WriteTemporaryUI(const std::string& equi_path, std::string equi
 			{
 				outfile << modifiedContent;
 				outfile.close();
+				return true;
 			}
-			return true;
 		}
 	}
 	return false;

--- a/Zeal/ui_manager.h
+++ b/Zeal/ui_manager.h
@@ -44,7 +44,7 @@ public:
 	void AddListItems(Zeal::EqUI::ListWnd* wnd, const std::vector<std::string> data);
 	Zeal::EqUI::EQWND* CreateSidlScreenWnd(const std::string& name);
 	void DestroySidlScreenWnd(Zeal::EqUI::EQWND* sidl_wnd);
-	void WriteTemporaryUI(const std::string& file_path, std::string ui_path);
+	bool WriteTemporaryUI(const std::string& file_path, std::string ui_path);
 	void RemoveTemporaryUI(const std::string& file_path);
 	void AddXmlInclude(const std::string& name);
 	ui_manager(class ZealService* zeal, class IO_ini* ini);


### PR DESCRIPTION
- The path1 CXSTR may be corrupted after executing the hooked function, so a correct path is preserved in a local std::string
- Also did some other cleanup to ensure that the filename used to write the temp file is the same one used to remove it and changed the remove function to no longer throw exceptions upon failures
- Added a modal dialog box if writing the EQUI_Zeal.xml fails