### PR TITLE
Add /shownames 5, 6, and 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,6 +575,7 @@ The Zeal Nameplate options tab is the primary interface, but the redundant comma
 * `/nameplate inlineguild` - Toggles guild name appearing inline or on a separate line
 * `/nameplate zealfont` - Toggles internal client or custom Zeal fonts
 * `/nameplate dropshadow` - Toggles drop shadowing on Zeal fonts
+* `/nameplate setting_extended_shownames` - Toggles availability of extended /Shownames 5, /Shownames 6, and /Shownames 7
 
 #### Changing the Color of Nameplates
 Zeal allows players to change the colors of the Nameplates of Players and NPCs in game.

--- a/README.md
+++ b/README.md
@@ -575,7 +575,7 @@ The Zeal Nameplate options tab is the primary interface, but the redundant comma
 * `/nameplate inlineguild` - Toggles guild name appearing inline or on a separate line
 * `/nameplate zealfont` - Toggles internal client or custom Zeal fonts
 * `/nameplate dropshadow` - Toggles drop shadowing on Zeal fonts
-* `/nameplate setting_extended_shownames` - Toggles availability of extended /Shownames 5, /Shownames 6, and /Shownames 7
+* `/nameplate extendedshownames` - Toggles availability of /Shownames 5, /Shownames 6, and /Shownames 7
 
 #### Changing the Color of Nameplates
 Zeal allows players to change the colors of the Nameplates of Players and NPCs in game.

--- a/Zeal/EqFunctions.cpp
+++ b/Zeal/EqFunctions.cpp
@@ -2342,6 +2342,7 @@ namespace Zeal
 		{
 			// Holds value of /showname command.
 			//  1 = first names, 2 = first/last names, 3 = first/last/guild names, 4 = everything
+			//  5 = title/first names 6. title/first/last names 7. first/guild names
 			return *reinterpret_cast<int32_t*>(0x007d01e4);
 		}
 		int get_show_pc_names()

--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -50,6 +50,9 @@ static int __fastcall SetNameSpriteTint_UpdateState(void* this_display, void* no
 
 bool NamePlate::handle_shownames_command(const std::vector<std::string>& args)
 {
+	if (!setting_extended_nameplate.get())
+		return false;
+	
 	// No arguments - show our custom help message and suppress original
 	if (args.size() < 2) {
 		Zeal::EqGame::print_chat("Format: /shownames <off/1/2/3/4/5/6/7>");
@@ -100,7 +103,7 @@ NamePlate::NamePlate(ZealService* zeal)
 			return true;
 		});
 
-	zeal->commands_hook->Add("/shownames", { "/show" }, "Show names command with extended support.",
+	zeal->commands_hook->Add("/shownames", { "/show", "/showname" }, "Show names command with extended support.",
 		[this](std::vector<std::string>& args) {
 			return handle_shownames_command(args); //Return the result to control suppression, Let the original command run too
 		});

--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -335,7 +335,7 @@ void NamePlate::render_ui()
 			int hp_percent = entity->HpCurrent;	// NPC value is stored as a percent.
 			if (entity->Type == Zeal::EqEnums::EntityTypes::Player)
 				hp_percent = (entity->HpCurrent > 0 && entity->HpMax > 0) ?
-				(entity->HpCurrent * 100) / entity->HpMax : 0;
+					(entity->HpCurrent * 100) / entity->HpMax : 0;
 			sprite_font->set_hp_percent(hp_percent);
 		}
 		int mana_percent = setting_mana_bars.get() ? get_mana_percent(entity) : -1;

--- a/Zeal/nameplate.h
+++ b/Zeal/nameplate.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include "EqStructures.h"
 #include "ZealSettings.h"
-#
+
 #include "bitmap_font.h"
 
 class NamePlate
@@ -18,7 +18,7 @@ public:
 		AFK = 0,
 		LFG = 1,
 		LD = 2,
-		MyGuild= 3,
+		MyGuild = 3,
 		Raid = 4,
 		Group = 5,
 		PVP = 6,
@@ -51,9 +51,26 @@ public:
 	ZealSetting<bool> setting_target_blink = { true, "Zeal", "NameplateTargetBlink", false };
 	ZealSetting<bool> setting_attack_only = { false, "Zeal", "NameplateAttackOnly", false };
 	ZealSetting<bool> setting_inline_guild = { false, "Zeal", "NameplateInlineGuild", false };
-	
+
 	ZealSetting<bool> setting_extended_nameplate = { true, "Zeal", "NameplateExtended", false,
 		[this](bool& val) { mem::write<BYTE>(0x4B0B3D, val ? 0 : 1); }, true };
+
+	
+	// Extended shownames (allows /shownames 5-7)
+	ZealSetting<bool> setting_extended_shownames = { true, "Zeal", "NameplateExtendedShownames", false,
+		[this](bool& val) {
+			if (val) {
+				// Verify we have the expected byte before patching
+				BYTE current_val = 0;
+				mem::get(0x004ff8ff, 1, &current_val); //current_val is 0x05, will change to 0x08 to allow args 5-7 
+				if (current_val == 0x05) {
+					mem::write<BYTE>(0x004ff8ff, 0x08);  // Change CMP ESI,0x5 to CMP ESI,0x8
+				}
+			}
+ else {
+  mem::write<BYTE>(0x004ff8ff, 0x05);  // Restore original value
+}
+}, true };
 
 	// Advanced fonts
 	ZealSetting<bool> setting_health_bars = { false, "Zeal", "NameplateHealthBars", false };
@@ -95,6 +112,7 @@ private:
 	bool is_nameplate_hidden_by_race(const Zeal::EqStructures::Entity& entity) const;
 	bool is_group_member(const Zeal::EqStructures::Entity& entity) const;
 	bool is_raid_member(const Zeal::EqStructures::Entity& entity) const;
+	bool handle_shownames_command(const std::vector<std::string>& args);
 
 	void clean_ui();
 	void render_ui();

--- a/Zeal/nameplate.h
+++ b/Zeal/nameplate.h
@@ -67,10 +67,10 @@ public:
 					mem::write<BYTE>(0x004ff8ff, 0x08);  // Change CMP ESI,0x5 to CMP ESI,0x8
 				}
 			}
- else {
-  mem::write<BYTE>(0x004ff8ff, 0x05);  // Restore original value
-}
-}, true };
+ 			else {
+				mem::write<BYTE>(0x004ff8ff, 0x05);  // Restore original value
+			}
+		}, true };
 
 	// Advanced fonts
 	ZealSetting<bool> setting_health_bars = { false, "Zeal", "NameplateHealthBars", false };

--- a/Zeal/nameplate.h
+++ b/Zeal/nameplate.h
@@ -61,11 +61,11 @@ public:
 		[this](bool& val) {
 			if (val) {
 				// Verify we have the expected byte before patching
+				BYTE target_val = val ? 0x08 : 0x05;
 				BYTE current_val = 0;
-				mem::get(0x004ff8ff, 1, &current_val); //current_val is 0x05, will change to 0x08 to allow args 5-7 
-				if (current_val == 0x05) {
-					mem::write<BYTE>(0x004ff8ff, 0x08);  // Change CMP ESI,0x5 to CMP ESI,0x8
-				}
+				mem::get(0x004ff8ff, 1, &current_val);
+				if (current_val != target_val)
+					mem::write<BYTE>(0x004ff8ff, target_val);
 			}
  			else {
 				mem::write<BYTE>(0x004ff8ff, 0x05);  // Restore original value


### PR DESCRIPTION
New Luclin Ready Showname options
-Adds toggleable command /nameplate setting_extended_shownames
-When enabled increases capacity of /Shownames command to take new args 5, 6, 7
-Also updated /shownames without any args. 
-Now says "Format: /shownames <off/1/2/3/4/5/6/7>" instead of original string
-This enables user to type the following new /shownames commands (shortened version /show also works)
/shownames 5 - "Title and first names."
/shownames 6 - "Title, first, and last names."
/shownames 7 - "First and guild names."
-Updates EqFunctions.cpp and Readme