### PR TITLE
Add an optional invite (raid/group) dialog box

### DIFF
--- a/Zeal/EqStructures.h
+++ b/Zeal/EqStructures.h
@@ -996,6 +996,18 @@ namespace Zeal
 
 		struct Everquest
 		{
+			void Invite()
+			{
+				reinterpret_cast<void(__thiscall*)(Everquest*)>(0x005302c1)(this);
+			}
+			void Follow()
+			{
+				reinterpret_cast<void(__thiscall*)(Everquest*)>(0x0053069c)(this);
+			}
+			void Disband()
+			{
+				reinterpret_cast<void(__thiscall*)(Everquest*)>(0x00530829)(this);
+			}
 			BYTE IsOkToTransact()
 			{
 				return reinterpret_cast<BYTE(__thiscall*)(Everquest*)>(0x54825C)(this);

--- a/Zeal/ui_options.h
+++ b/Zeal/ui_options.h
@@ -17,6 +17,7 @@ public:
 	void SaveColors() const;
 	void LoadColors();
 	DWORD GetColor(int index) const;
+	void ShowInviteDialog(const char* raid_invite_name = nullptr) const;
 	void PlayInviteSound() const;
 	void PlayTellSound() const;
 	Zeal::EqUI::EQWND* GetZealOptionsWindow() { return wnd; }  // Only use for short-term access.
@@ -24,6 +25,7 @@ public:
 	~ui_options();
 
 	ZealSetting<bool> setting_enable_container_lock = { false, "Zeal", "EnableContainerLock", false };
+	ZealSetting<bool> setting_invite_dialog = { false, "Zeal", "InviteDialog", false };
 	ZealSetting<std::string> setting_invite_sound = { "", "Zeal", "InviteSound", false,
 		[this](const std::string&) { PlayInviteSound(); } };
 	ZealSetting<std::string> setting_tell_sound = { "", "Zeal", "TellSound", false,

--- a/Zeal/uifiles/zeal/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_General.xml
@@ -805,7 +805,37 @@
       <Disabled>A_BtnDisabled</Disabled>
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
-  </Button>  
+  </Button>
+  <Button item="Zeal_InviteDialog">
+    <ScreenID>Zeal_InviteDialog</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>464</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Display a dialog when invited to a group</TooltipReference>
+    <Text>Invite Dialog</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
   <Button item="Zeal_CastAutoStand">
     <ScreenID>Zeal_CastAutoStand</ScreenID>
     <RelativePosition>true</RelativePosition>
@@ -1142,6 +1172,7 @@
     <Pieces>Zeal_RecastTimers</Pieces>
     <Pieces>Zeal_RecastTimersLeftAlign</Pieces>
     <Pieces>Zeal_CtrlRightClickCorpse</Pieces>
+    <Pieces>Zeal_InviteDialog</Pieces>
     <Pieces>Zeal_CastAutoStand</Pieces>
     <Pieces>Zeal_BrownSkeletons</Pieces>
     <Pieces>Zeal_ClassicMusic</Pieces>


### PR DESCRIPTION
- Zeal general options now has an additional Invite Dialog checkbox option that will enable a pop up dialog upon a raid or group invite
- Also extended the optional invite notification sound to also play when invited to a raid (previously group only)