### PR TITLE
Fix monk and bst hand2hand delay in recovery gauge

### DIFF
--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -3239,7 +3239,7 @@ namespace Zeal
 			return static_cast<float>(roll) * (1.f / 100);
 		}
 
-		static int get_hand_to_hand_delay()
+		int get_hand_to_hand_delay()
 		{
 			const int default_delay = 35;
 			auto char_info = Zeal::EqGame::get_char_info();

--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -270,6 +270,7 @@ namespace Zeal
 		int get_mitigation(bool include_cap = false);
 		int get_mitigation_softcap();
 		int get_display_AC();
+		int get_hand_to_hand_delay();
 		void print_melee_attack_stats(bool primary, const Zeal::EqStructures::EQITEMINFO* weapon = nullptr);
 	}
 }

--- a/Zeal/labels.cpp
+++ b/Zeal/labels.cpp
@@ -169,7 +169,7 @@ static int get_attack_timer_gauge(Zeal::EqUI::CXSTR* str)
 	if (attack_delay == 0) {
 		auto primary_item = char_info->InventoryItem[12];  // Primary slot.
 		if (!primary_item || !primary_item->Common.AttackDelay)  // No weapon or not a weapon.
-			attack_delay = 3500;  // Assuming _CombatEQ Skill was set to 0x16 and AttackDelay = 0x1c.
+			attack_delay = Zeal::EqGame::get_hand_to_hand_delay() * 100;
 		else if (primary_item->Common.Skill < 6 || primary_item->Common.Skill == 0xd)
 			attack_delay = primary_item->Common.AttackDelay * 100;
 		else if (primary_item->Common.Skill == 0x16)  // Hand-to-hand skilldict lookup.


### PR DESCRIPTION
- The hand2hand delay was using a simple 3500 msec default value for the attack recovery gauge calcs, which is accurate for all classes except high level monks and beastlords. Switched to using the class accurate calculation added with /mystats.