### PR TITLE
Shows DS damage dealt to NPCs

### DIFF
--- a/Zeal/chatfilter.cpp
+++ b/Zeal/chatfilter.cpp
@@ -455,12 +455,23 @@ chatfilter::chatfilter(ZealService* zeal)
             isDamage = true; 
             damageData = { source, target, type, spell_id, damage }; 
         }
-        if (spell_id > 0 && damage > 0 && source != Zeal::EqGame::get_self() && target != Zeal::EqGame::get_self())
+        if (spell_id > 0 && source != Zeal::EqGame::get_self() && target != Zeal::EqGame::get_self())
         {
-            isDamage = true;
-            damageData = { source, target, type, spell_id, damage };
-            if (source->Position.Dist2D(Zeal::EqGame::get_self()->Position) < 500 || target->Position.Dist2D(Zeal::EqGame::get_self()->Position) < 500)
-                Zeal::EqGame::print_chat(USERCOLOR_NON_MELEE, "%s hit %s for %i points of non-melee damage.", Zeal::EqGame::strip_name(source->Name), Zeal::EqGame::strip_name(target->Name), damage);
+            if (damage > 0)
+            {
+                isDamage = true;
+                damageData = { source, target, type, spell_id, damage };
+                if (source->Position.Dist2D(Zeal::EqGame::get_self()->Position) < 500 || target->Position.Dist2D(Zeal::EqGame::get_self()->Position) < 500)
+                    Zeal::EqGame::print_chat(USERCOLOR_NON_MELEE, "%s hit %s for %i points of non-melee damage.", Zeal::EqGame::strip_name(source->Name), Zeal::EqGame::strip_name(target->Name), damage);
+            }
+            else if (damage < 0)
+            {
+                if (type >= 244 && type <= 249 && target->Type == Zeal::EqEnums::EntityTypes::NPC && target->PetOwnerSpawnId == 0) // Show DS Damage to NPCs (non-pets)
+                {
+                    if (source->Position.Dist2D(Zeal::EqGame::get_self()->Position) < 500 || target->Position.Dist2D(Zeal::EqGame::get_self()->Position) < 500)
+                        Zeal::EqGame::print_chat(USERCOLOR_NON_MELEE, "%s hit %s for %i points of non-melee damage.", Zeal::EqGame::strip_name(source->Name), Zeal::EqGame::strip_name(target->Name), -damage);
+                }
+            }
         }
      });
     Extended_ChannelMaps.push_back(CustomFilter("Random", 0x10000, [this](short& color, std::string data) { return color == USERCOLOR_RANDOM; }));


### PR DESCRIPTION
- DS Damage dealt to non-pet NPCs is shown.
- This should improve the ability to get DPS logs of DPS damage dealt by tanks, etc.
- Does not log DS Damage dealt to players or pets, as that would cause way too much spam when a raid is attacking an NPC with thorns, plus it's better to keep DS damage dealt to the raid "as-is" (hidden/mystery)

![image](https://github.com/user-attachments/assets/ec6e877e-ff95-42fb-95c1-3cc9a681c6ec)