### PR TITLE
Upgrade invite dialog: auto-dismiss, buttons

### DIFF
--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -538,6 +538,16 @@ namespace Zeal
 		{
 			return reinterpret_cast<bool(__thiscall*)(Zeal::EqStructures::Entity * player, uint8_t type, uint8_t p2, Zeal::EqStructures::Entity * target)>(0x50A0F8)(get_self(), type, p2, get_target());
 		}
+		void do_raidaccept()
+		{
+			if (get_self())
+				reinterpret_cast<void(__thiscall*)(Zeal::EqStructures::Entity * player, const char* unused)>(0x004f3be5)(get_self(), "");
+		}
+		void do_raiddecline()
+		{
+			if (get_self())
+				reinterpret_cast<void(__thiscall*)(Zeal::EqStructures::Entity * player, const char* unused)>(0x004f3bc1)(get_self(), "");
+		}
 		Zeal::EqStructures::Entity* get_view_actor_entity()
 		{
 			Zeal::EqStructures::ViewActor* Actor = get_view_actor();

--- a/Zeal/EqFunctions.h
+++ b/Zeal/EqFunctions.h
@@ -143,6 +143,8 @@ namespace Zeal
 		void do_autoattack(bool enabled);
 		bool CanIHitTarget(float dist);
 		bool do_attack(uint8_t type, uint8_t p2);
+		void do_raidaccept();
+		void do_raiddecline();
 		void do_inspect(Zeal::EqStructures::Entity* player);
 		void do_join(Zeal::EqStructures::Entity* player, const char* name);
 		void send_to_channel(int chat_channel_zero_based, const char* message);

--- a/Zeal/ui_inputdialog.cpp
+++ b/Zeal/ui_inputdialog.cpp
@@ -51,6 +51,11 @@ bool ui_inputdialog::show(const std::string& title, const std::string& message, 
 	return true;
 }
 
+std::string ui_inputdialog::getTitle() const
+{
+	return wnd ? std::string(wnd->Text) : std::string("");
+}
+
 int __fastcall IDWndNotification(Zeal::EqUI::BasicWnd* wnd, int unused, Zeal::EqUI::BasicWnd* sender, int message, int data)
 {
 	ui_manager* ui = ZealService::get_instance()->ui.get();

--- a/Zeal/ui_inputdialog.h
+++ b/Zeal/ui_inputdialog.h
@@ -9,6 +9,7 @@ public:
 	bool show(const std::string& title, const std::string& message, const std::string& button1, const std::string button2, InputDialogCallback button1_callback = nullptr, InputDialogCallback button2_callback = nullptr, bool show_input_field = true);
 	void hide();
 	bool isVisible();
+	std::string getTitle() const;
 	std::pair<InputDialogCallback, InputDialogCallback> button_callbacks;
 	Zeal::EqUI::BasicWnd* button1;
 	Zeal::EqUI::BasicWnd* button2;

--- a/Zeal/ui_options.h
+++ b/Zeal/ui_options.h
@@ -18,6 +18,7 @@ public:
 	void LoadColors();
 	DWORD GetColor(int index) const;
 	void ShowInviteDialog(const char* raid_invite_name = nullptr) const;
+	void HideInviteDialog() const;
 	void PlayInviteSound() const;
 	void PlayTellSound() const;
 	Zeal::EqUI::EQWND* GetZealOptionsWindow() { return wnd; }  // Only use for short-term access.


### PR DESCRIPTION
- The optional group/raid invite dialog will now auto-dismiss when the player has accepted or declined the invites
- Added buttons to accept/follow or decline in the dialog window