### PR TITLE
Added FCD filter for npcs, hp updates

### DIFF
--- a/Zeal/EqUI.h
+++ b/Zeal/EqUI.h
@@ -447,9 +447,20 @@ namespace Zeal
 		struct CharSelect : EQWND
 		{
 			/*0x134*/	BYTE    Activated;   // Set to 1 when activated and 0 in Deactivate().
-			/*0x135*/	BYTE    Unknown0x135[0x3B];
+			/*0x135*/	BYTE    Unknown0x135[0x3];
+			/*0x138*/   EQWND*  ExploreButton;
+			/*0x13C*/   EQWND*  RotateButton;
+			/*0x140*/   EQWND*  CharButtons[8];
+			/*0x160*/   EQWND*  EnterWorldButton;
+			/*0x164*/   EQWND*  DeleteButton;
+			/*0x168*/   EQWND*  QuitButton;
+			/*0x16C*/   EQWND*  ExploreModeWnd;
 			/*0x170*/   BYTE    Rotate;
 			/*0x171*/   BYTE    Explore;
+			/*0x172*/   BYTE    Unknown0x172[2];
+			/*0x174*/   DWORD   SelectIndex;  // Set to 0xffffffff (-1) at ActivateStart().
+			/*0x178*/   BYTE    Unknown0x178[0x8];  // 0x180 allocated.
+
 		};
 		struct RaidWnd : EQWND
 		{

--- a/Zeal/character_select.cpp
+++ b/Zeal/character_select.cpp
@@ -65,7 +65,7 @@ static void SetYon(float clip)
 	reinterpret_cast<void(__fastcall*)(int display, int unused_edx, float clip)>(0x004aca7f)(*Zeal::EqGame::Display, 0, clip);
 }
 
-static void __fastcall SelectCharacter(DWORD t, DWORD unused, DWORD character_slot, DWORD unk2)
+static void __fastcall SelectCharacter(Zeal::EqUI::CharSelect* t, DWORD unused, DWORD character_slot, DWORD unk2)
 {
 	int prev_cam = *Zeal::EqGame::camera_view;
 	ZealService::get_instance()->hooks->hook_map["SelectCharacter"]->original(SelectCharacter)(t, unused, character_slot, unk2);

--- a/Zeal/floating_damage.h
+++ b/Zeal/floating_damage.h
@@ -45,6 +45,8 @@ public:
 	ZealSetting<bool> show_self = { true, "FloatingDamage", "Self", true };
 	ZealSetting<bool> show_pets = { true, "FloatingDamage", "Pets", true };
 	ZealSetting<bool> show_others = { true, "FloatingDamage", "Others", true };
+	ZealSetting<bool> show_npcs = { true, "FloatingDamage", "Npcs", true };
+	ZealSetting<bool> show_hp_updates = { true, "FloatingDamage", "ShowHpUpdates", true };
 	ZealSetting<int> big_hit_threshold = { 100, "FloatingDamage", "BigHitThreshold", true };
 	ZealSetting<std::string> bitmap_font_filename = { std::string(kUseClientFontString),
 		"FloatingDamage", "Font", true, [this](std::string val) { bitmap_font.reset(); } };

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -523,6 +523,8 @@ void ui_options::InitFloatingDamage()
 	ui->AddCheckboxCallback(wnd, "Zeal_FloatingSelf", [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->floating_damage->show_self.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_FloatingPets", [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->floating_damage->show_pets.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_FloatingOthers", [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->floating_damage->show_others.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_FloatingNpcs", [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->floating_damage->show_npcs.set(wnd->Checked); });
+	ui->AddCheckboxCallback(wnd, "Zeal_FloatingHpUpdates", [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->floating_damage->show_hp_updates.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_FloatingMelee", [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->floating_damage->show_melee.set(wnd->Checked); });
 	ui->AddCheckboxCallback(wnd, "Zeal_FloatingSpells", [](Zeal::EqUI::BasicWnd* wnd) { ZealService::get_instance()->floating_damage->show_spells.set(wnd->Checked); });
 	ui->AddLabel(wnd, "Zeal_FloatingBigHit_Value");
@@ -895,6 +897,8 @@ void ui_options::UpdateOptionsFloatingDamage()
 	ui->SetChecked("Zeal_FloatingSelf", ZealService::get_instance()->floating_damage->show_self.get());
 	ui->SetChecked("Zeal_FloatingPets", ZealService::get_instance()->floating_damage->show_pets.get());
 	ui->SetChecked("Zeal_FloatingOthers", ZealService::get_instance()->floating_damage->show_others.get());
+	ui->SetChecked("Zeal_FloatingNpcs", ZealService::get_instance()->floating_damage->show_npcs.get());
+	ui->SetChecked("Zeal_FloatingHpUpdates", ZealService::get_instance()->floating_damage->show_hp_updates.get());
 	ui->SetChecked("Zeal_FloatingMelee", ZealService::get_instance()->floating_damage->show_melee.get());
 	ui->SetChecked("Zeal_FloatingSpells", ZealService::get_instance()->floating_damage->show_spells.get());
 	ui->SetChecked("Zeal_FloatingSpellIcons", ZealService::get_instance()->floating_damage->spell_icons.get());

--- a/Zeal/uifiles/zeal/EQUI_Tab_FloatingDamage.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_FloatingDamage.xml
@@ -108,7 +108,67 @@
     <Style_Transparent>false</Style_Transparent>
     <Style_Checkbox>true</Style_Checkbox>
     <TooltipReference>Toggles display of damage from other players</TooltipReference>
-    <Text>Show from others</Text>
+    <Text>Show from other PCs</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_FloatingNpcs">
+    <ScreenID>Zeal_FloatingNpcs</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>112</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Toggles display of damage from NPCs</TooltipReference>
+    <Text>Show from NPCs</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_FloatingHpUpdates">
+    <ScreenID>Zeal_FloatingHpUpdates</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>134</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Toggles display of HP updates</TooltipReference>
+    <Text>Show HP Updates</Text>
     <TextColor>
       <R>255</R>
       <G>255</G>
@@ -127,7 +187,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>112</Y>
+      <Y>156</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -157,7 +217,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>134</Y>
+      <Y>178</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -188,7 +248,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>156</Y>
+      <Y>200</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -218,7 +278,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>178</Y>
+      <Y>222</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -367,6 +427,8 @@
     <Pieces>Zeal_FloatingSelf</Pieces>
     <Pieces>Zeal_FloatingPets</Pieces>
     <Pieces>Zeal_FloatingOthers</Pieces>
+    <Pieces>Zeal_FloatingNpcs</Pieces>
+    <Pieces>Zeal_FloatingHpUpdates</Pieces>
     <Pieces>Zeal_FloatingMelee</Pieces>
     <Pieces>Zeal_FloatingSpells</Pieces>
     <Pieces>Zeal_FloatingSpellIcons</Pieces>


### PR DESCRIPTION
- Added two new options checkboxes for filtering out FCD:
  - Npcs: toggles filtering of NPC damage
  - Hp updates: toggles filtering of the HP updates
- Also adjusted the pet filtering. The player's pet melee damage is now treated like the player's melee damage (filtering, colors). The show pets filter will filter out all other pets (player or npcs).