### PR TITLE
Add optional more reliable /follow mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,14 @@ ___
   - **Example:** `/fcd font arial_24` sets it to use custom font arial_24
   - **Description:** shows floating combat damage.
 
+- `/follow`
+  - **Arguments:** none, `zeal on`, `zeal off`, `distance <value>`
+  - **Example:** `/follow` toggles on and off (normal client command)
+  - **Example:** `/follow zeal on` turns on patched Zeal auto-follow mode (same as options tab)
+  - **Example:** `/follow distance 5` sets the Zeal mode follow distance to 5 (default 15)
+  - **Description:** adds /follow arguments that support enabling Zeal mode with adjustable distance. The
+    Zeal mode disables rapid toggling of run mode and slow turning to improve /follow reliability.
+
 - `/fov`
   - **Arguments:** `int`
   - **Example:** `/fov 65`

--- a/Zeal/character_select.cpp
+++ b/Zeal/character_select.cpp
@@ -69,6 +69,11 @@ static void __fastcall SelectCharacter(DWORD t, DWORD unused, DWORD character_sl
 {
 	int prev_cam = *Zeal::EqGame::camera_view;
 	ZealService::get_instance()->hooks->hook_map["SelectCharacter"]->original(SelectCharacter)(t, unused, character_slot, unk2);
+
+	if (Zeal::EqGame::Windows && Zeal::EqGame::Windows->CharacterSelect && !Zeal::EqGame::Windows->CharacterSelect->Explore &&
+		ZealService::get_instance()->ui->zoneselect)
+		ZealService::get_instance()->ui->zoneselect->ShowButton();  // Put dynamic button (if present) on top.
+
 	int zone_index = get_zone_index_setting();
 	if (zone_index <= 0)
 		return;
@@ -78,10 +83,6 @@ static void __fastcall SelectCharacter(DWORD t, DWORD unused, DWORD character_sl
 		*Zeal::EqGame::camera_view = prev_cam; // if you happen to click yourself this keeps the camera from going to the straight out char select cam
 	else
 		*Zeal::EqGame::camera_view = Zeal::EqEnums::CameraView::CharacterSelect;
-
-	if (Zeal::EqGame::Windows && Zeal::EqGame::Windows->CharacterSelect && !Zeal::EqGame::Windows->CharacterSelect->Explore &&
-					ZealService::get_instance()->ui->zoneselect)
-		ZealService::get_instance()->ui->zoneselect->ShowButton();  // Put dynamic button (if present) on top.
 
 	Zeal::EqStructures::Entity* self = Zeal::EqGame::get_self();
 	if (self)

--- a/Zeal/commands.cpp
+++ b/Zeal/commands.cpp
@@ -461,6 +461,7 @@ ChatCommands::ChatCommands(ZealService* zeal)
 				print_chat("Stat descriptions (all values include current spell effects):");
 				print_chat("Mitigation: modifies incoming damage based on offense vs mitigation (0.1x to 2.0x factor)");
 				print_chat("Mitigation (melee) ~= item_ac*4/3 + defense_skill/3 + agility/20 + spell_ac/4 + class_ac");
+				print_chat("Note: The spell_ac value is an internal calc from the database. Sites like pqdi already include the /4.");
 				print_chat("Avoidance: modifies probability of taking zero damage");
 				print_chat("Avoidance ~= (defense_skill*400/225 + 36 + (min(200,agi)-75)*2/15)*(1+AA_pct)");
 				print_chat("To Hit: sets probability of hitting based on to hit vs avoidance");
@@ -469,6 +470,15 @@ ChatCommands::ChatCommands(ZealService* zeal)
 				print_chat("Offense ~= weap_skill_value + spell_atk + item_atk + max(0, (str-75)*2/3)");
 				print_chat("Damage multiplier: Chance for bonus damage factor based on level, weapon skill, and offense");
 				print_chat("Average damage: Mitigation factor = 1, damage multiplier = average after both rolls");
+			}
+			else if (args.size() == 2 && args[1] == "affects")
+			{
+				auto char_info = Zeal::EqGame::get_char_info();
+				if (char_info)
+				{
+					const int SE_ArmorClass = 1;
+					print_chat("TotalSpellAffects: AC: %d", Zeal::EqGame::total_spell_affects(char_info, SE_ArmorClass, true, nullptr));
+				}
 			}
 			else if (args.size() >= 2 && args[1].size() >= 8 && args[1].front() == kMarker) {
 				std::string link = args[1];  // Only need the first item ID part of the link (name doesn't matter).
@@ -489,7 +499,6 @@ ChatCommands::ChatCommands(ZealService* zeal)
 			}
 			else if (args.size() == 1) {
 				bool is_luclin_enabled = (Zeal::EqGame::get_era() >= Zeal::EqGame::Era::Luclin);
-				auto char_info = Zeal::EqGame::get_char_info();
 				Zeal::EqGame::print_chat("---- Defensive stats ----");
 				print_chat("AC (display): %i = (Mit: %i  + Avoidance: %i) * 1000/847",
 					Zeal::EqGame::get_display_AC(), Zeal::EqGame::get_mitigation(),

--- a/Zeal/patches.h
+++ b/Zeal/patches.h
@@ -4,9 +4,12 @@ class patches
 {
 public:
 	ZealSetting<bool> BrownSkeletons = { false, "Zeal", "BrownSkeletons", false, [this](bool val) { SetBrownSkeletons(); } };
+	ZealSetting<bool> AutoFollowEnable = { false, "AutoFollow", "Enable", false, [this](bool val) { SyncAutoFollow(); } };
+	ZealSetting<float> AutoFollowDistance = { 15.f, "AutoFollow", "Distance", false, [this](bool val) { SyncAutoFollow(); } };
 	patches();
 	void fonts();
 private:
 	void SetBrownSkeletons();
+	void SyncAutoFollow(bool first_boot = false);
 };
 

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -412,6 +412,7 @@ void ui_options::InitGeneral()
 	ui->AddCheckboxCallback(wnd, "Zeal_DetectAssistFailure",	[](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->assist->setting_detect_assist_failure.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_SingleClickGiveEnable",  [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->give->setting_enable_give.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_InviteDialog",           [this](Zeal::EqUI::BasicWnd* wnd) { setting_invite_dialog.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_AutoFollowEnable",       [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->game_patches->AutoFollowEnable.set(wnd->Checked); });
 
 	ui->AddCheckboxCallback(wnd, "Zeal_LinkAllAltDelimiter",    [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->looting_hook->setting_alt_delimiter.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_CtrlRightClickCorpse",   [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->looting_hook->setting_ctrl_rightclick_loot.set(wnd->Checked); });
@@ -759,6 +760,7 @@ void ui_options::UpdateOptionsGeneral()
 	ui->SetChecked("Zeal_DetectAssistFailure", ZealService::get_instance()->assist->setting_detect_assist_failure.get());
 	ui->SetChecked("Zeal_SingleClickGiveEnable", ZealService::get_instance()->give->setting_enable_give.get());
 	ui->SetChecked("Zeal_InviteDialog", setting_invite_dialog.get());
+	ui->SetChecked("Zeal_AutoFollowEnable", ZealService::get_instance()->game_patches->AutoFollowEnable.get());
 
 	UpdateComboBox("Zeal_TellSound_Combobox", setting_tell_sound.get(), kDefaultSoundNone);
 	UpdateComboBox("Zeal_InviteSound_Combobox", setting_invite_sound.get(), kDefaultSoundNone);

--- a/Zeal/uifiles/zeal/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_General.xml
@@ -836,6 +836,36 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
+  <Button item="Zeal_AutoFollowEnable">
+    <ScreenID>Zeal_AutoFollowEnable</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>486</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Enable Zeal /follow mode (reliability)</TooltipReference>
+    <Text>Patch /follow</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>  
   <Button item="Zeal_CastAutoStand">
     <ScreenID>Zeal_CastAutoStand</ScreenID>
     <RelativePosition>true</RelativePosition>
@@ -1173,6 +1203,7 @@
     <Pieces>Zeal_RecastTimersLeftAlign</Pieces>
     <Pieces>Zeal_CtrlRightClickCorpse</Pieces>
     <Pieces>Zeal_InviteDialog</Pieces>
+    <Pieces>Zeal_AutoFollowEnable</Pieces>
     <Pieces>Zeal_CastAutoStand</Pieces>
     <Pieces>Zeal_BrownSkeletons</Pieces>
     <Pieces>Zeal_ClassicMusic</Pieces>


### PR DESCRIPTION
- Added arguments to the /follow command as well as an options tab button to support enabling a patched /follow mode:
  - Disables rapid toggling of run mode to reduce LD / crashes
  - Skips slow turning to reduce follow failures
  - Also supports an adjustable follow distance (command line only)

- Also fixed the missing dynamic Zone Select button on the default ui for character select if the zeal.ini does not have a value set for the zone index (no longer skips the Show() call)

Hat tip to Solar for the /follow patches.