### PR TITLE
Add /melody resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,10 @@ ___
   - **Description:** controls map enable, size, labels, zoom, and markers
 
 - `/melody`
-  - **Arguments:** `song gem #'s (maximum of 5)`
+  - **Arguments:** `song gem #'s (maximum of 5)`, `resume`
   - **Aliases:** `/mel`
   - **Example:** `/melody 1 4 2 3`
+  - **Example:** `/melody resume` - Resumes an interrupted melody at the interrupted song index.
   - **Description:** plays songs in order until interrupted in any fashion.
 
 - `/mystats`

--- a/Zeal/melody.h
+++ b/Zeal/melody.h
@@ -6,7 +6,8 @@
 class Melody
 {
 public:
-	bool start(const std::vector<int>& new_songs); //returns true if no errors
+	bool start(const std::vector<int>& new_songs, bool resume = false); //returns true if no errors
+	void resume(); //continues a stopped melody where it was interrupted (if valid)
 	void end(bool do_print=false);
 	void handle_stop_cast_callback(BYTE reason, WORD spell_id);
 	void handle_deactivate_ui();
@@ -16,6 +17,7 @@ public:
 private:
 	void tick();
 	void stop_current_cast();
+	bool is_active = false; // Set when melody is actively running.
 	int current_index = 0;  // Active song index. -1 if not started yet.
 	std::vector<int> songs; // Gem indices (base 0) for melody.
 	int retry_count = 0; // Tracks unsuccessful song casts.


### PR DESCRIPTION
- The `/melody resume` command will resume the last active melody's song list (gem index based) starting at the gem index of the interrupted song.
  - Supports macros like /stopsong, /cast 6, /melody resume