### PR TITLE
Patch to fix ItemTypeMartial and mnk/bst h2h delay

### DIFF
--- a/Zeal/labels.cpp
+++ b/Zeal/labels.cpp
@@ -183,7 +183,7 @@ static int get_attack_timer_gauge(Zeal::EqUI::CXSTR* str)
 		auto primary_item = char_info->InventoryItem[12];  // Primary slot.
 		if (!primary_item || !primary_item->Common.AttackDelay)  // No weapon or not a weapon.
 			attack_delay = Zeal::EqGame::get_hand_to_hand_delay() * 100;
-		else if (primary_item->Common.Skill < 6 || primary_item->Common.Skill == 0xd)
+		else if (primary_item->Common.Skill < 6 || primary_item->Common.Skill == 0x2d)  // Uses patched 0x2d, not 0xd.
 			attack_delay = primary_item->Common.AttackDelay * 100;
 		else if (primary_item->Common.Skill == 0x16)  // Hand-to-hand skilldict lookup.
 			attack_delay = reinterpret_cast<UINT**>(0x007f7aec)[primary_item->Common.AttackDelay][1];


### PR DESCRIPTION
- The client's DoPassageOfTime() call has two bugs that generate inaccurate ActorInfo.AttackTimer values:
  - Primary weapons with ItemTypeMartial (0x2d) are not handled, resulting in 0 attack delay and the melee/range buttons never showing the actual lockout
  - It uses the fixed 3500 ms skilldict value for hand to hand delay and does not calculate the correct value for higher level mnks and bsts or for the monk epic weapon
  - These bugs also impacted the new UI attack recovery timer gauge
- This patch fixes these two bugs by swapping the unused type 0xd with 0x2d and jumping to a Zeal calculated hand to hand delay value